### PR TITLE
servant, servant-server: handle corner case in doctests

### DIFF
--- a/servant-server/test/Doctests.hs
+++ b/servant-server/test/Doctests.hs
@@ -27,3 +27,5 @@ getCabalMacrosFile = do
   return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
     [x] -> "dist" </> x </> rest
     [] -> "dist" </> rest
+    xs -> error $ "ran doctests with multiple dist/dist-sandbox-xxxxx's: \n"
+                ++ show xs ++ "\nTry cabal clean"

--- a/servant/test/Doctests.hs
+++ b/servant/test/Doctests.hs
@@ -25,3 +25,5 @@ getCabalMacrosFile = do
   return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
     [x] -> "dist" </> x </> rest
     [] -> "dist" </> rest
+    xs -> error $ "ran doctests with multiple dist/dist-sandbox-xxxxx's: \n"
+                ++ show xs ++ "\nTry cabal clean"


### PR DESCRIPTION
They seem to encounter multiple sandboxes sometimes, we now provide a more
helpful error if that happens. Didn't look into why this happens.