### PR TITLE
Add support for wai-app-static-3.1.0

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -53,10 +53,11 @@ library
       , split              >= 0.2  && < 0.3
       , string-conversions >= 0.3  && < 0.4
       , system-filepath    >= 0.4  && < 0.5
+      , filepath           >= 1
       , text               >= 1.2  && < 1.3
       , transformers       >= 0.3  && < 0.5
       , wai                >= 3.0  && < 3.1
-      , wai-app-static     >= 3.0  && < 3.1
+      , wai-app-static     >= 3.0  && < 3.2
       , warp               >= 3.0  && < 3.1
   hs-source-dirs: src
   default-language: Haskell2010

--- a/servant-server/src/Servant/Utils/StaticFiles.hs
+++ b/servant-server/src/Servant/Utils/StaticFiles.hs
@@ -7,7 +7,7 @@ module Servant.Utils.StaticFiles (
   serveDirectory,
  ) where
 
-import Data.List (isSuffixOf)
+import System.FilePath (addTrailingPathSeparator)
 import Network.Wai.Application.Static (staticApp, defaultFileServerSettings)
 import Servant.API.Raw (Raw)
 import Servant.Server (Server)
@@ -38,8 +38,7 @@ import Filesystem.Path.CurrentOS (decodeString)
 serveDirectory :: FilePath -> Server Raw
 serveDirectory =
 #if MIN_VERSION_wai_app_static(3,1,0)
-    staticApp . defaultFileServerSettings . mkSuff
+    staticApp . defaultFileServerSettings . addTrailingPathSeparator
 #else
-    staticApp . defaultFileServerSettings . decodeString . mkSuff
+    staticApp . defaultFileServerSettings . decodeString . addTrailingPathSeparator
 #endif
-  where mkSuff x = if "/" `isSuffixOf` x then x else x ++ "/"


### PR DESCRIPTION
system-filepath was just deprecated http://www.yesodweb.com/blog/2015/05/deprecating-system-filepath
This also fixes #81