### PR TITLE
Make it easier to define more HTTP methods

### DIFF
--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -43,7 +43,7 @@ import           Network.Wai                 (Application, lazyRequestBody,
                                               requestMethod, responseLBS, remoteHost,
                                               isSecure, vault, httpVersion, Response,
                                               Request)
-import           Servant.API                 ((:<|>) (..), (:>), Capture,
+import           Servant.API                 ((:<|>) (..), (:>), Capture, DefaultStatusCode,
                                               Header, HttpMethod, IsSecure(..),
                                               MatrixFlag, MatrixParam, MatrixParams,
                                               QueryFlag, QueryParam, QueryParams,
@@ -236,25 +236,24 @@ instance
 #endif
          ( AllCTRender ctypes a
          , KnownSymbol method
-         , KnownNat status
-         ) => HasServer (HttpMethod method status ctypes a) where
+         , KnownNat (DefaultStatusCode method)
+         ) => HasServer (HttpMethod method ctypes a) where
 
-  type ServerT (HttpMethod method status ctypes a) m = m a
+  type ServerT (HttpMethod method ctypes a) m = m a
 
   route Proxy = methodRouter method (Proxy :: Proxy ctypes) status
     where 
       method = B8.pack $ symbolVal (Proxy :: Proxy method)
-      status = toEnum $ fromInteger $ natVal (Proxy :: Proxy status)
+      status = toEnum $ fromInteger $ natVal (Proxy :: Proxy (DefaultStatusCode method))
 
 instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPING #-}
 #endif 
         ( KnownSymbol method
-        , KnownNat status
-        ) => HasServer (HttpMethod method status ctypes ()) where
+        ) => HasServer (HttpMethod method ctypes ()) where
 
-  type ServerT (HttpMethod method status ctypes ()) m = m ()
+  type ServerT (HttpMethod method ctypes ()) m = m ()
 
   route Proxy = methodRouterEmpty method
     where 
@@ -269,15 +268,15 @@ instance
          ( GetHeaders (Headers h v)
          , AllCTRender ctypes v
          , KnownSymbol method
-         , KnownNat status
-         ) => HasServer (HttpMethod method status ctypes (Headers h v)) where
+         , KnownNat (DefaultStatusCode method)
+         ) => HasServer (HttpMethod method ctypes (Headers h v)) where
 
-  type ServerT (HttpMethod method status ctypes (Headers h v)) m = m (Headers h v)
+  type ServerT (HttpMethod method ctypes (Headers h v)) m = m (Headers h v)
 
   route Proxy = methodRouterHeaders method (Proxy :: Proxy ctypes) status
     where 
       method = B8.pack $ symbolVal (Proxy :: Proxy method)
-      status = toEnum $ fromInteger $ natVal (Proxy :: Proxy status)
+      status = toEnum $ fromInteger $ natVal (Proxy :: Proxy (DefaultStatusCode method))
 
 
 -- | If you use @'QueryParam' "author" Text@ in one of the endpoints for your API,

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -218,19 +218,18 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
     where str = fromString $ symbolVal (Proxy :: Proxy sym)
 
 
--- | When implementing the handler for a 'Put' endpoint,
--- just like for 'Servant.API.Delete.Delete', 'Servant.API.Get.Get'
--- and 'Servant.API.Post.Post', the handler code runs in the
--- @EitherT ServantErr IO@ monad, where the 'Int' represents
--- the status code and the 'String' a message, returned in case of
--- failure. You can quite handily use 'Control.Monad.Trans.EitherT.left'
+-- | When implementing the handler for an 'HttpMethod' endpoint,
+-- the handler code runs in the @EitherT ServantErr IO@ monad.
+--
+-- You can quite handily use 'Control.Monad.Trans.EitherT.left'
 -- to quickly fail if some conditions are not met.
 --
