### PR TITLE
Clean up QQ and Utils.Links haddock.

### DIFF
--- a/src/Servant/QQ.hs
+++ b/src/Servant/QQ.hs
@@ -26,7 +26,7 @@
 -- @
 --
 -- Note the @/@ before a @QueryParam@!
-module Servant.QQ where
+module Servant.QQ (sitemap) where
 
 import Control.Monad (void)
 import Control.Applicative hiding (many, (<|>), optional)

--- a/src/Servant/Utils/Links.hs
+++ b/src/Servant/Utils/Links.hs
@@ -33,7 +33,20 @@
 -- and part of the sitemap.
 --
 -- __N.B.:__ 'mkLink' assumes a capture matches any string (without slashes).
-module Servant.Utils.Links where
+module Servant.Utils.Links (
+    -- * Link and mkLink
+    -- | The only end-user utilities
+      mkLink
+    , Link
+    -- * Internal
+    -- | These functions will likely only be of interest if you are writing
+    -- more API combinators and would like to extend the behavior of
+    -- 'mkLink'
+    , ValidLinkIn()
+    , VLinkHelper(..)
+    , IsElem
+    , IsLink
+                           )where
 
 import Data.Proxy
 import GHC.TypeLits
@@ -94,6 +107,9 @@ instance ( IsElem f s ~ 'True
          , VLinkHelper f) => ValidLinkIn f s where
     mkLink _ _ = Link (vlh (Proxy :: Proxy f))
 
+-- | A safe link datatype.
+-- The only way of constructing a 'Link' is using 'mkLink', which means any
+-- 'Link' is guaranteed to be part of the mentioned API.
 data Link = Link String deriving Show
 
 class VLinkHelper f where


### PR DESCRIPTION
The haddocks for `QQ` and `Utils.Links` were kind of nasty, since everything was exported and it wasn't clear what was meant for end-users. This cleans it up a little.

@alpmestan 
