### PR TITLE
Shahn/cabal fixes second try

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -25,22 +25,16 @@ readarray -t SOURCES < "$SOURCES_TXT"
 declare -a SDISTS
 
 
-prepare_sandbox () {
-    $CABAL sandbox init
-    for s in ${SOURCES[@]} ; do
-        (cd "$s" && $CABAL clean && $CABAL sandbox init --sandbox=../.cabal-sandbox/ && $CABAL sandbox add-source .)
-    done
-    $CABAL install --enable-tests ${SOURCES[@]}
-}
-
 test_each () {
     for s in ${SOURCES[@]} ; do
         echo "Testing $s..."
         pushd "$s"
+        $CABAL install --enable-tests --only-dep
         $CABAL check
         $CABAL configure --enable-tests --ghc-options="$GHC_FLAGS"
         $CABAL build
         $CABAL test
+        $CABAL install
         popd
     done
 }
@@ -62,6 +56,5 @@ via_sdist () {
     $CABAL install --force-reinstalls --enable-tests ${SDISTS[@]}
 }
 
-prepare_sandbox
 test_each
 via_sdist

--- a/servant-server/src/Servant/Utils/StaticFiles.hs
+++ b/servant-server/src/Servant/Utils/StaticFiles.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 -- | This module defines a sever-side handler that lets you serve static files.
 --
 -- - 'serveDirectory' lets you serve anything that lives under a particular

--- a/sources.txt
+++ b/sources.txt
@@ -1,8 +1,8 @@
 servant
+servant-server
 servant-client
 servant-docs
 servant-jquery
-servant-server
 servant-examples
 servant-blaze
 servant-lucid


### PR DESCRIPTION
I've switched to installing everything into the user package db. This seems to work.

We might run into problems at some point because we don't use cabal's constraint solver to figure out the dependencies all at once. I would consider switching to stackage then. But for now this works.

@jkarni: What do you think?