### PR TITLE
fix doctests for cabal-install-1.18

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -113,6 +113,8 @@ test-suite doctests
               , servant
               , doctest
               , filemanip
+              , directory
+              , filepath
  type: exitcode-stdio-1.0
  main-is: test/Doctests.hs
  buildable: True

--- a/servant-server/test/Doctests.hs
+++ b/servant-server/test/Doctests.hs
@@ -1,14 +1,18 @@
 module Main where
 
+import           Data.List (isPrefixOf)
+import           System.Directory
+import           System.FilePath
 import           System.FilePath.Find
 import           Test.DocTest
 
 main :: IO ()
 main = do
     files <- find always (extension ==? ".hs") "src"
+    cabalMacrosFile <- getCabalMacrosFile
     doctest $ [ "-isrc"
               , "-optP-include"
-              , "-optPdist/build/autogen/cabal_macros.h"
+              , "-optP" ++ cabalMacrosFile
               , "-XOverloadedStrings"
               , "-XFlexibleInstances"
               , "-XMultiParamTypeClasses"
@@ -16,3 +20,10 @@ main = do
               , "-XTypeOperators"
               ] ++ files
 
+getCabalMacrosFile :: IO FilePath
+getCabalMacrosFile = do
+  contents <- getDirectoryContents "dist"
+  let rest = "build" </> "autogen" </> "cabal_macros.h"
+  return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
+    [x] -> "dist" </> x </> rest
+    [] -> "dist" </> rest

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -107,6 +107,8 @@ test-suite doctests
               , servant
               , doctest
               , filemanip
+              , directory
+              , filepath
  type: exitcode-stdio-1.0
  main-is: test/Doctests.hs
  buildable: True

--- a/servant/test/Doctests.hs
+++ b/servant/test/Doctests.hs
@@ -1,16 +1,27 @@
 module Main where
 
+import           Data.List (isPrefixOf)
+import           System.Directory
+import           System.FilePath
 import           System.FilePath.Find
 import           Test.DocTest
 
 main :: IO ()
 main = do
     files <- find always (extension ==? ".hs") "src"
+    cabalMacrosFile <- getCabalMacrosFile
     doctest $ [ "-isrc"
               , "-optP-include"
-              , "-optPdist/build/autogen/cabal_macros.h"
+              , "-optP" ++ cabalMacrosFile
               , "-XOverloadedStrings"
               , "-XFlexibleInstances"
               , "-XMultiParamTypeClasses"
               ] ++ files
 
+getCabalMacrosFile :: IO FilePath
+getCabalMacrosFile = do
+  contents <- getDirectoryContents "dist"
+  let rest = "build" </> "autogen" </> "cabal_macros.h"
+  return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
+    [x] -> "dist" </> x </> rest
+    [] -> "dist" </> rest


### PR DESCRIPTION
Not the most elegant code, but I think this is the best fix.