### PR TITLE
add stack.yaml and use it in travis file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.config
 *.aux
 *.hp
 Setup
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,26 @@
-language: haskell
+sudo: false
 
 env:
-  - CABALVER=1.18 GHCVER=7.8.4
-  - CABALVER=1.22 GHCVER=7.10.1
-
-before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- - travis_retry cabal update
+#  - GHCVER=7.8.4 STACK_YAML=stack.yaml
+  - GHCVER=7.10.1 STACK_YAML=stack.yaml
 
 install:
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - cabal --version
+ # ghc
+ - export PATH=/opt/ghc/$GHCVER/bin:$PATH
+ # stack
+ - mkdir -p ~/.local/bin
+ - export PATH=~/.local/bin:$PATH
+ - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.2.0/stack-0.1.2.0-x86_64-linux.gz | gunzip > ~/.local/bin/stack
+ - chmod a+x ~/.local/bin/stack
 
 script:
-  - ./scripts/test-all.sh
+ - stack build
+ - stack test
 
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#servant"
-    template:
-      - "%{repository}#%{build_number} - %{commit} on %{branch} by %{author}: %{message}"
-      - "Build details: %{build_url} - Change view: %{compare_url}"
-    skip_join: true
-    on_success: change
-    on_failure: always
+addons:
+  apt:
+    sources:
+    - hvr-ghc
+    packages:
+    - ghc-7.8.4
+    - ghc-7.10.1

--- a/servant-js/servant-js.cabal
+++ b/servant-js/servant-js.cabal
@@ -80,7 +80,7 @@ test-suite spec
     , lens
     , servant-js
     , servant
-    , hspec >= 2.0
+    , hspec >= 2.1.8
     , hspec-expectations
     , language-ecmascript >= 0.16
   default-language: Haskell2010

--- a/servant-server/test/Doctests.hs
+++ b/servant-server/test/Doctests.hs
@@ -9,23 +9,10 @@ import           Test.DocTest
 main :: IO ()
 main = do
     files <- find always (extension ==? ".hs") "src"
-    cabalMacrosFile <- getCabalMacrosFile
     doctest $ [ "-isrc"
-              , "-optP-include"
-              , "-optP" ++ cabalMacrosFile
               , "-XOverloadedStrings"
               , "-XFlexibleInstances"
               , "-XMultiParamTypeClasses"
               , "-XDataKinds"
               , "-XTypeOperators"
               ] ++ files
-
-getCabalMacrosFile :: IO FilePath
-getCabalMacrosFile = do
-  contents <- getDirectoryContents "dist"
-  let rest = "build" </> "autogen" </> "cabal_macros.h"
-  return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
-    [x] -> "dist" </> x </> rest
-    [] -> "dist" </> rest
-    xs -> error $ "ran doctests with multiple dist/dist-sandbox-xxxxx's: \n"
-                ++ show xs ++ "\nTry cabal clean"

--- a/servant/test/Doctests.hs
+++ b/servant/test/Doctests.hs
@@ -9,21 +9,8 @@ import           Test.DocTest
 main :: IO ()
 main = do
     files <- find always (extension ==? ".hs") "src"
-    cabalMacrosFile <- getCabalMacrosFile
     doctest $ [ "-isrc"
-              , "-optP-include"
-              , "-optP" ++ cabalMacrosFile
               , "-XOverloadedStrings"
               , "-XFlexibleInstances"
               , "-XMultiParamTypeClasses"
               ] ++ files
-
-getCabalMacrosFile :: IO FilePath
-getCabalMacrosFile = do
-  contents <- getDirectoryContents "dist"
-  let rest = "build" </> "autogen" </> "cabal_macros.h"
-  return $ case filter ("dist-sandbox-" `isPrefixOf`) contents of
-    [x] -> "dist" </> x </> rest
-    [] -> "dist" </> rest
-    xs -> error $ "ran doctests with multiple dist/dist-sandbox-xxxxx's: \n"
-                ++ show xs ++ "\nTry cabal clean"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,14 @@
+flags:
+  servant-js:
+    example: false
+packages:
+- servant-client/
+- servant-server/
+- servant-examples/
+- servant-js/
+- servant-docs/
+- servant/
+- servant-lucid/
+- servant-blaze/
+extra-deps: []
+resolver: nightly-2015-07-24


### PR DESCRIPTION
Please, don't merge yet, opening this PR for discussion.

`travis` is throwing an error because definitions from `cabal_macros.h` are not available. This should be fixed in `stack-0.1.2.1` (on master). Here's the build:

https://travis-ci.org/haskell-servant/servant/builds/72568559

So we can either wait for the next stack release or try to get rid of the cabal macros. I think at least some of them could be avoided through using `base-compat`.

Also, I haven't figured out caching yet.