### PR TITLE
Add support for application/x-www-form-urlencoded

### DIFF
--- a/servant.cabal
+++ b/servant.cabal
@@ -94,3 +94,4 @@ test-suite spec
     , servant
     , string-conversions
     , text
+    , url

--- a/src/Servant/API/ContentTypes.hs
+++ b/src/Servant/API/ContentTypes.hs
@@ -261,6 +261,7 @@ encodeFormUrlEncoded xs =
     let escape :: TextS.Text -> ByteString
         escape = cs . escapeURIString isUnreserved . cs
         encodePair :: (TextS.Text, TextS.Text) -> ByteString
+        encodePair (k, "") = escape k
         encodePair (k, v) = escape k <> "=" <> escape v
     in B.intercalate "&" $ map encodePair xs
 
@@ -275,6 +276,7 @@ decodeFormUrlEncoded q = do
                 [k,v] -> return ( unescape k
                                 , unescape v
                                 )
+                [k] -> return ( unescape k, "" )
                 _ -> Left $ "not a valid pair: " <> cs p
         unescape :: TextS.Text -> TextS.Text
         unescape = cs . unEscapeString . cs . TextS.intercalate "%20" . TextS.splitOn "+"

--- a/test/Servant/API/ContentTypesSpec.hs
+++ b/test/Servant/API/ContentTypesSpec.hs
@@ -6,11 +6,12 @@
 module Servant.API.ContentTypesSpec where
 
 import           Control.Applicative
+import           Control.Arrow
 import           Data.Aeson
 import           Data.Function            (on)
 import           Data.Proxy
 
-import           Data.ByteString.Char8
+import           Data.ByteString.Char8    (ByteString, append, pack)
 import qualified Data.ByteString.Lazy     as BSL
 import           Data.List                (maximumBy)
 import           Data.Maybe               (fromJust, isJust, isNothing)
@@ -19,6 +20,7 @@ import           Data.String.Conversions  (cs)
 import qualified Data.Text                as TextS
 import qualified Data.Text.Lazy           as TextL
 import           GHC.Generics
+import           Network.URL              (importParams, exportParams)
 import           Test.Hspec
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
@@ -43,6 +45,14 @@ spec = describe "Servant.API.ContentTypes" $ do
         it "has fromByteString reverse toByteString" $ do
             let p = Proxy :: Proxy FormUrlEncoded
             property $ \x -> fromByteString p (toByteString p x) == Right (x::[(TextS.Text,TextS.Text)])
+
+        it "has fromByteString reverse exportParams (Network.URL)" $ do
+            let p = Proxy :: Proxy FormUrlEncoded
+            property $ \x -> (fromByteString p . cs . exportParams . map (cs *** cs) $ x) == Right (x::[(TextS.Text,TextS.Text)])
+
+        it "has importParams (Network.URL) reverse toByteString" $ do
+            let p = Proxy :: Proxy FormUrlEncoded
+            property $ \x -> (fmap (map (cs *** cs)) . importParams . cs . toByteString p $ x) == Just (x::[(TextS.Text,TextS.Text)])
 
     describe "The PlainText Content-Type type" $ do
 

--- a/test/Servant/API/ContentTypesSpec.hs
+++ b/test/Servant/API/ContentTypesSpec.hs
@@ -38,6 +38,12 @@ spec = describe "Servant.API.ContentTypes" $ do
             let p = Proxy :: Proxy JSON
             property $ \x -> fromByteString p (toByteString p x) == Right (x::SomeData)
 
+    describe "The FormUrlEncoded Content-Type type" $ do
+
+        it "has fromByteString reverse toByteString" $ do
+            let p = Proxy :: Proxy FormUrlEncoded
+            property $ \x -> fromByteString p (toByteString p x) == Right (x::[(TextS.Text,TextS.Text)])
+
     describe "The PlainText Content-Type type" $ do
 
         it "has fromByteString reverse toByteString (lazy Text)" $ do


### PR DESCRIPTION
This depends on https://github.com/haskell-servant/servant/pull/9. It support for url encoded request bodys. To use a custom type, There is these typeclasses:

```.haskell
class ToFormUrlEncoded a where
  toFormUrlEncoded :: a -> [(TextL.Text, TextL.Text)]

class FromFormUrlEncoded a where
  fromFormUrlEncoded :: [(TextL.Text, TextL.Text)] -> Either String a
```