--- If successfully returning a value, we use the type-level list, combined
--- with the request's @Accept@ header, to encode the value for you
--- (returning a status code of 200). If there was no @Accept@ header or it
--- was @*\/\*@, we return encode using the first @Content-Type@ type on the
--- list.
+-- If successfully returning a value, we use the type-level list,
+-- combined with the request's @Accept@ header, to encode the value
+-- for you (returning the default status code for the method -
+-- e.g. for GET the status code will be 200). If there was no @Accept@
+-- header or it was @*\/\*@, we encode the result using the first
+-- @Content-Type@ type in the list.
 instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLE #-}

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -36,6 +36,7 @@ library
     Servant.API.Header
     Servant.API.HttpVersion
     Servant.API.IsSecure
+    Servant.API.Methods
     Servant.API.Patch
     Servant.API.Post
     Servant.API.Put

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -27,6 +27,8 @@ module Servant.API (
   -- | Access the location for arbitrary data to be shared by applications and middleware
 
   -- * Actual endpoints, distinguished by HTTP method
+  module Servant.API.Methods,
+  -- | Ability to define more methods
   module Servant.API.Get,
   -- | @GET@ requests
   module Servant.API.Post,
@@ -73,6 +75,7 @@ import           Servant.API.HttpVersion     (HttpVersion (..))
 import           Servant.API.IsSecure        (IsSecure (..))
 import           Servant.API.MatrixParam     (MatrixFlag, MatrixParam,
                                               MatrixParams)
+import           Servant.API.Methods         (HttpMethod)
 import           Servant.API.Patch           (Patch)
 import           Servant.API.Post            (Post)
 import           Servant.API.Put             (Put)

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -75,7 +75,7 @@ import           Servant.API.HttpVersion     (HttpVersion (..))
 import           Servant.API.IsSecure        (IsSecure (..))
 import           Servant.API.MatrixParam     (MatrixFlag, MatrixParam,
                                               MatrixParams)
-import           Servant.API.Methods         (HttpMethod)
+import           Servant.API.Methods         (DefaultStatusCode, HttpMethod)
 import           Servant.API.Patch           (Patch)
 import           Servant.API.Post            (Post)
 import           Servant.API.Put             (Put)

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -19,7 +19,7 @@
 --
 -- Content-Types are used in `ReqBody` and the method combinators:
 --
--- >>> type MyEndpoint = ReqBody '[JSON, PlainText] Book :> Get '[JSON, PlainText] :> Book
+-- >>> type MyEndpoint = ReqBody '[JSON, PlainText] Book :> Get '[JSON, PlainText] Book
 --
 -- Meaning the endpoint accepts requests of Content-Type @application/json@
 -- or @text/plain;charset-utf8@, and returns data in either one of those

--- a/servant/src/Servant/API/Delete.hs
+++ b/servant/src/Servant/API/Delete.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Delete (Delete) where
 
-import           Data.Typeable (Typeable)
+import           Servant.API.Methods
 
 -- | Combinator for DELETE requests.
 --
@@ -12,9 +12,7 @@ import           Data.Typeable (Typeable)
 --
 -- >>>            -- DELETE /books/:isbn
 -- >>> type MyApi = "books" :> Capture "isbn" Text :> Delete
-data Delete (contentTypes :: [*]) a
-  deriving Typeable
-
+type Delete (contentTypes :: [*]) a = HttpMethod "DELETE" 200 contentTypes a
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Delete.hs
+++ b/servant/src/Servant/API/Delete.hs
@@ -11,7 +11,7 @@ import           Servant.API.Methods
 -- Example:
 --
 -- >>>            -- DELETE /books/:isbn
--- >>> type MyApi = "books" :> Capture "isbn" Text :> Delete
+-- >>> type MyApi = "books" :> Capture "isbn" Text :> Delete '[JSON] ()
 type Delete (contentTypes :: [*]) a = HttpMethod "DELETE" 200 contentTypes a
 
 -- $setup

--- a/servant/src/Servant/API/Delete.hs
+++ b/servant/src/Servant/API/Delete.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Delete (Delete) where
 
@@ -12,7 +13,9 @@ import           Servant.API.Methods
 --
 -- >>>            -- DELETE /books/:isbn
 -- >>> type MyApi = "books" :> Capture "isbn" Text :> Delete '[JSON] ()
-type Delete (contentTypes :: [*]) a = HttpMethod "DELETE" 200 contentTypes a
+type Delete (contentTypes :: [*]) a = HttpMethod "DELETE" contentTypes a
+
+type instance DefaultStatusCode "DELETE" = 200
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Get.hs
+++ b/servant/src/Servant/API/Get.hs
@@ -4,15 +4,14 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Get (Get) where
 
-import           Data.Typeable (Typeable)
+import           Servant.API.Methods
 
 -- | Endpoint for simple GET requests. Serves the result as JSON.
 --
 -- Example:
 --
 -- >>> type MyApi = "books" :> Get '[JSON] [Book]
-data Get (contentTypes :: [*]) a
-  deriving Typeable
+type Get (contentTypes :: [*]) a = HttpMethod "GET" 200 contentTypes a
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Get.hs
+++ b/servant/src/Servant/API/Get.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Get (Get) where
 
@@ -11,7 +12,9 @@ import           Servant.API.Methods
 -- Example:
 --
 -- >>> type MyApi = "books" :> Get '[JSON] [Book]
-type Get (contentTypes :: [*]) a = HttpMethod "GET" 200 contentTypes a
+type Get (contentTypes :: [*]) a = HttpMethod "GET" contentTypes a
+
+type instance DefaultStatusCode "GET" = 200
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Methods.hs
+++ b/servant/src/Servant/API/Methods.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE KindSignatures     #-}
+{-# OPTIONS_HADDOCK not-home    #-}
+
+module Servant.API.Methods where
+
+import           Data.Typeable (Typeable)
+import           GHC.TypeLits (Nat, Symbol)
+
+data HttpMethod (m :: Symbol) (s :: Nat) (contentTypes :: [*]) a 
+    deriving Typeable

--- a/servant/src/Servant/API/Methods.hs
+++ b/servant/src/Servant/API/Methods.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 
 module Servant.API.Methods where
@@ -8,5 +9,7 @@ module Servant.API.Methods where
 import           Data.Typeable (Typeable)
 import           GHC.TypeLits (Nat, Symbol)
 
-data HttpMethod (m :: Symbol) (s :: Nat) (contentTypes :: [*]) a 
+data HttpMethod (m :: Symbol) (contentTypes :: [*]) a 
     deriving Typeable
+
+type family DefaultStatusCode (m :: Symbol) :: Nat

--- a/servant/src/Servant/API/Patch.hs
+++ b/servant/src/Servant/API/Patch.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Patch (Patch) where
 
@@ -18,7 +19,9 @@ import           Servant.API.Methods
 -- >>>            -- with a JSON encoded Book as the request body
 -- >>>            -- returning the just-created Book
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Patch '[JSON] Book
-type Patch (contentTypes :: [*]) a = HttpMethod "PATCH" 200 contentTypes a
+type Patch (contentTypes :: [*]) a = HttpMethod "PATCH" contentTypes a
+
+type instance DefaultStatusCode "PATCH" = 200
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Patch.hs
+++ b/servant/src/Servant/API/Patch.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Patch (Patch) where
 
-import           Data.Typeable (Typeable)
+import           Servant.API.Methods
 
 -- | Endpoint for PATCH requests. The type variable represents the type of the
 -- response body (not the request body, use 'Servant.API.ReqBody.ReqBody' for
@@ -18,8 +18,7 @@ import           Data.Typeable (Typeable)
 -- >>>            -- with a JSON encoded Book as the request body
 -- >>>            -- returning the just-created Book
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Patch '[JSON] Book
-data Patch (contentTypes :: [*]) a
-  deriving Typeable
+type Patch (contentTypes :: [*]) a = HttpMethod "PATCH" 200 contentTypes a
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Post.hs
+++ b/servant/src/Servant/API/Post.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Post (Post) where
 
@@ -16,7 +17,9 @@ import           Servant.API.Methods
 -- >>>            -- with a JSON encoded Book as the request body
 -- >>>            -- returning the just-created Book
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book
-type Post (contentTypes :: [*]) a = HttpMethod "POST" 201 contentTypes a
+type Post (contentTypes :: [*]) a = HttpMethod "POST" contentTypes a
+
+type instance DefaultStatusCode "POST" = 201
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Post.hs
+++ b/servant/src/Servant/API/Post.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Post (Post) where
 
-import           Data.Typeable (Typeable)
+import           Servant.API.Methods
 
 -- | Endpoint for POST requests. The type variable represents the type of the
 -- response body (not the request body, use 'Servant.API.ReqBody.ReqBody' for
@@ -16,8 +16,7 @@ import           Data.Typeable (Typeable)
 -- >>>            -- with a JSON encoded Book as the request body
 -- >>>            -- returning the just-created Book
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book
-data Post (contentTypes :: [*]) a
-  deriving Typeable
+type Post (contentTypes :: [*]) a = HttpMethod "POST" 201 contentTypes a
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Put.hs
+++ b/servant/src/Servant/API/Put.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Put (Put) where
 
-import           Data.Typeable (Typeable)
+import           Servant.API.Methods
 
 -- | Endpoint for PUT requests, usually used to update a ressource.
 -- The type @a@ is the type of the response body that's returned.
@@ -14,8 +14,7 @@ import           Data.Typeable (Typeable)
 -- >>> -- PUT /books/:isbn
 -- >>> -- with a Book as request body, returning the updated Book
 -- >>> type MyApi = "books" :> Capture "isbn" Text :> ReqBody '[JSON] Book :> Put '[JSON] Book
-data Put (contentTypes :: [*]) a
-  deriving Typeable
+type Put (contentTypes :: [*]) a = HttpMethod "PUT" 200 contentTypes a
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Put.hs
+++ b/servant/src/Servant/API/Put.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Put (Put) where
 
@@ -14,7 +15,9 @@ import           Servant.API.Methods
 -- >>> -- PUT /books/:isbn
 -- >>> -- with a Book as request body, returning the updated Book
 -- >>> type MyApi = "books" :> Capture "isbn" Text :> ReqBody '[JSON] Book :> Put '[JSON] Book
-type Put (contentTypes :: [*]) a = HttpMethod "PUT" 200 contentTypes a
+type Put (contentTypes :: [*]) a = HttpMethod "PUT" contentTypes a
+
+type instance DefaultStatusCode "PUT" = 200
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/Utils/Links.hs
+++ b/servant/src/Servant/Utils/Links.hs
@@ -74,7 +74,9 @@
 -- >>> safeLink api bad_link
 -- ...
 --     Could not deduce (Or
---                         (IsElem' (Delete '[JSON] ()) (Get '[JSON] Int))
+--                         (IsElem' 
+--                            (HttpMethod "DELETE" 200 '[JSON] ())
+--                            (HttpMethod "GET" 200 '[JSON] Int))
 --                         (IsElem'
 --                            ("hello" :> Delete '[JSON] ())
 --                            ("bye" :> (QueryParam "name" String :> Delete '[JSON] ()))))


### PR DESCRIPTION
Sending this for a bit of discussion.

This change factors out common functionality from the HasServer instances for
the various existing HTTP methods, so that there is only one real
datatype (`HttpMethod`) and the existing implementations are all just type
aliases for this.

This should hopefully make it near-trivial to define new HTTP methods.

I think this should be mostly source-compatible with the previous implementation?

Probably need to do something about the 'default' status codes as well (per #189).