### PR TITLE
Don't export HttpException

### DIFF
--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -46,12 +46,12 @@ data ServantError
     { responseContentType       :: MediaType
     , responseBody              :: ByteString
     }
-  | ConnectionError
-    { connectionError           :: HttpException
-    }
   | InvalidContentTypeHeader
     { responseContentTypeHeader :: ByteString
     , responseBody              :: ByteString
+    }
+  | ConnectionError
+    { connectionError           :: String
     }
   deriving (Show)
 
@@ -148,11 +148,11 @@ performRequest reqMethod req isWantedStatus reqHost = do
                                }
 
   eResponse <- liftIO $ __withGlobalManager $ \ manager ->
-    catchHttpException $
-    Client.httpLbs request manager
+    catchConnectionError $
+      Client.httpLbs request manager
   case eResponse of
     Left err ->
-      left $ ConnectionError err
+      left $ ConnectionError (show err)
 
     Right response -> do
       let status = Client.responseStatus response
@@ -185,6 +185,7 @@ performRequestNoBody reqMethod req wantedStatus reqHost = do
   _ <- performRequest reqMethod req (`elem` wantedStatus) reqHost
   return ()
 
-catchHttpException :: IO a -> IO (Either HttpException a)
-catchHttpException action =
-  catch (Right <$> action) (pure . Left)
+catchConnectionError :: IO a -> IO (Either ServantError a)
+catchConnectionError action =
+  catch (Right <$> action) $ \e ->
+    pure . Left . ConnectionError . show $ (e :: HttpException)

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -303,7 +303,7 @@ failSpec = withFailServer $ \ baseUrl -> do
       it "reports ConnectionError" $ do
         Left res <- runEitherT getGetWrongHost
         case res of
-          ConnectionError (C.FailedConnectionException2 "127.0.0.1" 19872 False _) -> return ()
+          ConnectionError _ -> return ()
           _ -> fail $ "expected ConnectionError, but got " <> show res
 
       it "reports UnsupportedContentType" $ do


### PR DESCRIPTION
This simplifies the error type. This allows for `http-client` to be swapped out (#51).