### PR TITLE
Canonical types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.3
 ---
+* Add a `Canonicalize` type family that distributes all `:>`s inside `:<|>`s to get to the canonical type of an API -- which is then used in all other packages to avoid weird handler types in *servant-server*.
 * Multiple content-type/accept support for all the relevant combinators
 * Provide *JSON*, *PlainText*, *OctetStream* and *FormUrlEncoded* content types out of the box
 * Type-safe link generation to API endpoints

--- a/src/Servant/API.hs
+++ b/src/Servant/API.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Servant.API (
 
   -- * Combinators
@@ -43,6 +46,9 @@ module Servant.API (
   module Servant.Common.Text,
   -- | Classes and instances for types that can be converted to and from @Text@
 
+  -- * Canonicalizing (flattening) API types
+  Canonicalize,
+
   -- * Utilities
   module Servant.Utils.Links,
   -- | Type-safe internal URIs
@@ -69,3 +75,25 @@ import           Servant.API.ReqBody      (ReqBody)
 import           Servant.API.Sub          ((:>))
 import           Servant.Utils.Links      (HasLink (..), IsElem, IsElem',
                                            URI (..), safeLink)
+
+-- | Turn an API type into its canonical form.
+--
+-- The canonical form is defined and will basically turn:
+--
+-- > "hello" :> (Get Hello :<|> ReqBody Hello :> Put Hello)
+--
+-- into
+--
+-- > ("hello" :> Get Hello) :<|> ("hello" :> ReqBody Hello :> Put Hello)
+--
+-- i.e distributing all ':>'-separated bits into the subsequent ':<|>'s.
+type family Canonicalize api :: * where
+  -- requires UndecidableInstances
+  Canonicalize (a :> (b :<|> c)) = ((a :> Canonicalize b)  :<|>  (a :> Canonicalize c))
+  Canonicalize (a :> b)          = Redex b (Canonicalize b) a
+  Canonicalize (a :<|> b)        = Canonicalize a :<|> Canonicalize b
+  Canonicalize a                 = a
+
+type family Redex a b c :: * where
+  Redex a a first = Canonicalize first :> a
+  Redex a b first = Canonicalize (first :> b)

--- a/src/Servant/API.hs
+++ b/src/Servant/API.hs
@@ -80,7 +80,12 @@ import           Servant.Utils.Links      (HasLink (..), IsElem, IsElem',
 
 -- | Turn an API type into its canonical form.
 --
--- The canonical form is defined and will basically turn:
+-- The canonical form of an API type is basically the all-flattened form
+-- of the original type. More formally, it takes a type as input and hands you
+-- back an /equivalent/ type formed of toplevel `:<|>`-separated chains of `:>`s,
+-- i.e with all `:>`s distributed inside the `:<|>`s.
+--
+-- It basically turns:
 --
 -- > "hello" :> (Get Hello :<|> ReqBody Hello :> Put Hello)
 --
@@ -101,5 +106,5 @@ type family Redex a b c :: * where
   Redex a a first = Canonicalize first :> a
   Redex a b first = Canonicalize (first :> b)
 
-canonicalize :: Canonicalize layout ~ t => Proxy layout -> Proxy t
+canonicalize :: Proxy layout -> Proxy (Canonicalize layout)
 canonicalize Proxy = Proxy

--- a/src/Servant/API.hs
+++ b/src/Servant/API.hs
@@ -48,12 +48,14 @@ module Servant.API (
 
   -- * Canonicalizing (flattening) API types
   Canonicalize,
+  canonicalize,
 
   -- * Utilities
   module Servant.Utils.Links,
   -- | Type-safe internal URIs
   ) where
 
+import           Data.Proxy               (Proxy(..))
 import           Servant.Common.Text      (FromText(..), ToText(..))
 import           Servant.API.Alternative  ((:<|>) (..))
 import           Servant.API.Capture      (Capture)
@@ -97,3 +99,6 @@ type family Canonicalize api :: * where
 type family Redex a b c :: * where
   Redex a a first = Canonicalize first :> a
   Redex a b first = Canonicalize (first :> b)
+
+canonicalize :: Canonicalize layout ~ t => Proxy layout -> Proxy t
+canonicalize Proxy = Proxy

--- a/src/Servant/API.hs
+++ b/src/Servant/API.hs
@@ -91,7 +91,8 @@ import           Servant.Utils.Links      (HasLink (..), IsElem, IsElem',
 -- i.e distributing all ':>'-separated bits into the subsequent ':<|>'s.
 type family Canonicalize api :: * where
   -- requires UndecidableInstances
-  Canonicalize (a :> (b :<|> c)) = ((a :> Canonicalize b)  :<|>  (a :> Canonicalize c))
+  Canonicalize (a :> (b :<|> c)) = a :> Canonicalize b :<|> a :> Canonicalize c
+  Canonicalize ((a :<|> b) :> c) = a :> Canonicalize c :<|> b :> Canonicalize c
   Canonicalize (a :> b)          = Redex b (Canonicalize b) a
   Canonicalize (a :<|> b)        = Canonicalize a :<|> Canonicalize b
   Canonicalize a                 = a

--- a/src/Servant/API/ContentTypes.hs
+++ b/src/Servant/API/ContentTypes.hs
@@ -55,6 +55,8 @@ module Servant.API.ContentTypes
     , AcceptHeader(..)
     , AllCTRender(..)
     , AllCTUnrender(..)
+    , AllMimeRender(..)
+    , AllMimeUnrender(..)
     , FromFormUrlEncoded(..)
     , ToFormUrlEncoded(..)
     , IsNonEmpty


### PR DESCRIPTION
Hello folks,

While thinking about the more formal aspects of servant with @jkarni, I mentionned that I was uncomfortable with the fact that we couldn't state some kinds of "laws" for *interpretations* of an API type, like:

``` haskell
Server (a :<|> b) = Server a :<|> Server b -- this one holds
Server (a :> (b :<|> c)) = Server (a :> b) :<|> Server (a :> c) -- this one doesn't!
```

Julian seemed just as comfortable with this as I am and after giving it some thought, we found a solution:

``` haskell
-- | Turn an API type into its canonical form.
--
-- The canonical form is defined and will basically turn:
--
-- > "hello" :> (Get Hello :<|> ReqBody Hello :> Put Hello)
--
-- into
--
-- > ("hello" :> Get Hello) :<|> ("hello" :> ReqBody Hello :> Put Hello)
--
-- i.e distributing all ':>'-separated bits into the subsequent ':<|>'s.
type family Canonicalize api :: * where
  -- requires UndecidableInstances
  Canonicalize (a :> (b :<|> c)) = ((a :> Canonicalize b)  :<|>  (a :> Canonicalize c))
  Canonicalize (a :> b)          = Redex b (Canonicalize b) a
  Canonicalize (a :<|> b)        = Canonicalize a :<|> Canonicalize b
  Canonicalize a                 = a

type family Redex a b c :: * where
  Redex a a first = Canonicalize first :> a
  Redex a b first = Canonicalize (first :> b)

canonicalize :: Canonicalize layout ~ t => Proxy layout -> Proxy t
canonicalize Proxy = Proxy
```

We can now just rely on `Caninocalize` to turn:

``` haskell
Capture "name" String :> (Get User :<|> ReqBody User :> Put User)
```

into

``` haskell
(Capture "name" String :> Get User) :<|> (Capture "name" String :> ReqBody User :> Put User)
```

The `Server` handlers type for the former would be:

``` haskell
String -> (EitherT (Int, String) IO User :<|> (User -> EitherT (Int, String) IO User))
```

whereas for the latter it would be:

``` haskell
(String -> EitherT (Int, String) IO User) :<|> (String -> User -> EitherT (Int, String) IO User)
```

See accompanying PRs for the 4 other libraries in order to automatically guarantee our 2 laws from above by always running `Canonicalize` before "interpreting" the API type with some class/recursion:

- haskell-servant/servant-server#32
- haskell-servant/servant-client#15
- haskell-servant/servant-jquery#10
- haskell-servant/servant-docs#16
