### PR TITLE
add missing exports (lenses) to servant-docs's Servant.Docs module

### DIFF
--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -155,11 +155,11 @@ module Servant.Docs
   , -- * ADTs to represent an 'API'
     Method(..)
   , Endpoint, path, method, defEndpoint
-  , API, emptyAPI
+  , API, apiIntros, apiEndpoints, emptyAPI
   , DocCapture(..), capSymbol, capDesc
   , DocQueryParam(..), ParamKind(..), paramName, paramValues, paramDesc, paramKind
   , DocNote(..), noteTitle, noteBody
-  , DocIntro(..)
+  , DocIntro(..), introTitle, introBody
   , Response(..), respStatus, respTypes, respBody, defResponse
   , Action, captures, headers, notes, params, rqtypes, rqbody, response, defAction
   , single

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -495,7 +495,7 @@ markdown api = unlines $
 
         introStr :: DocIntro -> [String]
         introStr i =
-            ("#### " ++ i ^. introTitle) :
+            ("## " ++ i ^. introTitle) :
             "" :
             intersperse "" (i ^. introBody) ++
             "" :


### PR DESCRIPTION
We simply forgot to export them.