### PR TITLE
servant-docs: Fix docsWith.

### DIFF
--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -70,6 +70,7 @@ test-suite spec
       base
     , aeson
     , hspec
+    , lens
     , servant
     , servant-docs
     , string-conversions

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -338,7 +338,7 @@ extraInfo p action =
 docsWith :: HasDocs layout => [DocIntro] -> ExtraInfo layout -> Proxy layout -> API
 docsWith intros (ExtraInfo endpoints) p =
     docs p & apiIntros <>~ intros
-           & apiEndpoints %~ HM.unionWith combineAction endpoints
+           & apiEndpoints %~ HM.unionWith (flip combineAction) endpoints
 
 
 -- | Generate the docs for a given API that implements 'HasDocs' with with any


### PR DESCRIPTION
Hi,

thanks for this nice library :)

I noticed that the enpoints vanished from the documentation when adding extra info via docsWith. This pull-request fixes that.

Best,
Philipp