### PR TITLE
Fix GenerateList to let the API be nested

### DIFF
--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -156,8 +156,8 @@ class GenerateList reqs where
 instance GenerateList AjaxReq where
   generateList r = [r]
 
-instance GenerateList rest => GenerateList (AjaxReq :<|> rest) where
-  generateList (r :<|> rest) = r : generateList rest
+instance (GenerateList start, GenerateList rest) => GenerateList (start :<|> rest) where
+  generateList (start :<|> rest) = (generateList start) ++ (generateList rest)
 
 -- | Generate the necessary data for JS codegen as a list, each 'AjaxReq'
 --   describing one endpoint from your API type. 


### PR DESCRIPTION
Previous definition only let you define one API containing all the API
This way, you can divide it into small pieces

```haskell
type PartAPI = ...

type AppAPI = ... :<|> PartAPI
```