### PR TITLE
Authentication: Digest auth support

### DIFF
--- a/servant-client/CHANGELOG.md
+++ b/servant-client/CHANGELOG.md
@@ -4,6 +4,7 @@ HEAD
 * Support for the `HttpVersion`, `IsSecure`, `RemoteHost` and `Vault` combinators
 * Added support for `path` on `BaseUrl`.
 * `client` now takes an explicit `Manager` argument.
+* Support for servant's new authentication framework.
 
 0.4.1
 -----

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -33,6 +33,7 @@ library
       base >=4.7 && <5
     , aeson
     , attoparsec
+    , base64-bytestring
     , bytestring
     , exceptions
     , http-client
@@ -65,7 +66,6 @@ test-suite spec
     , transformers
     , transformers-compat
     , aeson
-    , base64-bytestring
     , bytestring
     , deepseq
     , hspec == 2.*

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
     Servant.Client
+    Servant.Client.Authentication
     Servant.Common.BaseUrl
     Servant.Common.Req
   build-depends:
@@ -64,6 +65,7 @@ test-suite spec
     , transformers
     , transformers-compat
     , aeson
+    , base64-bytestring
     , bytestring
     , deepseq
     , hspec == 2.*

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -125,10 +125,11 @@ instance (KnownSymbol capture, ToText a, HasClient sublayout)
 instance (AuthenticateRequest authdata, HasClient sublayout) => HasClient (AuthProtect authdata (usr :: *) policy :> sublayout) where
     type Client (AuthProtect authdata usr policy :> sublayout) = authdata -> Client sublayout
 
-    clientWithRoute Proxy req baseurl val =
+    clientWithRoute Proxy req baseurl manager val =
         clientWithRoute (Proxy :: Proxy sublayout)
                         (authReq val req)
                         baseurl
+                        manager
 
 -- | If you have a 'Delete' endpoint in your API, the client
 -- side querying function that is created when calling 'client'

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -37,6 +37,8 @@ import           Network.HTTP.Media
 import qualified Network.HTTP.Types         as H
 import qualified Network.HTTP.Types.Header  as HTTP
 import           Servant.API
+import           Servant.API.Authentication (AuthProtect)
+import           Servant.Client.Authentication (AuthenticateRequest(authReq))
 import           Servant.Common.BaseUrl
 import           Servant.Common.Req
 
@@ -118,6 +120,15 @@ instance (KnownSymbol capture, ToText a, HasClient sublayout)
                     manager
 
     where p = unpack (toText val)
+
+-- | Authentication
+instance (AuthenticateRequest authdata, HasClient sublayout) => HasClient (AuthProtect authdata (usr :: *) policy :> sublayout) where
+    type Client (AuthProtect authdata usr policy :> sublayout) = authdata -> Client sublayout
+
+    clientWithRoute Proxy req baseurl val =
+        clientWithRoute (Proxy :: Proxy sublayout)
+                        (authReq val req)
+                        baseurl
 
 -- | If you have a 'Delete' endpoint in your API, the client
 -- side querying function that is created when calling 'client'

--- a/servant-client/src/Servant/Client/Authentication.hs
+++ b/servant-client/src/Servant/Client/Authentication.hs
@@ -1,12 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Authentication for clients
 
 module Servant.Client.Authentication (
     AuthenticateRequest ( authReq )
     ) where
 
-import Servant.Common.Req (Req)
+import Data.ByteString.Base64  (encode)
+import Data.Monoid ((<>))
+import Data.Text.Encoding (decodeUtf8)
+import Servant.API.Authentication (BasicAuth(BasicAuth))
+import Servant.Common.Req (addHeader, Req)
 
 -- | Class to represent the ability to authenticate a 'Request'
 -- object. For example, we may add special headers to the 'Request'.
 class AuthenticateRequest a where
     authReq :: a -> Req -> Req
+     
+
+instance AuthenticateRequest (BasicAuth realm) where
+    authReq (BasicAuth user pass) req =
+        let authText = decodeUtf8 ("Basic " <> encode (user <> ":" <> pass)) in
+            addHeader "Authorization" authText req
+

--- a/servant-client/src/Servant/Client/Authentication.hs
+++ b/servant-client/src/Servant/Client/Authentication.hs
@@ -1,0 +1,12 @@
+-- | Authentication for clients
+
+module Servant.Client.Authentication (
+    AuthenticateRequest ( authReq )
+    ) where
+
+import Servant.Common.Req (Req)
+
+-- | Class to represent the ability to authenticate a 'Request'
+-- object. For example, we may add special headers to the 'Request'.
+class AuthenticateRequest a where
+    authReq :: a -> Req -> Req

--- a/servant-client/src/Servant/Client/Authentication.hs
+++ b/servant-client/src/Servant/Client/Authentication.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 -- | Authentication for clients
 
