### PR TITLE
make travis builds use stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,27 @@
-language: haskell
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libgmp-dev
 
 env:
-  - CABALVER=1.18 GHCVER=7.8.4
-  - CABALVER=1.22 GHCVER=7.10.1
-
-before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- - travis_retry cabal update
+  - STACK_YAML=stack-ghc-7.8.4.yaml
+  - STACK_YAML=stack.yaml
 
 install:
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - cabal --version
+  # stack
+  - mkdir -p ~/.local/bin
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar -xvzf -
+  - mv stack ~/.local/bin
+  - export PATH=~/.local/bin:$PATH
+  - stack --version
 
 script:
-  - ./scripts/test-all.sh
+  - stack setup
+  - stack build
+  - stack test
 
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#servant"
-    template:
-      - "%{repository}#%{build_number} - %{commit} on %{branch} by %{author}: %{message}"
-      - "Build details: %{build_url} - Change view: %{compare_url}"
-    skip_join: true
-    on_success: change
-    on_failure: always
+cache:
+  directories:
+    - $HOME/.stack

--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -30,7 +30,7 @@ library
     servant >= 0.4,
     servant-server >= 0.4,
     transformers >= 0.3 && <0.5,
-    QuickCheck >= 2.8 && <2.9,
+    QuickCheck >= 2.7 && <2.9,
     wai >= 3.0 && <3.1
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/stack-ghc-7.8.4.yaml
+++ b/stack-ghc-7.8.4.yaml
@@ -1,0 +1,22 @@
+flags: {}
+packages:
+- servant-examples/
+- servant-docs/
+- servant-blaze/
+- servant-client/
+- servant-lucid/
+- servant-mock/
+- servant-js/
+- servant/
+- servant-server/
+extra-deps:
+- hspec-2.2.0
+- hspec-core-2.2.0
+- hspec-discover-2.2.0
+- hspec-expectations-0.7.2
+- doctest-0.10.1
+- engine-io-1.2.10
+- engine-io-wai-1.0.3
+- socket-io-1.3.3
+- stm-delay-0.1.1.1
+resolver: lts-2.22

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,5 +13,4 @@ packages:
 - servant-server/
 extra-deps:
 - engine-io-wai-1.0.2
-- attoparsec-0.13.0.1
-resolver: nightly-2015-07-24
+resolver: nightly-2015-09-05


### PR DESCRIPTION
This PR switches our travis builds to stack. Build times of this branch are about 4 minutes.

The one caveat (that has been discussed before) of this switch is that we don't test for hackage breakage through travis anymore. I talked about this with @jkarni and we thought it would be best to set up a separate CI (not through travis) for this. He's working on that.

cc: @alpmestan