@@ -8,6 +9,7 @@ module Servant.Client.Authentication (
 
 import Data.ByteString.Base64  (encode)
 import Data.Monoid ((<>))
+import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Servant.API.Authentication (BasicAuth(BasicAuth))
 import Servant.Common.Req (addHeader, Req)
@@ -23,3 +25,8 @@ instance AuthenticateRequest (BasicAuth realm) where
         let authText = decodeUtf8 ("Basic " <> encode (user <> ":" <> pass)) in
             addHeader "Authorization" authText req
 
+type JSON = Text
+instance AuthenticateRequest JSON where
+  authReq token req =
+    let authText = ("Bearer " <> token)
+    in addHeader "Authorization" authText req

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -283,7 +283,7 @@ spec = withServer $ \ baseUrl -> do
       Left res <- runExceptT (getPrivatePerson (BasicAuth "xxx" "yyy"))
       case res of
         FailureResponse (Status 401 _) _ _ -> return ()
-        _ -> fail $ "expcted 401 response, but got " <> show res
+        _ -> fail $ "expected 401 response, but got " <> show res
 
     modifyMaxSuccess (const 20) $ do
       it "works for a combination of Capture, QueryParam, QueryFlag and ReqBody" $

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -20,14 +20,12 @@ import           Control.Concurrent
 import           Control.Exception
 import           Control.Monad.Trans.Except
 import           Data.Aeson
-import qualified Data.ByteString.Base64     as B64
 import           Data.ByteString.Lazy       (ByteString)
 import           Data.Char
 import           Data.Foldable              (forM_)
 import           Data.Monoid
 import           Data.Proxy
 import qualified Data.Text                  as T
-import qualified Data.Text.Encoding         as TE
 import           GHC.Generics
 import qualified Network.HTTP.Client        as C
 import           Network.HTTP.Media
@@ -44,8 +42,7 @@ import           Test.QuickCheck
 import           Servant.API
 import           Servant.API.Authentication
 import           Servant.Client
-import qualified Servant.Common.Req         as SCR
-import           Servant.Client.Authentication (AuthenticateRequest(authReq))
+import           Servant.Client.Authentication()
 import           Servant.Server
 import           Servant.Server.Internal.Authentication
 
@@ -112,11 +109,6 @@ basicAuthCheck :: BasicAuth "realm" -> IO (Maybe Person)
 basicAuthCheck (BasicAuth user pass) = if user == "servant" && pass == "server"
                                        then return (Just $ Person "servant" 17)
                                        else return Nothing
-
-instance AuthenticateRequest (BasicAuth realm) where
-    authReq (BasicAuth user pass) req =
-        let authText = TE.decodeUtf8 ("Basic " <> B64.encode (user <> ":" <> pass)) in
-            SCR.addHeader "Authorization" authText req
 
 api :: Proxy Api
 api = Proxy

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -161,7 +161,6 @@ withFailServer action = withWaiDaemon (return failServer) action
 
 spec :: IO ()
 spec = withServer $ \ baseUrl -> do
-<<<<<<< HEAD
   manager <- C.newManager C.defaultManagerSettings
   let getGet :: ExceptT ServantError IO Person
       getDeleteEmpty :: ExceptT ServantError IO ()
@@ -269,7 +268,7 @@ spec = withServer $ \ baseUrl -> do
         Right val -> getHeaders val `shouldBe` [("X-Example1", "1729"), ("X-Example2", "eg2")]
 
     it "Handles Authentication appropriatley" $ withServer $ \ _ -> do
-      (Arrow.left show <$> runExceptT (getPrivatePerson (BasicAuth "servant" "server"))) `shouldReturn` Right alice
+      (Control.Arrow.left show <$> runExceptT (getPrivatePerson (BasicAuth "servant" "server"))) `shouldReturn` Right alice
 
     it "returns 401 when not properly authenticated" $ do
       Left res <- runExceptT (getPrivatePerson (BasicAuth "xxx" "yyy"))

--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -8,6 +8,8 @@ HEAD
 * Add more `ToSamples` instances: `Bool`, `Ordering`, tuples (up to 7), `[]`, `Maybe`, `Either`, `Const`, `ZipList` and some monoids
 * Move `toSample` out of `ToSample` class
 * Add a few helper functions to define `toSamples`
+* Support for new Authentication framework
+* Added `ToAuthInfo` typeclass.
 
 0.4
 ---

--- a/servant-docs/example/greet.hs
+++ b/servant-docs/example/greet.hs
@@ -73,14 +73,14 @@ instance ToSample Greet where
 instance ToSample Int where
   toSamples _ = singleSample 1729
 
-instance ToSample User User where
-  toSample _ = Just (User "I'm a user!")
+instance ToSample User  where
+  toSamples _ = singleSample (User "I'm a user!")
 
-instance ToSample Cookie Cookie where
-  toSample _ = Just (Cookie "cookie")
+instance ToSample Cookie where
+  toSamples _ = singleSample (Cookie "cookie")
 
-instance ToSample SecretData SecretData where
-  toSample _ = Just (SecretData "shhhhh!")
+instance ToSample SecretData where
+  toSamples _ = singleSample (SecretData "shhhhh!")
 
 instance ToAuthInfo (AuthProtect Cookie User policy) where
     toAuthInfo _ = AuthenticationInfo "In this sentence we outline how authentication works."

--- a/servant-docs/example/greet.hs
+++ b/servant-docs/example/greet.hs
@@ -82,7 +82,7 @@ instance ToSample Cookie Cookie where
 instance ToSample SecretData SecretData where
   toSample _ = Just (SecretData "shhhhh!")
 
-instance ToAuthInfo (AuthProtect Cookie User 'Strict) where
+instance ToAuthInfo (AuthProtect Cookie User policy) where
     toAuthInfo _ = AuthenticationInfo "In this sentence we outline how authentication works."
                                       "The following data is required on each request as a serialized header."
 
@@ -116,6 +116,8 @@ type TestApi =
 
        -- GET /private
   :<|> "private" :> AuthProtect Cookie User 'Strict :> Get '[JSON] SecretData
+       -- GET /private-lax
+  :<|> "private-lax" :> AuthProtect Cookie User 'Lax :> Get '[JSON] SecretData
 
 testApi :: Proxy TestApi
 testApi = Proxy

--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -149,13 +149,12 @@ module Servant.Docs
   , DocOptions(..) , defaultDocOptions, maxSamples
 
   , -- * Classes you need to implement for your types
-<<<<<<< HEAD
     ToSample(..)
   , toSample
   , noSamples
   , singleSample
   , samples
-    ToAuthInfo(..)
+  , ToAuthInfo(..)
   , sampleByteString
   , sampleByteStrings
   , ToParam(..)

--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -149,11 +149,13 @@ module Servant.Docs
   , DocOptions(..) , defaultDocOptions, maxSamples
 
   , -- * Classes you need to implement for your types
+<<<<<<< HEAD
     ToSample(..)
   , toSample
   , noSamples
   , singleSample
   , samples
+    ToAuthInfo(..)
   , sampleByteString
   , sampleByteStrings
   , ToParam(..)
@@ -163,12 +165,13 @@ module Servant.Docs
     Method(..)
   , Endpoint, path, method, defEndpoint
   , API, apiIntros, apiEndpoints, emptyAPI
+  , AuthenticationInfo(..), authIntro, authDataRequired
   , DocCapture(..), capSymbol, capDesc
   , DocQueryParam(..), ParamKind(..), paramName, paramValues, paramDesc, paramKind
   , DocNote(..), noteTitle, noteBody
   , DocIntro(..), introTitle, introBody
   , Response(..), respStatus, respTypes, respBody, defResponse
-  , Action, captures, headers, notes, params, rqtypes, rqbody, response, defAction
+  , Action, authInfo, captures, headers, notes, params, rqtypes, rqbody, response, defAction
   , single
   ) where
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -43,6 +43,7 @@ import           GHC.Exts                   (Constraint)
 import           GHC.Generics
 import           GHC.TypeLits
 import           Servant.API
+import           Servant.API.Authentication
 import           Servant.API.ContentTypes
 import           Servant.Utils.Links
 
@@ -81,8 +82,8 @@ instance Hashable Method
 -- POST /foo
 -- @
 data Endpoint = Endpoint
-  { _path   :: [String] -- type collected
-  , _method :: Method   -- type collected
+  { _path           :: [String]     -- type collected
+  , _method         :: Method       -- type collected
   } deriving (Eq, Ord, Generic)
 
 instance Show Endpoint where
@@ -235,6 +236,13 @@ defResponse = Response
   , _respHeaders = []
   }
 
+-- | A type to represent Authentication information about an endpoint.
+data AuthenticationInfo = AuthenticationInfo
+  { _authIntro        :: String
+  , _authDataRequired :: String
+  , _authUserReturned :: String
+  } deriving (Eq, Ord, Show)
+
 -- | A datatype that represents everything that can happen
 -- at an endpoint, with its lenses:
 --
@@ -246,7 +254,8 @@ defResponse = Response
 -- You can tweak an 'Action' (like the default 'defAction') with these lenses
 -- to transform an action and add some information to it.
 data Action = Action
-  { _captures :: [DocCapture]                -- type collected + user supplied info
+  { _authInfo :: Maybe AuthenticationInfo    -- type collected + user supplied info
+  , _captures :: [DocCapture]                -- type collected + user supplied info
   , _headers  :: [Text]                      -- type collected
   , _params   :: [DocQueryParam]             -- type collected + user supplied info
   , _notes    :: [DocNote]                   -- user supplied
@@ -263,8 +272,8 @@ data Action = Action
 -- 'combineAction' to mush two together taking the response, body and content
 -- types from the very left.
 combineAction :: Action -> Action -> Action
-Action c h p n m ts body resp `combineAction` Action c' h' p' n' m' _ _ _ =
-        Action (c <> c') (h <> h') (p <> p') (n <> n') (m <> m') ts body resp
+Action a c h p n m ts body resp `combineAction` Action _ c' h' p' n' m' _ _ _ =
+        Action a (c <> c') (h <> h') (p <> p') (n <> n') (m <> m') ts body resp
 
 -- Default 'Action'. Has no 'captures', no GET 'params', expects
 -- no request body ('rqbody') and the typical response is 'defResponse'.
@@ -272,12 +281,13 @@ Action c h p n m ts body resp `combineAction` Action c' h' p' n' m' _ _ _ =
 -- Tweakable with lenses.
 --
 -- > λ> defAction
--- > Action {_captures = [], _headers = [], _params = [], _mxParams = [], _rqbody = Nothing, _response = Response {_respStatus = 200, _respBody = Nothing}}
+-- > Action {_authentication = Nothing, _captures = [], _headers = [], _params = [], _mxParams = [], _rqbody = Nothing, _response = Response {_respStatus = 200, _respBody = Nothing}}
 -- > λ> defAction & response.respStatus .~ 201
--- > Action {_captures = [], _headers = [], _params = [], _mxParams = [], _rqbody = Nothing, _response = Response {_respStatus = 201, _respBody = Nothing}}
+-- > Action {_authentication = Nothing, _captures = [], _headers = [], _params = [], _mxParams = [], _rqbody = Nothing, _response = Response {_respStatus = 201, _respBody = Nothing}}
 defAction :: Action
 defAction =
-  Action []
+  Action Nothing
+         []
          []
          []
          []
@@ -295,6 +305,7 @@ single e a = API mempty (HM.singleton e a)
 -- gimme some lenses
 makeLenses ''DocOptions
 makeLenses ''API
+makeLenses ''AuthenticationInfo
 makeLenses ''Endpoint
 makeLenses ''DocCapture
 makeLenses ''DocQueryParam
@@ -533,6 +544,10 @@ class ToParam t where
 class ToCapture c where
   toCapture :: Proxy c -> DocCapture
 
+-- | The class that helps us get documentation for authenticated endpoints
+class ToAuthInfo a where
+    toAuthInfo :: Proxy a -> AuthenticationInfo
+
 -- | Generate documentation in Markdown format for
 --   the given 'API'.
 markdown :: API -> String
@@ -545,6 +560,7 @@ markdown api = unlines $
           str :
           "" :
           notesStr (action ^. notes) ++
+          authStr (action ^. authInfo) ++
           capturesStr (action ^. captures) ++
           mxParamsStr (action ^. mxParams) ++
           headersStr (action ^. headers) ++
@@ -576,6 +592,16 @@ markdown api = unlines $
             "" :
             intersperse "" (nt ^. noteBody) ++
             "" :
+            []
+
+        authStr :: Maybe AuthenticationInfo -> [String]
+        authStr Nothing = []
+        authStr (Just auth) =
+            "#### Authentication" :
+            "This endpoint is protected." :
+            auth ^. authIntro :
+            "Data to supply" :
+            auth ^. authDataRequired :
             []
 
         capturesStr :: [DocCapture] -> [String]
@@ -720,6 +746,22 @@ instance (KnownSymbol sym, ToCapture (Capture sym a), HasDocs sublayout)
           endpoint' = over path (\p -> p ++ [":" ++ symbolVal symP]) endpoint
           symP = Proxy :: Proxy sym
 
+-- | authentication instance.
+instance
+#if MIN_VERSION_base(4,8,0)
+        {-# OVERLAPPABLE #-}
+#endif
+         ( HasDocs sublayout
+         , ToSample auth auth
+         , ToSample usr usr
+         , ToAuthInfo (AuthProtect auth usr policy)
+         )
+         => HasDocs (AuthProtect auth usr policy :> sublayout) where
+            docsFor Proxy (endpoint, action) =
+              docsFor (Proxy :: Proxy sublayout) (endpoint, action')
+
+                where
+                  action' = action & authInfo .~ Just (toAuthInfo (Proxy :: Proxy (AuthProtect auth usr policy)))
 
 instance
 #if MIN_VERSION_base(4,8,0)

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -754,8 +754,8 @@ instance
         {-# OVERLAPPABLE #-}
 #endif
          ( HasDocs sublayout
-         , ToSample auth auth
-         , ToSample usr usr
+         , ToSample auth
+         , ToSample usr
          , ToAuthInfo (AuthProtect auth usr policy)
          )
          => HasDocs (AuthProtect auth usr policy :> sublayout) where

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -82,8 +82,8 @@ instance Hashable Method
 -- POST /foo
 -- @
 data Endpoint = Endpoint
-  { _path           :: [String]     -- type collected
-  , _method         :: Method       -- type collected
+  { _path   :: [String]     -- type collected
+  , _method :: Method       -- type collected
   } deriving (Eq, Ord, Generic)
 
 instance Show Endpoint where
@@ -240,7 +240,6 @@ defResponse = Response
 data AuthenticationInfo = AuthenticationInfo
   { _authIntro        :: String
   , _authDataRequired :: String
-  , _authUserReturned :: String
   } deriving (Eq, Ord, Show)
 
 -- | A datatype that represents everything that can happen
@@ -598,10 +597,13 @@ markdown api = unlines $
         authStr Nothing = []
         authStr (Just auth) =
             "#### Authentication" :
-            "This endpoint is protected." :
+            "" :
             auth ^. authIntro :
-            "Data to supply" :
+            "" :
+            "Clients must supply the following data" :
+            "" :
             auth ^. authDataRequired :
+            "" :
             []
 
         capturesStr :: [DocCapture] -> [String]

--- a/servant-examples/auth-combinator/auth-combinator.hs
+++ b/servant-examples/auth-combinator/auth-combinator.hs
@@ -1,19 +1,14 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
+-- | An example of a custom authentication framework that checks a Cookie for a
+-- value.
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
-import           Data.Aeson
-import           Data.ByteString          (ByteString)
-import           Data.Text                (Text)
-import           GHC.Generics
-import           Network.HTTP.Types
-import           Network.Wai
-import           Network.Wai.Handler.Warp
-import           Servant
-import           Servant.Server.Internal
+
 import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder.Internal (byteStringCopy)
@@ -27,9 +22,6 @@ import Servant
 import Servant.API.Authentication
 import Servant.Server.Internal
 import Servant.Server.Internal.Authentication (strictProtect, AuthHandlers(AuthHandlers))
-
--- | An example of a custom authentication framework that checks a Cookie for a
--- value.
 
 -- | Data we will use to test for authentication
 data CookieAuth = CookieAuth { cookie :: ByteString }

--- a/servant-examples/auth-combinator/auth-combinator.hs
+++ b/servant-examples/auth-combinator/auth-combinator.hs
@@ -34,13 +34,13 @@ import Servant.Server.Internal.Authentication (strictProtect, AuthHandlers(AuthH
 -- | Data we will use to test for authentication
 data CookieAuth = CookieAuth { cookie :: ByteString }
 
--- | a 'User' datatype we get once the authentication data is tested.
+-- | A 'User' datatype we get once the authentication data is tested.
 type User = ByteString
 
--- | we will look up authentication data in the database and extract a User.
+-- | We will look up authentication data in the database and extract a User.
 type DBLookup = CookieAuth -> IO (Maybe User)
 
--- | method that tests for authentication and extracts a User type.
+-- | Method that tests for authentication and extracts a User type.
 isGoodCookie :: DBLookup
 isGoodCookie (CookieAuth cookie) = if cookie == "good cookie" then return (Just "one user") else return Nothing
 
@@ -56,11 +56,11 @@ cookieAuthHandlers = AuthHandlers missingAuth notAuthenticated
         responseBuilder status401 [] ("Invalid cookie: " <> byteStringCopy cookie)
 
 -- | 'AuthData' is a typeclass that provides a method to extract authentication
--- data from a 'Reqest'
+-- data from a 'Request'
 instance AuthData CookieAuth where
     authData req = fmap CookieAuth (lookup "Cookie" (requestHeaders req))
 
--- | some data we will return from our API that is protected
+-- | Some data we will return from our API that is protected
 newtype PrivateData = PrivateData { ssshhh :: Text }
   deriving (Eq, Show, Generic)
 

--- a/servant-examples/auth-combinator/auth-combinator.hs
+++ b/servant-examples/auth-combinator/auth-combinator.hs
@@ -86,7 +86,7 @@ api :: Proxy API
 api = Proxy
 
 server :: Server API
-server = strictProtect isGoodCookie (const (return prvdata)) cookieAuthHandlers
+server = strictProtect isGoodCookie cookieAuthHandlers (const (return prvdata))
     :<|> return pubdata
 
   where prvdata = [PrivateData "this is a secret"]

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -29,6 +29,7 @@ library
   build-depends:       base    == 4.*
                      , lens    == 4.*
                      , servant == 0.5.*
+                     , text            >= 1.2  && < 1.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/servant-js/src/Servant/JS/Internal.hs
+++ b/servant-js/src/Servant/JS/Internal.hs
@@ -111,6 +111,7 @@ toValidFunctionName [] = "_"
 
 toJSHeader :: HeaderArg -> String
 toJSHeader (HeaderArg n)          = toValidFunctionName ("header" <> n)
+toJSHeader (HeaderArgGen n b)     = b (toJSHeader (HeaderArg n))
 toJSHeader (ReplaceHeaderArg n p)
   | pn `isPrefixOf` p = pv <> " + \"" <> rp <> "\""
   | pn `isSuffixOf` p = "\"" <> rp <> "\" + " <> pv

--- a/servant-mock/src/Servant/Mock.hs
+++ b/servant-mock/src/Servant/Mock.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- |
 -- Module     : Servant.Mock
@@ -61,9 +62,12 @@ import           GHC.TypeLits
 import           Network.HTTP.Types.Status
 import           Network.Wai
 import           Servant
+import           Servant.API.Authentication
 import           Servant.API.ContentTypes
+import            Servant.Server.Internal.Authentication
 import           Test.QuickCheck.Arbitrary  (Arbitrary (..), vector)
 import           Test.QuickCheck.Gen        (Gen, generate)
+
 
 -- | 'HasMock' defines an interpretation of API types
 --   than turns them into random-response-generating
@@ -149,6 +153,21 @@ instance (KnownSymbol s, HasMock rest) => HasMock (MatrixFlag s :> rest) where
 
 instance (KnownSymbol h, FromText a, HasMock rest) => HasMock (Header h a :> rest) where
   mock _ = \_ -> mock (Proxy :: Proxy rest)
+
+instance (HasMock rest, AuthData authdata, Arbitrary usr) => HasMock (AuthProtect authdata (usr :: *) 'Lax :> rest) where
+  mock _ = laxProtect (\_ -> do { a <- generate arbitrary; return (Just a)}) (\_ -> mock (Proxy :: Proxy rest))
+
+instance (HasMock rest, Arbitrary usr, KnownSymbol realm)
+      => HasMock (AuthProtect (BasicAuth realm) (usr :: *) 'Strict :> rest) where
+  mock _ = basicAuthStrict (\_ -> do { a <- generate arbitrary; return (Just a)})
+                           (\_ -> mock (Proxy :: Proxy rest))
+
+instance (HasMock rest, Arbitrary usr)
+      => HasMock (AuthProtect JWTAuth (usr :: *) 'Strict :> rest) where
+  mock _ = strictProtect (\_ -> do { a <- generate arbitrary; return (Just a)})
+                         (AuthHandlers (return authFailure) ((const . return) authFailure))
+                         (\_ -> mock (Proxy :: Proxy rest))
+    where authFailure = responseBuilder status401 [] mempty
 
 instance (Arbitrary a, AllCTRender ctypes a) => HasMock (Delete ctypes a) where
   mock _ = mockArbitrary

--- a/servant-mock/src/Servant/Mock.hs
+++ b/servant-mock/src/Servant/Mock.hs
@@ -154,8 +154,10 @@ instance (KnownSymbol s, HasMock rest) => HasMock (MatrixFlag s :> rest) where
 instance (KnownSymbol h, FromText a, HasMock rest) => HasMock (Header h a :> rest) where
   mock _ = \_ -> mock (Proxy :: Proxy rest)
 
-instance (HasMock rest, AuthData authdata, Arbitrary usr) => HasMock (AuthProtect authdata (usr :: *) 'Lax :> rest) where
-  mock _ = laxProtect (\_ -> do { a <- generate arbitrary; return (Just a)}) (\_ -> mock (Proxy :: Proxy rest))
+instance (HasMock rest, AuthData authdata, Arbitrary usr)
+      => HasMock (AuthProtect authdata (usr :: *) 'Lax :> rest) where
+  mock _ = laxProtect (\_ -> do { a <- generate arbitrary; return (Just a)})
+                      (\_ -> mock (Proxy :: Proxy rest))
 
 instance (HasMock rest, Arbitrary usr, KnownSymbol realm)
       => HasMock (AuthProtect (BasicAuth realm) (usr :: *) 'Strict :> rest) where

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -3,6 +3,11 @@ HEAD
 
 * Support for the `HttpVersion`, `IsSecure`, `RemoteHost` and `Vault` combinators
 * Drop `EitherT` in favor of `ExceptT`
+* Support for the new authentication framework. Including:
+  * `HasServer` instances for `AuthProtect` in `Strict` and `Lax` mode
+  * `Enter` instances for `AuthProtected`
+  * combinators to support `Basic` authentication.
+  * combinators to support `JWT` authentication
 
 0.4.1
 -----

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -43,7 +43,6 @@ library
     Servant.Server.Internal.ServantErr
     Servant.Utils.StaticFiles
   build-depends:
-<<<<<<< HEAD
         base               >= 4.7  && < 5
       , aeson              >= 0.7  && < 0.11
       , attoparsec         >= 0.12 && < 0.14
@@ -67,7 +66,7 @@ library
       , wai                >= 3.0  && < 3.1
       , wai-app-static     >= 3.0  && < 3.2
       , warp               >= 3.0  && < 3.2
-
+      , word8              >= 0.1.0
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -68,6 +68,7 @@ library
       , wai-app-static     >= 3.0  && < 3.2
       , warp               >= 3.0  && < 3.2
       , word8              >= 0.1.0
+      , jwt
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -43,9 +43,11 @@ library
     Servant.Server.Internal.ServantErr
     Servant.Utils.StaticFiles
   build-depends:
+<<<<<<< HEAD
         base               >= 4.7  && < 5
       , aeson              >= 0.7  && < 0.11
       , attoparsec         >= 0.12 && < 0.14
+      , base64-bytestring  >= 1.0.0.0
       , bytestring         >= 0.10 && < 0.11
       , containers         >= 0.5  && < 0.6
       , http-types         >= 0.8  && < 0.9

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -36,6 +36,7 @@ library
     Servant
     Servant.Server
     Servant.Server.Internal
+    Servant.Server.Internal.Authentication
     Servant.Server.Internal.Enter
     Servant.Server.Internal.PathInfo
     Servant.Server.Internal.Router

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -15,6 +15,7 @@
 
 module Servant.Server.Internal
   ( module Servant.Server.Internal
+  , module Servant.Server.Internal.Authentication
   , module Servant.Server.Internal.PathInfo
   , module Servant.Server.Internal.Router
   , module Servant.Server.Internal.RoutingApplication

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -30,7 +30,6 @@ import qualified Data.ByteString             as B
 import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Map                    as M
 import qualified Data.ByteString                            as B
-import           Data.ByteString.Base64      (decodeLenient)
 import qualified Data.ByteString.Lazy                       as BL
 import qualified Data.Map                                   as M
 import           Data.Maybe                  (mapMaybe, fromMaybe)

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -73,8 +73,15 @@ type Server layout = ServerT layout (ExceptT ServantErr IO)
 
 -- | A type-indexed class to encapsulate Basic authentication handling.
 -- Authentication handling is indexed by the lookup type.
-class BasicAuthLookup lookup a | lookup -> a where
-    basicAuthLookup :: Proxy lookup -> B.ByteString -> B.ByteString -> IO (Maybe a)
+--
+-- > data ExampleAuthDB
+-- > data ExampleUser
+-- > instance BasicAuthLookup ExampleAuthDB where
+-- >   type BasicAuthVal = ExampleUser
+-- >   basicAuthLookup _ _ _ = return Nothing
+class BasicAuthLookup lookup where
+    type BasicAuthVal
+    basicAuthLookup :: Proxy lookup -> B.ByteString -> B.ByteString -> IO (Maybe BasicAuthVal)
 
 -- * Instances
 
@@ -244,31 +251,44 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLE #-}
 #endif
-         (HasServer sublayout, BasicAuthLookup lookup authVal) => HasServer (BasicAuth realm lookup authVal :> sublayout) where
-    type ServerT (BasicAuth realm lookup authVal :> sublayout) m = authVal -> ServerT sublayout m
-    route proxy action request response =
+    ( HasServer sublayout
+    , BasicAuthLookup lookup
+    , KnownSymbol realm
+    )
+    => HasServer (BasicAuth realm lookup :> sublayout) where
+
+    type ServerT (BasicAuth realm lookup :> sublayout) m
+        = BasicAuthVal -> ServerT sublayout m
+
+    route _ action request respond =
         case lookup "Authorization" (requestHeaders request) of
-            Nothing     -> error "handle no authorization header" -- 401
+            Nothing     -> respond . succeedWith $ authFailure401
             Just authBs ->
                 -- ripped from: https://hackage.haskell.org/package/wai-extra-1.3.4.5/docs/src/Network-Wai-Middleware-HttpAuth.html#basicAuth
                 let (x,y) = B.break isSpace authBs in
                     if B.map toLower x == "basic"
-                    then checkB64 (B.dropWhile isSpace y)
-                    else error "not basic authentication" -- 401
+                         -- check base64-encoded password
+                    then checkB64AndRespond (B.dropWhile isSpace y)
+                         -- Authenticaiton header is not Basic, fail with 401.
+                    else respond . succeedWith $ authFailure401
       where
-        checkB64 encoded =
+        realmBytes = (fromString . symbolVal) (Proxy :: Proxy realm)
+        headerBytes = "Basic realm=\"" <> realmBytes <> "\""
+        authFailure401 = responseLBS status401 [("WWW-Authenticate", headerBytes)] ""
+        checkB64AndRespond encoded =
             case B.uncons passwordWithColonAtHead of
                 Just (_, password) -> do
                     -- let's check these credentials using the user-provided lookup method
                     maybeAuthData <- basicAuthLookup (Proxy :: Proxy lookup) username password
                     case maybeAuthData of
-                        Nothing         -> error "bad password" -- 403
+                        Nothing         -> respond . succeedWith $ authFailure403
                         (Just authData) ->
-                            route (Proxy :: Proxy sublayout) (action authData) request response
+                            route (Proxy :: Proxy sublayout) (action authData) request respond
 
                 -- no username:password present
-                Nothing            -> error "No password" -- 403
+                Nothing            -> respond . succeedWith $ authFailure401
           where
+            authFailure403 = responseLBS status403 [] ""
             raw = decodeLenient encoded
             -- split username and password at the colon ':' char.
             (username, passwordWithColonAtHead) = B.breakByte _colon raw

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -23,7 +23,7 @@ module Servant.Server.Internal
   ) where
 
 #if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative                        ((<$>))
+import           Control.Applicative                        ((<$>), pure)
 #endif
 import           Control.Monad.Trans.Except  (ExceptT)
 import qualified Data.ByteString             as B

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString.Lazy                       as BL
 import qualified Data.Map                                   as M
 import           Data.Maybe                  (mapMaybe, fromMaybe)
 import           Data.String                                (fromString)
-import           Data.String.Conversions                    (cs, (<>), ConvertibleStrings)
+import           Data.String.Conversions                    (ConvertibleStrings, cs, (<>))
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
 import           Data.Text.Encoding                         (decodeUtf8,
@@ -51,6 +51,8 @@ import           Network.Wai                                (Application,
                                                              lazyRequestBody,
                                                              rawQueryString,
                                                              remoteHost,
+                                                             Response,
+                                                             Request,
                                                              requestHeaders,
                                                              requestMethod,
                                                              responseLBS, vault)
@@ -80,8 +82,8 @@ import           Servant.Common.Text                        (FromText, fromText)
 import           Servant.Server.Internal.Authentication     (AuthData (authData),
                                                              AuthProtected (..),
                                                              checkAuthStrict,
-                                                             onMissingAuthData,
-                                                             onUnauthenticated)
+                                                             AuthHandlers(onMissingAuthData,
+                                                             onUnauthenticated))
 import           Servant.Server.Internal.PathInfo
 import           Servant.Server.Internal.Router
 import           Servant.Server.Internal.RoutingApplication

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 #if !MIN_VERSION_base(4,8,0)
-{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE OverlappingInstances   #-}
 #endif
 
 module Servant.Server.Internal
@@ -27,6 +27,8 @@ import           Control.Monad.Trans.Except  (ExceptT)
 import qualified Data.ByteString             as B
 import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Map                    as M
+import           Data.ByteString.Base64      (decodeLenient)
+import qualified Data.ByteString.Lazy        as BL
 import           Data.Maybe                  (mapMaybe, fromMaybe)
 import           Data.String                 (fromString)
 import           Data.String.Conversions     (cs, (<>), ConvertibleStrings)
@@ -34,20 +36,22 @@ import           Data.Text                   (Text)
 import qualified Data.Text                   as T
 import           Data.Text.Encoding          (decodeUtf8, encodeUtf8)
 import           Data.Typeable
+import           Data.Word8                  (isSpace, _colon, toLower)
 import           GHC.TypeLits                (KnownSymbol, symbolVal)
 import           Network.HTTP.Types          hiding (Header, ResponseHeaders)
 import           Network.Socket              (SockAddr)
-import           Network.Wai                 (Application, lazyRequestBody,
-                                              rawQueryString, requestHeaders,
-                                              requestMethod, responseLBS, remoteHost,
-                                              isSecure, vault, httpVersion, Response,
-                                              Request)
-import           Servant.API                 ((:<|>) (..), (:>), Capture,
-                                              Delete, Get, Header,
-                                              IsSecure(..), MatrixFlag, MatrixParam,
-                                              MatrixParams, Patch, Post, Put,
-                                              QueryFlag, QueryParam, QueryParams,
-                                              Raw, RemoteHost, ReqBody, Vault)
+import           Network.Wai                 (Application, Request, Response,
+                                              ResponseReceived, lazyRequestBody,
+                                              pathInfo, rawQueryString,
+                                              requestBody, requestHeaders,
+                                              requestMethod, responseLBS,
+                                              strictRequestBody)
+import           Servant.API                 ((:<|>) (..), (:>), BasicAuth, Capture,
+                                               Delete, Get, Header,
+                                              MatrixFlag, MatrixParam, MatrixParams,
+                                              Patch, Post, Put, QueryFlag,
+                                              QueryParam, QueryParams, Raw,
+                                              ReqBody)
 import           Servant.API.ContentTypes    (AcceptHeader (..),
                                               AllCTRender (..),
                                               AllCTUnrender (..))
@@ -66,6 +70,11 @@ class HasServer layout where
   route :: Proxy layout -> IO (RouteResult (Server layout)) -> Router
 
 type Server layout = ServerT layout (ExceptT ServantErr IO)
+
+-- | A type-indexed class to encapsulate Basic authentication handling.
+-- Authentication handling is indexed by the lookup type.
+class BasicAuthLookup lookup a | lookup -> a where
+    basicAuthLookup :: Proxy lookup -> B.ByteString -> B.ByteString -> IO (Maybe a)
 
 -- * Instances
 
@@ -229,6 +238,42 @@ instance
   type ServerT (Delete ctypes (Headers h v)) m = m (Headers h v)
 
   route Proxy = methodRouterHeaders methodDelete (Proxy :: Proxy ctypes) ok200
+
+-- | Authentication
+instance
+#if MIN_VERSION_base(4,8,0)
+         {-# OVERLAPPABLE #-}
+#endif
+         (HasServer sublayout, BasicAuthLookup lookup authVal) => HasServer (BasicAuth realm lookup authVal :> sublayout) where
+    type ServerT (BasicAuth realm lookup authVal :> sublayout) m = authVal -> ServerT sublayout m
+    route proxy action request response =
+        case lookup "Authorization" (requestHeaders request) of
+            Nothing     -> error "handle no authorization header" -- 401
+            Just authBs ->
+                -- ripped from: https://hackage.haskell.org/package/wai-extra-1.3.4.5/docs/src/Network-Wai-Middleware-HttpAuth.html#basicAuth
+                let (x,y) = B.break isSpace authBs in
+                    if B.map toLower x == "basic"
+                    then checkB64 (B.dropWhile isSpace y)
+                    else error "not basic authentication" -- 401
+      where
+        checkB64 encoded =
+            case B.uncons passwordWithColonAtHead of
+                Just (_, password) -> do
+                    -- let's check these credentials using the user-provided lookup method
+                    maybeAuthData <- basicAuthLookup (Proxy :: Proxy lookup) username password
+                    case maybeAuthData of
+                        Nothing         -> error "bad password" -- 403
+                        (Just authData) ->
+                            route (Proxy :: Proxy sublayout) (action authData) request response
+
+                -- no username:password present
+                Nothing            -> error "No password" -- 403
+          where
+            raw = decodeLenient encoded
+            -- split username and password at the colon ':' char.
+            (username, passwordWithColonAtHead) = B.breakByte _colon raw
+
+
 
 -- | When implementing the handler for a 'Get' endpoint,
 -- just like for 'Servant.API.Delete.Delete', 'Servant.API.Post.Post'

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Servant.Server.Internal.Authentication
+( AuthProtected (..)
+, AuthData (..)
+, AuthHandlers (..)
+, basicAuthLax
+, basicAuthStrict
+, laxProtect
+, strictProtect
+        ) where
+
+import           Control.Monad              (guard)
+import qualified Data.ByteString            as B
+import           Data.ByteString.Base64     (decodeLenient)
+import           Data.Monoid                ((<>))
+import           Data.Proxy                 (Proxy (Proxy))
+import           Data.String                (fromString)
+import           Data.Word8                 (isSpace, toLower, _colon)
+import           GHC.TypeLits               (KnownSymbol, symbolVal)
+import           Network.HTTP.Types.Status  (status401)
+import           Network.Wai                (Request, Response, requestHeaders,
+                                             responseBuilder)
+import           Servant.API.Authentication (AuthPolicy (Strict, Lax),
+                                             AuthProtected,
+                                             BasicAuth (BasicAuth))
+
+-- | Class to represent the ability to extract authentication-related
+-- data from a 'Request' object.
+class AuthData a where
+    authData :: Request -> Maybe a
+
+-- | handlers to deal with authentication failures.
+data AuthHandlers authData = AuthHandlers
+    {   -- we couldn't find the right type of auth data (or any, for that matter)
+        onMissingauthData :: IO Response
+    ,
+        -- we found the right type of auth data in the request but the check failed
+        onUnauthenticated :: authData -> IO Response
+    }
+
+-- | concrete type to provide when in 'Strict' mode.
+data instance AuthProtected authData usr subserver 'Strict =
+    AuthProtectedStrict { checkAuthStrict :: authData -> IO (Maybe usr)
+                        , subServerStrict :: subserver
+                        , authHandlers :: AuthHandlers authData
+                        }
+
+-- | concrete type to provide when in 'Lax' mode.
+data instance AuthProtected authData usr subserver 'Lax =
+    AuthProtectedLax { checkAuthLax :: authData -> IO (Maybe usr)
+                     , subServerLax :: subserver
+                     }
+
+-- | handy function to build an auth-protected bit of API with a Lax policy
+laxProtect :: (authData -> IO (Maybe usr)) -- ^ check auth
+           -> subserver                    -- ^ the handlers for the auth-aware bits of the API
+           -> AuthProtected authData usr subserver 'Lax
+laxProtect = AuthProtectedLax
+
+-- | handy function to build an auth-protected bit of API with a Strict policy
+strictProtect :: (authData -> IO (Maybe usr)) -- ^ check auth
+              -> subserver                    -- ^ handlers for the auth-protected bits of the API
+              -> AuthHandlers authData        -- ^ functions to call on auth failure
+              -> AuthProtected authData usr subserver 'Strict
+strictProtect = AuthProtectedStrict
+
+-- | 'BasicAuth' instance for authData
+instance AuthData (BasicAuth realm) where
+    authData request = do
+        authBs <- lookup "Authorization" (requestHeaders request)
+        let (x,y) = B.break isSpace authBs
+        guard (B.map toLower x == "basic")
+        -- decode the base64-encoded username and password
+        let (username, passWithColonAtHead) = B.break (== _colon) (decodeLenient (B.dropWhile isSpace y))
+        (_, password) <- B.uncons passWithColonAtHead
+        return $ BasicAuth username password
+
+-- | handlers for Basic Authentication.
+basicAuthHandlers :: forall realm. KnownSymbol realm => AuthHandlers (BasicAuth realm)
+basicAuthHandlers =
+    let realmBytes = (fromString . symbolVal) (Proxy :: Proxy realm)
+        headerBytes = "Basic realm=\"" <> realmBytes <> "\""
+        authFailure = responseBuilder status401 [("WWW-Authenticate", headerBytes)] mempty in
+        AuthHandlers (return authFailure)  ((const . return) authFailure)
+
+-- | Basic authentication combinator with strict failure.
+basicAuthStrict :: KnownSymbol realm
+                => (BasicAuth realm -> IO (Maybe usr))
+                -> subserver
+                -> AuthProtected (BasicAuth realm) usr subserver 'Strict
+basicAuthStrict check subserver = strictProtect check subserver basicAuthHandlers
+
+-- | Basic authentication combinator with lax failure.
+basicAuthLax :: KnownSymbol realm
+             => (BasicAuth realm -> IO (Maybe usr))
+             -> subserver
+             -> AuthProtected (BasicAuth realm) usr subserver 'Lax
+basicAuthLax = laxProtect

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -45,8 +45,8 @@ data AuthHandlers authData = AuthHandlers
 -- | concrete type to provide when in 'Strict' mode.
 data instance AuthProtected authData usr subserver 'Strict =
     AuthProtectedStrict { checkAuthStrict :: authData -> IO (Maybe usr)
-                        , subServerStrict :: subserver
                         , authHandlers :: AuthHandlers authData
+                        , subServerStrict :: subserver
                         }
 
 -- | concrete type to provide when in 'Lax' mode.
@@ -63,8 +63,8 @@ laxProtect = AuthProtectedLax
 
 -- | handy function to build an auth-protected bit of API with a Strict policy
 strictProtect :: (authData -> IO (Maybe usr)) -- ^ check auth
-              -> subserver                    -- ^ handlers for the auth-protected bits of the API
               -> AuthHandlers authData        -- ^ functions to call on auth failure
+              -> subserver                    -- ^ handlers for the auth-protected bits of the API
               -> AuthProtected authData usr subserver 'Strict
 strictProtect = AuthProtectedStrict
 
@@ -92,7 +92,7 @@ basicAuthStrict :: KnownSymbol realm
                 => (BasicAuth realm -> IO (Maybe usr))
                 -> subserver
                 -> AuthProtected (BasicAuth realm) usr subserver 'Strict
-basicAuthStrict check subserver = strictProtect check subserver basicAuthHandlers
+basicAuthStrict check subserver = strictProtect check basicAuthHandlers subserver
 
 -- | Basic authentication combinator with lax failure.
 basicAuthLax :: KnownSymbol realm

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -6,7 +6,7 @@
 module Servant.Server.Internal.Authentication
 ( AuthProtected (..)
 , AuthData (..)
-, AuthHandlers (..)
+, AuthHandlers (AuthHandlers, onMissingAuthData, onUnauthenticated)
 , basicAuthLax
 , basicAuthStrict
 , laxProtect
@@ -36,7 +36,7 @@ class AuthData a where
 -- | handlers to deal with authentication failures.
 data AuthHandlers authData = AuthHandlers
     {   -- we couldn't find the right type of auth data (or any, for that matter)
-        onMissingauthData :: IO Response
+        onMissingAuthData :: IO Response
     ,
         -- we found the right type of auth data in the request but the check failed
         onUnauthenticated :: authData -> IO Response

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,7 +17,11 @@ module Servant.Server.Internal.Authentication
 import           Control.Monad              (guard)
 import qualified Data.ByteString            as B
 import           Data.ByteString.Base64     (decodeLenient)
+#if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid                ((<>), mempty)
+#else
+import           Data.Monoid                ((<>))
+#endif
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.String                (fromString)
 import           Data.Word8                 (isSpace, toLower, _colon)

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -60,13 +60,13 @@ data instance AuthProtected authData usr subserver 'Lax =
                      , subServerLax :: subserver
                      }
 
--- | handy function to build an auth-protected bit of API with a Lax policy
+-- | handy function to build an auth-protected bit of API with a 'Lax' policy
 laxProtect :: (authData -> IO (Maybe usr)) -- ^ check auth
            -> subserver                    -- ^ the handlers for the auth-aware bits of the API
            -> AuthProtected authData usr subserver 'Lax
 laxProtect = AuthProtectedLax
 
--- | handy function to build an auth-protected bit of API with a Strict policy
+-- | handy function to build an auth-protected bit of API with a 'Strict' policy
 strictProtect :: (authData -> IO (Maybe usr)) -- ^ check auth
               -> AuthHandlers authData        -- ^ functions to call on auth failure
               -> subserver                    -- ^ handlers for the auth-protected bits of the API

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -16,7 +16,7 @@ module Servant.Server.Internal.Authentication
 import           Control.Monad              (guard)
 import qualified Data.ByteString            as B
 import           Data.ByteString.Base64     (decodeLenient)
-import           Data.Monoid                ((<>))
+import           Data.Monoid                ((<>), mempty)
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.String                (fromString)
 import           Data.Word8                 (isSpace, toLower, _colon)

--- a/servant-server/src/Servant/Server/Internal/Authentication.hs
+++ b/servant-server/src/Servant/Server/Internal/Authentication.hs
@@ -13,6 +13,8 @@ module Servant.Server.Internal.Authentication
 , basicAuthStrict
 , laxProtect
 , strictProtect
+, jwtAuthHandlers
+, jwtAuth
         ) where
 
 import           Control.Monad              (guard, (<=<))
@@ -133,5 +135,5 @@ jwtAuthHandlers =
 -- One can use  strictProtect and laxProtect to make more complex authentication
 -- and authorization schemes.  For an example of that, see our tutorial: @placeholder@
 jwtAuth :: Secret -> subserver -> AuthProtected (JWT UnverifiedJWT) (JWT VerifiedJWT) subserver 'Strict
-jwtAuth  secret subserver = strictProtect (return . JWT.verify secret) jwtAuthHandlers subserver
+jwtAuth secret subserver = strictProtect (return . JWT.verify secret) jwtAuthHandlers subserver
 

--- a/servant-server/src/Servant/Server/Internal/Enter.hs
+++ b/servant-server/src/Servant/Server/Internal/Enter.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                    #-}
+{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE DeriveDataTypeable     #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -13,7 +14,7 @@ module Servant.Server.Internal.Enter where
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
-import qualified Control.Category            as C
+import qualified Control.Category                       as C
 #if MIN_VERSION_mtl(2,2,1)
 import           Control.Monad.Except
 #endif
@@ -24,8 +25,15 @@ import qualified Control.Monad.State.Lazy    as LState
 import qualified Control.Monad.State.Strict  as SState
 import qualified Control.Monad.Writer.Lazy   as LWriter
 import qualified Control.Monad.Writer.Strict as SWriter
+import qualified Control.Monad.State.Lazy               as LState
+import qualified Control.Monad.State.Strict             as SState
+import qualified Control.Monad.Writer.Lazy              as LWriter
+import qualified Control.Monad.Writer.Strict            as SWriter
 import           Data.Typeable
 import           Servant.API
+
+import           Servant.API.Authentication
+import           Servant.Server.Internal.Authentication (AuthProtected (AuthProtectedStrict, AuthProtectedLax))
 
 class Enter typ arg ret | typ arg -> ret, typ ret -> arg where
     enter :: arg -> typ -> ret
@@ -95,3 +103,12 @@ squashNat = Nat squash
 -- | Like @mmorph@'s `generalize`.
 generalizeNat :: Applicative m => Identity :~> m
 generalizeNat = Nat (pure . runIdentity)
+
+-- | 'Enter' instance for AuthProtectedStrict
+instance Enter subserver arg ret => Enter (AuthProtected authData usr subserver 'Strict) arg (AuthProtected authData usr ret 'Strict) where
+    enter arg (AuthProtectedStrict check subserver handlers) = AuthProtectedStrict check (enter arg subserver) handlers
+
+
+-- | 'Enter' instance for AuthProtectedLax
+instance Enter subserver arg ret => Enter (AuthProtected authData usr subserver 'Lax) arg (AuthProtected authData usr ret 'Lax) where
+    enter arg (AuthProtectedLax check subserver) = AuthProtectedLax check (enter arg subserver)

--- a/servant-server/src/Servant/Server/Internal/Enter.hs
+++ b/servant-server/src/Servant/Server/Internal/Enter.hs
@@ -106,7 +106,7 @@ generalizeNat = Nat (pure . runIdentity)
 
 -- | 'Enter' instance for AuthProtectedStrict
 instance Enter subserver arg ret => Enter (AuthProtected authData usr subserver 'Strict) arg (AuthProtected authData usr ret 'Strict) where
-    enter arg (AuthProtectedStrict check subserver handlers) = AuthProtectedStrict check (enter arg subserver) handlers
+    enter arg (AuthProtectedStrict check handlers subserver) = AuthProtectedStrict check handlers (enter arg subserver)
 
 
 -- | 'Enter' instance for AuthProtectedLax

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -54,9 +54,6 @@ data RouteMismatch =
   | HttpError Status [Header] (Maybe BL.ByteString)  -- ^ an even even more informative arbitrary HTTP response code error.
   | RouteMismatch Response -- ^ an arbitrary mismatch with custom Response.
 
-instance Show RouteMismatch where
-    show = const "hello"
-
 -- | specialized 'Less Than' for use with Monoid RouteMismatch
 (<=:) :: RouteMismatch -> RouteMismatch -> Bool
 {-# INLINE (<=:) #-}

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -31,7 +31,7 @@ type RoutingApplication =
 -- | A wrapper around @'Either' 'RouteMismatch' a@.
 newtype RouteResult a =
   RR { routeResult :: Either RouteMismatch a }
-  deriving (Show, Functor, Applicative, Monad)
+  deriving (Functor, Applicative, Monad)
 
 -- | If we get a `Right`, it has precedence over everything else.
 --

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -16,7 +16,7 @@ import           Data.IORef                         (newIORef, readIORef,
 import           Data.Maybe                         (fromMaybe)
 import           Data.Monoid                        ((<>))
 import           Data.String                        (fromString)
-import           Network.HTTP.Types                 hiding (Header, ResponseHeaders)
+import           Network.HTTP.Types                 hiding (ResponseHeaders)
 import           Network.Wai                        (Application, Request,
                                                      Response, ResponseReceived,
                                                      requestBody, responseLBS,

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -778,7 +778,6 @@ authRequiredApi = Proxy
 authRequiredServer :: Server AuthRequiredAPI
 authRequiredServer = basicAuthStrict basicAuthFooCheck (const . return $ alice)
                 :<|> basicAuthStrict basicAuthBarCheck (const . return $ jerry)
--- authRequiredServer =  const (return alice) :<|> const (return jerry)
 
 -- base64-encoded "servant:server"
 base64ServantColonServer :: ByteString

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -16,7 +17,11 @@ import           Data.Aeson                 (FromJSON, ToJSON, decode', encode)
 import           Data.ByteString            (ByteString)
 import           Data.ByteString.Conversion ()
 import           Data.Char                  (toUpper)
+#if !MIN_VERSION_base(4,8,0)
+import           Data.Monoid                ((<>), mempty)
+#else
 import           Data.Monoid                ((<>))
+#endif
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.String                (fromString)
 import           Data.String.Conversions    (cs)

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -659,7 +659,7 @@ prioErrorsSpec = describe "PrioErrors" $ do
 -- | Test server error functionality.
 errorsSpec :: Spec
 errorsSpec = do
-  let he = HttpError status409 (Just "A custom error")
+  let he = HttpError status409 [] (Just "A custom error")
   let ib = InvalidBody "The body is invalid"
   let wm = WrongMethod
   let nf = NotFound
@@ -789,4 +789,4 @@ authRequiredSpec = do
                 foo401 <- get "/foo"
                 bar401 <- get "/bar"
                 WaiSession (assertHeader "WWW-Authenticate" "Basic realm=\"foo-realm\"" foo401)
-                WaiSession (assertHeader "WWW-Authenticate" "Basic realm=\"foo-realm\"" bar401)
+                WaiSession (assertHeader "WWW-Authenticate" "Basic realm=\"bar-realm\"" bar401)

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -4,6 +4,12 @@ HEAD
 * Add `HttpVersion`, `IsSecure`, `RemoteHost` and `Vault` combinators
 * Fix safeLink, so Header is not in fact required.
 * Added more instances for (:<|>)
+* Add combinators for the new authentication framework:
+  * `AuthPolicy` universe to parameterize authentication policy strictness.
+  * `AuthProtect` combinator used to protect sets of endpoints
+  * `AuthProtected` data family that users will provide at the server/client-level.
+  * `BasicAuth` data type for `Basic` authentication.
+  * `JSON` data type for `JWT` authentication.
 
 0.4.2
 -----

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:
     Servant.API
     Servant.API.Alternative
+    Servant.API.Authentication
     Servant.API.Capture
     Servant.API.ContentTypes
     Servant.API.Delete

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -5,6 +5,8 @@ module Servant.API (
   -- | Type-level combinator for expressing subrouting: @':>'@
   module Servant.API.Alternative,
   -- | Type-level combinator for alternative endpoints: @':<|>'@
+  module Servant.API.Authentication,
+  -- | Type-level combinator for endpoints requiring auth: @'BasicAuth'@
 
   -- * Accessing information from the request
   module Servant.API.Capture,
@@ -60,6 +62,7 @@ module Servant.API (
   ) where
 
 import           Servant.API.Alternative     ((:<|>) (..))
+import           Servant.API.Authentication  (BasicAuth)
 import           Servant.API.Capture         (Capture)
 import           Servant.API.ContentTypes    (Accept (..), FormUrlEncoded,
                                               FromFormUrlEncoded (..), JSON,

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -1,24 +1,31 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE KindSignatures     #-}
 {-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
-module Servant.API.Authentication (BasicAuth) where
+module Servant.API.Authentication where
 
-import           Data.Typeable (Typeable)
-import           GHC.TypeLits  (Symbol)
+import           Data.ByteString (ByteString)
+import           Data.Typeable   (Typeable)
+import           GHC.TypeLits    (Symbol)
+
+-- | we can be either Strict or Lax.
+-- Strict: all handlers under 'AuthProtect' take a 'usr' argument.
+--         when auth fails, we call user-supplied handlers to respond.
+-- Lax: all handlers under 'AuthProtect' take a 'Maybe usr' argument.
+--      when auth fails, we call the handlers with 'Nothing'.
+data AuthPolicy = Strict | Lax
+
+-- | the combinator to be used in API types
+data AuthProtect authdata usr (policy :: AuthPolicy)
+
+-- | what we'll ask user to provide at the server-level when we see a
+-- 'AuthProtect' combinator in an API type
+data family AuthProtected authdata usr subserver :: AuthPolicy -> *
 
 -- | Basic Authentication with respect to a specified @realm@ and a @lookup@
 -- type to encapsulate authentication logic.
---
--- Example:
--- >>> type MyApi = BasicAuth "book-realm" DB :> "books" :> Get '[JSON] [Book]
-data BasicAuth (realm :: Symbol) lookup
-    deriving (Typeable)
-
--- $setup
--- >>> import Servant.API
--- >>> import Data.Aeson
--- >>> import Data.Text
--- >>> data DB
--- >>> data Book
--- >>> instance ToJSON Book where { toJSON = undefined }
+data BasicAuth (realm :: Symbol) = BasicAuth { baUser :: ByteString
+                                             , baPass :: ByteString
+                                             } deriving (Eq, Show, Typeable)

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -12,7 +12,7 @@ import           GHC.TypeLits  (Symbol)
 --
 -- Example:
 -- >>> type MyApi = BasicAuth "book-realm" DB :> "books" :> Get '[JSON] [Book]
-data BasicAuth (realm :: Symbol) lookup
+data BasicAuth (realm :: Symbol) lookup a
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -12,7 +12,7 @@ import           GHC.TypeLits  (Symbol)
 --
 -- Example:
 -- >>> type MyApi = BasicAuth "book-realm" DB :> "books" :> Get '[JSON] [Book]
-data BasicAuth (realm :: Symbol) lookup a
+data BasicAuth (realm :: Symbol) lookup
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -11,8 +11,7 @@ import           GHC.TypeLits  (Symbol)
 -- type to encapsulate authentication logic.
 --
 -- Example:
--- >>> type AuthLookup = Text -> IO User
--- >>> type MyApi = BasicAuth "book-realm" :> "books" :> Get '[JSON] [Book]
+-- >>> type MyApi = BasicAuth "book-realm" DB :> "books" :> Get '[JSON] [Book]
 data BasicAuth (realm :: Symbol) lookup
     deriving (Typeable)
 
@@ -20,6 +19,6 @@ data BasicAuth (realm :: Symbol) lookup
 -- >>> import Servant.API
 -- >>> import Data.Aeson
 -- >>> import Data.Text
--- >>> data User
+-- >>> data DB
 -- >>> data Book
 -- >>> instance ToJSON Book where { toJSON = undefined }

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# OPTIONS_HADDOCK not-home    #-}
+module Servant.API.Authentication (BasicAuth) where
+
+import           Data.Typeable (Typeable)
+import           GHC.TypeLits  (Symbol)
+
+-- | Basic Authentication with respect to a specified @realm@ and a @lookup@
+-- type to encapsulate authentication logic.
+--
+-- Example:
+-- >>> type AuthLookup = Text -> IO User
+-- >>> type MyApi = BasicAuth "book-realm" :> "books" :> Get '[JSON] [Book]
+data BasicAuth (realm :: Symbol) lookup
+    deriving (Typeable)
+
+-- $setup
+-- >>> import Servant.API
+-- >>> import Data.Aeson
+-- >>> import Data.Text
+-- >>> data User
+-- >>> data Book
+-- >>> instance ToJSON Book where { toJSON = undefined }

--- a/servant/src/Servant/API/Authentication.hs
+++ b/servant/src/Servant/API/Authentication.hs
@@ -4,11 +4,19 @@
 {-# LANGUAGE PolyKinds          #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home    #-}
-module Servant.API.Authentication where
+module Servant.API.Authentication
+( AuthPolicy (..)
+, AuthProtect (..)
+, AuthProtected (..)
+, BasicAuth (..)
+, JWTAuth
+) where
+
 
 import           Data.ByteString (ByteString)
 import           Data.Typeable   (Typeable)
 import           GHC.TypeLits    (Symbol)
+import           Data.Text       (Text)
 
 -- | we can be either Strict or Lax.
 -- Strict: all handlers under 'AuthProtect' take a 'usr' argument.
@@ -29,3 +37,5 @@ data family AuthProtected authdata usr subserver :: AuthPolicy -> *
 data BasicAuth (realm :: Symbol) = BasicAuth { baUser :: ByteString
                                              , baPass :: ByteString
                                              } deriving (Eq, Show, Typeable)
+
+type JWTAuth = Text


### PR DESCRIPTION
This is based off of aaronlevin's pull request. It adds (minimal) support for  Digest authentication.

Any comments are welcome. I still need to write tests and `HasClient` instances. But I'm awaiting aaronlevin's  `HasClient` impl for `BasicAuth` to see how to do that.