### PR TITLE
Fix error priority and retries

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -496,19 +496,6 @@ sampleByteStrings ctypes@Proxy Proxy =
         enc (t, s) = uncurry (t,,) <$> allMimeRender ctypes s
     in concatMap enc samples'
 
--- | Generate a list of 'MediaType' values describing the content types
--- accepted by an API component.
-class SupportedTypes (list :: [*]) where
-    supportedTypes :: Proxy list -> [M.MediaType]
-
-instance SupportedTypes '[] where
-    supportedTypes Proxy = []
-
-instance (Accept ctype, SupportedTypes rest) => SupportedTypes (ctype ': rest)
-  where
-    supportedTypes Proxy =
-        contentType (Proxy :: Proxy ctype) : supportedTypes (Proxy :: Proxy rest)
-
 -- | The class that helps us automatically get documentation
 --   for GET parameters.
 --
@@ -709,14 +696,14 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLe #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts)
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a)
     => HasDocs (Delete cts a) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
     single endpoint' action'
 
     where endpoint' = endpoint & method .~ DocDELETE
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
 
@@ -724,7 +711,7 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPING #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a
          , AllHeaderSamples ls , GetHeaders (HList ls) )
     => HasDocs (Delete cts (Headers ls a)) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
@@ -733,7 +720,7 @@ instance
     where hdrs = allHeaderToSample (Proxy :: Proxy ls)
           endpoint' = endpoint & method .~ DocDELETE
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respHeaders .~ hdrs
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
@@ -742,14 +729,14 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLe #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts)
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a)
     => HasDocs (Get cts a) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
     single endpoint' action'
 
     where endpoint' = endpoint & method .~ DocGET
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
 
@@ -757,7 +744,7 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPING #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a
          , AllHeaderSamples ls , GetHeaders (HList ls) )
     => HasDocs (Get cts (Headers ls a)) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
@@ -766,7 +753,7 @@ instance
     where hdrs = allHeaderToSample (Proxy :: Proxy ls)
           endpoint' = endpoint & method .~ DocGET
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respHeaders .~ hdrs
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
@@ -784,14 +771,14 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLE #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts)
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a)
     => HasDocs (Post cts a) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
     single endpoint' action'
 
     where endpoint' = endpoint & method .~ DocPOST
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respStatus .~ 201
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
@@ -800,7 +787,7 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPING #-}
 #endif
-         (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts
+         (ToSample a, IsNonEmpty cts, AllMimeRender cts a
          , AllHeaderSamples ls , GetHeaders (HList ls) )
     => HasDocs (Post cts (Headers ls a)) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
@@ -809,7 +796,7 @@ instance
     where hdrs = allHeaderToSample (Proxy :: Proxy ls)
           endpoint' = endpoint & method .~ DocPOST
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respStatus .~ 201
                            & response.respHeaders .~ hdrs
           t = Proxy :: Proxy cts
@@ -819,14 +806,14 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPABLE #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts)
+        (ToSample a, IsNonEmpty cts, AllMimeRender cts a)
     => HasDocs (Put cts a) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
     single endpoint' action'
 
     where endpoint' = endpoint & method .~ DocPUT
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respStatus .~ 200
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
@@ -835,8 +822,8 @@ instance
 #if MIN_VERSION_base(4,8,0)
          {-# OVERLAPPING #-}
 #endif
-        (ToSample a, IsNonEmpty cts, AllMimeRender cts a, SupportedTypes cts
-         , AllHeaderSamples ls , GetHeaders (HList ls) )
+        ( ToSample a, IsNonEmpty cts, AllMimeRender cts a,
+          AllHeaderSamples ls , GetHeaders (HList ls) )
     => HasDocs (Put cts (Headers ls a)) where
   docsFor Proxy (endpoint, action) DocOptions{..} =
     single endpoint' action'
@@ -844,7 +831,7 @@ instance
     where hdrs = allHeaderToSample (Proxy :: Proxy ls)
           endpoint' = endpoint & method .~ DocPUT
           action' = action & response.respBody .~ take _maxSamples (sampleByteStrings t p)
-                           & response.respTypes .~ supportedTypes t
+                           & response.respTypes .~ allMime t
                            & response.respStatus .~ 200
                            & response.respHeaders .~ hdrs
           t = Proxy :: Proxy cts
@@ -890,8 +877,7 @@ instance HasDocs Raw where
 -- example data. However, there's no reason to believe that the instances of
 -- 'AllMimeUnrender' and 'AllMimeRender' actually agree (or to suppose that
 -- both are even defined) for any particular type.
-instance (ToSample a, IsNonEmpty cts, AllMimeRender cts a, HasDocs sublayout
-         , SupportedTypes cts)
+instance (ToSample a, IsNonEmpty cts, AllMimeRender cts a, HasDocs sublayout)
       => HasDocs (ReqBody cts a :> sublayout) where
 
   docsFor Proxy (endpoint, action) =
@@ -899,7 +885,7 @@ instance (ToSample a, IsNonEmpty cts, AllMimeRender cts a, HasDocs sublayout
 
     where sublayoutP = Proxy :: Proxy sublayout
           action' = action & rqbody .~ sampleByteString t p
-                           & rqtypes .~ supportedTypes t
+                           & rqtypes .~ allMime t
           t = Proxy :: Proxy cts
           p = Proxy :: Proxy a
 
@@ -957,4 +943,3 @@ instance ToSample a => ToSample (Product a)
 instance ToSample a => ToSample (First a)
 instance ToSample a => ToSample (Last a)
 instance ToSample a => ToSample (Dual a)
-

--- a/servant-examples/auth-combinator/auth-combinator.hs
+++ b/servant-examples/auth-combinator/auth-combinator.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+
 import           Data.Aeson
 import           Data.ByteString          (ByteString)
 import           Data.Text                (Text)
@@ -31,12 +32,12 @@ instance HasServer rest => HasServer (AuthProtected :> rest) where
   route Proxy a = WithRequest $ \ request ->
     route (Proxy :: Proxy rest) $ do
       case lookup "Cookie" (requestHeaders request) of
-        Nothing -> return $ failWith $ HttpError status401 (Just "Missing auth header.")
+        Nothing -> return $! failFatallyWith err401 { errBody = "Missing auth header" }
         Just v  -> do
           authGranted <- isGoodCookie v
           if authGranted
             then a
-            else return $ failWith $ HttpError status403 (Just "Invalid cookie.")
+            else return $! failFatallyWith err403 { errBody = "Invalid cookie" }
 
 type PrivateAPI = Get '[JSON] [PrivateData]
 

--- a/servant-examples/auth-combinator/auth-combinator.hs
+++ b/servant-examples/auth-combinator/auth-combinator.hs
@@ -32,12 +32,12 @@ instance HasServer rest => HasServer (AuthProtected :> rest) where
   route Proxy a = WithRequest $ \ request ->
     route (Proxy :: Proxy rest) $ do
       case lookup "Cookie" (requestHeaders request) of
-        Nothing -> return $! failFatallyWith err401 { errBody = "Missing auth header" }
+        Nothing -> return $! FailFatal err401 { errBody = "Missing auth header" }
         Just v  -> do
           authGranted <- isGoodCookie v
           if authGranted
             then a
-            else return $! failFatallyWith err403 { errBody = "Invalid cookie" }
+            else return $ FailFatal err403 { errBody = "Invalid cookie" }
 
 type PrivateAPI = Get '[JSON] [PrivateData]
 

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -7,9 +7,7 @@ HEAD
 * Remove matrix params.
 * Remove `RouteMismatch`.
 * Redefined constructors of `RouteResult`.
-* Add `failFatallyWith`.
-* Make all (framework-generated) HTTP errors except 404 and 405 not try other
-  handlers.
+* Added `Delayed` and related functions (`addMethodCheck`, `addAcceptCheck`, `addBodyCheck`, `runDelayed`)
 
 0.4.1
 -----

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -5,6 +5,11 @@ HEAD
 * Drop `EitherT` in favor of `ExceptT`
 * Use `http-api-data` instead of `Servant.Common.Text`
 * Remove matrix params.
+* Remove `RouteMismatch`.
+* Redefined constructors of `RouteResult`.
+* Add `failFatallyWith`.
+* Make all (framework-generated) HTTP errors except 404 and 405 not try other
+  handlers.
 
 0.4.1
 -----

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -108,6 +108,7 @@ test-suite spec
     , network >= 2.6
     , QuickCheck
     , parsec
+    , safe
     , servant
     , servant-server
     , string-conversions

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -95,6 +95,7 @@ test-suite spec
       Servant.Server.Internal.EnterSpec
       Servant.ServerSpec
       Servant.Utils.StaticFilesSpec
+      Servant.Server.ErrorSpec
   build-depends:
       base == 4.*
     , aeson

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -103,7 +103,7 @@ import           Servant.Server.Internal.Enter
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
 serve :: HasServer layout => Proxy layout -> Server layout -> Application
-serve p server = toApplication (runRouter (route p (return (HandlerVal server))))
+serve p server = toApplication (runRouter (route p (return (Route server))))
 
 
 -- Documentation

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -103,7 +103,10 @@ import           Servant.Server.Internal.Enter
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
 serve :: HasServer layout => Proxy layout -> Server layout -> Application
-serve p server = toApplication (runRouter (route p (return (Route server))))
+serve p server = toApplication (runRouter (route p d))
+  where
+    d = Delayed r r r (\ _ _ -> Route server)
+    r = return (Route ())
 
 
 -- Documentation

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -103,7 +103,7 @@ import           Servant.Server.Internal.Enter
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
 serve :: HasServer layout => Proxy layout -> Server layout -> Application
-serve p server = toApplication (runRouter (route p (return (RR (Right server)))))
+serve p server = toApplication (runRouter (route p (return (HandlerVal server))))
 
 
 -- Documentation

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 #if !MIN_VERSION_base(4,8,0)
-{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE OverlappingInstances       #-}
 #endif
 
 module Servant.Server.Internal
@@ -26,9 +26,9 @@ import           Control.Monad.Trans.Except  (ExceptT)
 import qualified Data.ByteString             as B
 import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Map                    as M
-import           Data.Maybe                  (mapMaybe, fromMaybe)
+import           Data.Maybe                  (fromMaybe, mapMaybe)
 import           Data.String                 (fromString)
-import           Data.String.Conversions     (cs, (<>), ConvertibleStrings)
+import           Data.String.Conversions     (ConvertibleStrings, cs, (<>))
 import           Data.Text                   (Text)
 import           Data.Typeable
 import           GHC.TypeLits                (KnownSymbol, symbolVal)
@@ -47,8 +47,8 @@ import           Servant.API                 ((:<|>) (..), (:>), Capture,
 import           Servant.API.ContentTypes    (AcceptHeader (..),
                                               AllCTRender (..),
                                               AllCTUnrender (..))
-import           Servant.API.ResponseHeaders (Headers, getResponse, GetHeaders,
-                                              getHeaders)
+import           Servant.API.ResponseHeaders (GetHeaders, Headers, getHeaders,
+                                              getResponse)
 
 import           Servant.Server.Internal.Router
 import           Servant.Server.Internal.RoutingApplication
@@ -114,7 +114,7 @@ instance (KnownSymbol capture, FromHttpApiData a, HasServer sublayout)
 
   route Proxy subserver =
     DynamicRouter $ \ first -> case captured captureProxy first of
-       Nothing  -> LeafRouter (\_ r -> r $ failWith err404)
+       Nothing  -> LeafRouter (\_ r -> r $ Fail err404)
        Just v   -> route (Proxy :: Proxy sublayout) (feedTo subserver v)
 
     where captureProxy = Proxy :: Proxy (Capture capture a)
@@ -130,8 +130,8 @@ processMethodRouter :: forall a. ConvertibleStrings a B.ByteString
                     -> Maybe [(HeaderName, B.ByteString)]
                     -> Request -> RouteResult Response
 processMethodRouter handleA status method headers request = case handleA of
-  Nothing -> failFatallyWith err406
-  Just (contentT, body) -> succeedWith $ responseLBS status hdrs bdy
+  Nothing -> FailFatal err406
+  Just (contentT, body) -> Route $! responseLBS status hdrs bdy
     where
       bdy = if allowedMethodHead method request then "" else body
       hdrs = (hContentType, cs contentT) : (fromMaybe [] headers)
@@ -149,8 +149,8 @@ methodRouter method proxy status action = LeafRouter route'
                 handleA = handleAcceptH proxy (AcceptHeader accH) output
             processMethodRouter handleA status method Nothing request
       | pathIsEmpty request && requestMethod request /= method =
-          respond $ failWith err405
-      | otherwise = respond $ failWith err404
+          respond $ Fail err405
+      | otherwise = respond $ Fail err404
 
 methodRouterHeaders :: (GetHeaders (Headers h v), AllCTRender ctypes v)
                     => Method -> Proxy ctypes -> Status
@@ -166,8 +166,8 @@ methodRouterHeaders method proxy status action = LeafRouter route'
               handleA = handleAcceptH proxy (AcceptHeader accH) (getResponse output)
           processMethodRouter handleA status method (Just headers) request
       | pathIsEmpty request && requestMethod request /= method =
-          respond $ failWith err405
-      | otherwise = respond $ failWith err404
+          respond $ Fail err405
+      | otherwise = respond $ Fail err404
 
 methodRouterEmpty :: Method
                   -> IO (RouteResult (ExceptT ServantErr IO ()))
@@ -177,10 +177,10 @@ methodRouterEmpty method action = LeafRouter route'
     route' request respond
       | pathIsEmpty request && allowedMethod method request = do
           runAction action respond $ \ () ->
-            succeedWith $ responseLBS noContent204 [] ""
+            Route $! responseLBS noContent204 [] ""
       | pathIsEmpty request && requestMethod request /= method =
-          respond $ failWith err405
-      | otherwise = respond $ failWith err404
+          respond $ Fail err405
+      | otherwise = respond $ Fail err404
 
 -- | If you have a 'Delete' endpoint in your API,
 -- the handler for this endpoint is meant to delete
@@ -557,9 +557,9 @@ instance HasServer Raw where
   route Proxy rawApplication = LeafRouter $ \ request respond -> do
     r <- rawApplication
     case r of
-      HandlerVal app  -> app request (respond . succeedWith)
-      Retriable  e    -> respond $ failWith e
-      NonRetriable e  -> respond $! failFatallyWith e
+      Route app   -> app request (respond . Route)
+      Fail a      -> respond $ Fail a
+      FailFatal e -> respond $ FailFatal e
 
 -- | If you use 'ReqBody' in one of the endpoints for your API,
 -- this automatically requires your server-side handler to be a function
@@ -599,8 +599,8 @@ instance ( AllCTUnrender list a, HasServer sublayout
       mrqbody <- handleCTypeH (Proxy :: Proxy list) (cs contentTypeH)
              <$> lazyRequestBody request
       case mrqbody of
-        Nothing -> return $! failFatallyWith err415
-        Just (Left e) -> return $! failFatallyWith err400 { errBody = cs e }
+        Nothing -> return $ FailFatal err415
+        Just (Left e) -> return $ FailFatal err400 { errBody = cs e }
         Just (Right v) -> feedTo subserver v
 
 -- | Make sure the incoming request starts with @"/path"@, strip it and

--- a/servant-server/src/Servant/Server/Internal/Router.hs
+++ b/servant-server/src/Servant/Server/Internal/Router.hs
@@ -6,7 +6,6 @@ import           Data.Map                                   (Map)
 import qualified Data.Map                                   as M
 import           Data.Text                                  (Text)
 import           Network.Wai                                (Request, Response, pathInfo)
-import           Servant.Server.Internal.PathInfo
 import           Servant.Server.Internal.RoutingApplication
 import           Servant.Server.Internal.ServantErr
 

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 module Servant.Server.Internal.RoutingApplication where
 
 #if !MIN_VERSION_base(4,8,0)
@@ -18,19 +21,18 @@ import           Network.Wai                        (Application, Request,
                                                      Response, ResponseReceived,
                                                      requestBody,
                                                      strictRequestBody)
-import           Servant.API                        ((:<|>) (..))
 import           Servant.Server.Internal.ServantErr
 
 type RoutingApplication =
      Request -- ^ the request, the field 'pathInfo' may be modified by url routing
   -> (RouteResult Response -> IO ResponseReceived) -> IO ResponseReceived
 
--- | A wrapper around @'Either' 'RouteMismatch' a@.
+-- | The result of matching against a path in the route tree.
 data RouteResult a =
     Fail ServantErr           -- ^ Keep trying other paths. The @ServantErr@
-                              -- should only be 404 or 405.
-  | FailFatal ServantErr      -- ^ Don't other paths.
-  | Route a
+                              -- should only be 404, 405 or 406.
+  | FailFatal !ServantErr     -- ^ Don't try other paths.
+  | Route !a
   deriving (Eq, Show, Read, Functor)
 
 data ReqBodyState = Uncalled
@@ -63,15 +65,183 @@ toApplication ra request respond = do
   ra request{ requestBody = memoReqBody } routingRespond
  where
   routingRespond :: RouteResult Response -> IO ResponseReceived
-  routingRespond (Fail err)    = respond $! responseServantErr err
-  routingRespond (FailFatal err) = respond $! responseServantErr err
-  routingRespond (Route v)     = respond v
+  routingRespond (Fail err)      = respond $ responseServantErr err
+  routingRespond (FailFatal err) = respond $ responseServantErr err
+  routingRespond (Route v)       = respond v
 
-runAction :: IO (RouteResult (ExceptT ServantErr IO a))
+-- TODO: The above may not be quite right yet.
+--
+-- We currently mix up the order in which we perform checks
+-- and the priority with which errors are reported.
+--
+-- For example, we perform Capture checks prior to method checks,
+-- and therefore get 404 before 405.
+--
+-- However, we also perform body checks prior to method checks
+-- now, and therefore get 415 before 405, which is wrong.
+--
+-- If we delay Captures, but perform method checks eagerly, we
+-- end up potentially preferring 405 over 404, whcih is also bad.
+--
+-- So in principle, we'd like:
+--
+-- static routes (can cause 404)
+-- delayed captures (can cause 404)
+-- methods (can cause 405)
+-- delayed body (can cause 415, 400)
+-- accept header (can cause 406)
+--
+-- According to the HTTP decision diagram, the priority order
+-- between HTTP status codes is as follows:
+--
+
+-- | A 'Delayed' is a representation of a handler with scheduled
+-- delayed checks that can trigger errors.
+--
+-- Why would we want to delay checks?
+--
+-- There are two reasons:
+--
+-- 1. Currently, the order in which we perform checks coincides
+-- with the error we will generate. This is because during checks,
+-- once an error occurs, we do not perform any subsequent checks,
+-- but rather return this error.
+--
+-- This is not a necessity: we could continue doing other checks,
+-- and choose the preferred error. However, that would in general
+-- mean more checking, which leads us to the other reason.
+--
+-- 2. We really want to avoid doing certain checks too early. For
+-- example, captures involve parsing, and are much more costly
+-- than static route matches. In particular, if several paths
+-- contain the "same" capture, we'd like as much as possible to
+-- avoid trying the same parse many times. Also tricky is the
+-- request body. Again, this involves parsing, but also, WAI makes
+-- obtaining the request body a side-effecting operation. We
+-- could/can work around this by manually caching the request body,
+-- but we'd rather keep the number of times we actually try to
+-- decode the request body to an absolute minimum.
+--
+-- We prefer to have the following relative priorities of error
+-- codes:
+--
+-- @
+-- 404
+-- 405 (bad method)
+-- 401 (unauthorized)
+-- 415 (unsupported media type)
+-- 400 (bad request)
+-- 406 (not acceptable)
+-- @
+--
+-- Therefore, while routing, we delay most checks so that they
+-- will ultimately occur in the right order.
+--
+-- A 'Delayed' contains three delayed blocks of tests, and
+-- the actual handler:
+--
+-- 1. Delayed captures. These can actually cause 404, and
+-- while they're costly, they should be done first among the
+-- delayed checks (at least as long as we do not decouple the
+-- check order from the error reporting, see above). Delayed
+-- captures can provide inputs to the actual handler.
+--
+-- 2. Method check(s). This can cause a 405. On success,
+-- it does not provide an input for the handler. Method checks
+-- are comparatively cheap.
+--
+-- 3. Body and accept header checks. The request body check can
+-- cause both 400 and 415. This provides an input to the handler.
+-- The accept header check can be performed as the final
+-- computation in this block. It can cause a 406.
+--
+data Delayed :: * -> * where
+  Delayed :: IO (RouteResult a)
+          -> IO (RouteResult ())
+          -> IO (RouteResult b)
+          -> (a -> b -> RouteResult c)
+          -> Delayed c
+
+deriving instance Functor Delayed
+
+-- | Add a capture to the end of the capture block.
+addCapture :: Delayed (a -> b)
+           -> IO (RouteResult a)
+           -> Delayed b
+addCapture (Delayed captures method body server) new =
+  Delayed (combineRouteResults (,) captures new) method body (\ (x, v) y -> ($ v) <$> server x y)
+
+-- | Add a method check to the end of the method block.
+addMethodCheck :: Delayed a
+               -> IO (RouteResult ())
+               -> Delayed a
+addMethodCheck (Delayed captures method body server) new =
+  Delayed captures (combineRouteResults const method new) body server
+
+-- | Add a body check to the end of the body block.
+addBodyCheck :: Delayed (a -> b)
+             -> IO (RouteResult a)
+             -> Delayed b
+addBodyCheck (Delayed captures method body server) new =
+  Delayed captures method (combineRouteResults (,) body new) (\ x (y, v) -> ($ v) <$> server x y)
+
+-- | Add an accept header check to the end of the body block.
+-- The accept header check should occur after the body check,
+-- but this will be the case, because the accept header check
+-- is only scheduled by the method combinators.
+addAcceptCheck :: Delayed a
+                -> IO (RouteResult ())
+                -> Delayed a
+addAcceptCheck (Delayed captures method body server) new =
+  Delayed captures method (combineRouteResults const body new) server
+
+-- | Many combinators extract information that is passed to
+-- the handler without the possibility of failure. In such a
+-- case, 'passToServer' can be used.
+passToServer :: Delayed (a -> b) -> a -> Delayed b
+passToServer d x = ($ x) <$> d
+
+-- | The combination 'IO . RouteResult' is a monad, but we
+-- don't explicitly wrap it in a newtype in order to make it
+-- an instance. This is the '>>=' of that monad.
+--
+-- We stop on the first error.
+bindRouteResults :: IO (RouteResult a) -> (a -> IO (RouteResult b)) -> IO (RouteResult b)
+bindRouteResults m f = do
+  r <- m
+  case r of
+    Fail      e -> return $ Fail e
+    FailFatal e -> return $ FailFatal e
+    Route     a -> f a
+
+-- | Common special case of 'bindRouteResults', corresponding
+-- to 'liftM2'.
+combineRouteResults :: (a -> b -> c) -> IO (RouteResult a) -> IO (RouteResult b) -> IO (RouteResult c)
+combineRouteResults f m1 m2 =
+  m1 `bindRouteResults` \ a ->
+  m2 `bindRouteResults` \ b ->
+  return (Route (f a b))
+
+-- | Run a delayed server. Performs all scheduled operations
+-- in order, and passes the results from the capture and body
+-- blocks on to the actual handler.
+runDelayed :: Delayed a
+           -> IO (RouteResult a)
+runDelayed (Delayed captures method body server) =
+  captures `bindRouteResults` \ c ->
+  method   `bindRouteResults` \ _ ->
+  body     `bindRouteResults` \ b ->
+  return (server c b)
+
+-- | Runs a delayed server and the resulting action.
+-- Takes a continuation that lets us send a response.
+-- Also takes a continuation for how to turn the
+-- result of the delayed server into a response.
+runAction :: Delayed (ExceptT ServantErr IO a)
           -> (RouteResult Response -> IO r)
           -> (a -> RouteResult Response)
           -> IO r
-runAction action respond k = action >>= go >>= respond
+runAction action respond k = runDelayed action >>= go >>= respond
   where
     go (Fail  e)   = return $ Fail e
     go (FailFatal e) = return $ FailFatal e
@@ -80,16 +250,3 @@ runAction action respond k = action >>= go >>= respond
       case e of
         Left err -> return . Route $ responseServantErr err
         Right x  -> return $! k x
-
-feedTo :: IO (RouteResult (a -> b)) -> a -> IO (RouteResult b)
-feedTo f x = (($ x) <$>) <$> f
-
-extractL :: RouteResult (a :<|> b) -> RouteResult a
-extractL (Route (a :<|> _)) = Route a
-extractL (Fail x)           = Fail x
-extractL (FailFatal x)      = FailFatal x
-
-extractR :: RouteResult (a :<|> b) -> RouteResult b
-extractR (Route (_ :<|> b)) = Route b
-extractR (Fail x)           = Fail x
-extractR (FailFatal x)      = FailFatal x

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeOperators              #-}
@@ -6,21 +7,17 @@ module Servant.Server.Internal.RoutingApplication where
 
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative                (Applicative, (<$>))
-import           Data.Monoid                        (Monoid, mappend, mempty)
+import           Data.Monoid                        (Monoid, mappend, mempty,
+                                                     (<>))
 #endif
 import           Control.Monad.Trans.Except         (ExceptT, runExceptT)
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Lazy               as BL
 import           Data.IORef                         (newIORef, readIORef,
                                                      writeIORef)
-import           Data.Maybe                         (fromMaybe)
-import           Data.Monoid                        ((<>))
-import           Data.String                        (fromString)
-import           Network.HTTP.Types                 hiding (Header,
-                                                     ResponseHeaders)
 import           Network.Wai                        (Application, Request,
                                                      Response, ResponseReceived,
-                                                     requestBody, responseLBS,
+                                                     requestBody,
                                                      strictRequestBody)
 import           Servant.API                        ((:<|>) (..))
 import           Servant.Server.Internal.ServantErr
@@ -30,39 +27,12 @@ type RoutingApplication =
   -> (RouteResult Response -> IO ResponseReceived) -> IO ResponseReceived
 
 -- | A wrapper around @'Either' 'RouteMismatch' a@.
-newtype RouteResult a =
-  RR { routeResult :: Either RouteMismatch a }
-  deriving (Eq, Show, Functor, Applicative)
-
--- | If we get a `Right`, it has precedence over everything else.
---
--- This in particular means that if we could get several 'Right's,
--- only the first we encounter would be taken into account.
-instance Monoid (RouteResult a) where
-  mempty = RR $ Left mempty
-
-  RR (Left x)  `mappend` RR (Left y)  = RR $ Left (x <> y)
-  RR (Left _)  `mappend` RR (Right y) = RR $ Right y
-  r            `mappend` _            = r
-
--- Note that the ordering of the constructors has great significance! It
--- determines the Ord instance and, consequently, the monoid instance.
-data RouteMismatch =
-    NotFound           -- ^ the usual "not found" error
-  | WrongMethod        -- ^ a more informative "you just got the HTTP method wrong" error
-  | UnsupportedMediaType -- ^ request body has unsupported media type
-  | InvalidBody String -- ^ an even more informative "your json request body wasn't valid" error
-  | HttpError Status (Maybe BL.ByteString)  -- ^ an even even more informative arbitrary HTTP response code error.
-  deriving (Eq, Ord, Show)
-
-instance Monoid RouteMismatch where
-  mempty = NotFound
-  -- The following isn't great, since it picks @InvalidBody@ based on
-  -- alphabetical ordering, but any choice would be arbitrary.
-  --
-  -- "As one judge said to the other, 'Be just and if you can't be just, be
-  -- arbitrary'" -- William Burroughs
-  mappend = max
+data RouteResult a =
+    Retriable ServantErr      -- ^ Keep trying other paths. The @ServantErr@
+                              -- should only be 404 or 405.
+  | NonRetriable ServantErr   -- ^ Stop trying.
+  | HandlerVal a
+  deriving (Eq, Show, Read, Functor)
 
 data ReqBodyState = Uncalled
                   | Called !B.ByteString
@@ -91,55 +61,52 @@ toApplication ra request respond = do
                 writeIORef reqBodyRef $ Called bs
                 return B.empty
 
-  ra request{ requestBody = memoReqBody } (routingRespond . routeResult)
+  ra request{ requestBody = memoReqBody } routingRespond
  where
-  routingRespond :: Either RouteMismatch Response -> IO ResponseReceived
-  routingRespond (Left NotFound) =
-    respond $ responseLBS notFound404 [] "not found"
-  routingRespond (Left WrongMethod) =
-    respond $ responseLBS methodNotAllowed405 [] "method not allowed"
-  routingRespond (Left (InvalidBody err)) =
-    respond $ responseLBS badRequest400 [] $ fromString $ "invalid request body: " ++ err
-  routingRespond (Left UnsupportedMediaType) =
-    respond $ responseLBS unsupportedMediaType415 [] "unsupported media type"
-  routingRespond (Left (HttpError status body)) =
-    respond $ responseLBS status [] $ fromMaybe (BL.fromStrict $ statusMessage status) body
-  routingRespond (Right response) =
-    respond response
+  routingRespond :: RouteResult Response -> IO ResponseReceived
+  routingRespond (Retriable err)    = respond $! responseServantErr err
+  routingRespond (NonRetriable err) = respond $! responseServantErr err
+  routingRespond (HandlerVal v)     = respond v
 
 runAction :: IO (RouteResult (ExceptT ServantErr IO a))
           -> (RouteResult Response -> IO r)
           -> (a -> RouteResult Response)
           -> IO r
-runAction action respond k = do
-  r <- action
-  go r
+runAction action respond k = action >>= go >>= respond
   where
-    go (RR (Right a))  = do
+    go (Retriable  e)   = return $! Retriable e
+    go (NonRetriable e) = return . succeedWith $! responseServantErr e
+    go (HandlerVal a)   = do
       e <- runExceptT a
-      respond $ case e of
-        Right x  -> k x
-        Left err -> succeedWith $ responseServantErr err
-    go (RR (Left err)) = respond $ failWith err
+      case e of
+        Left err -> return . succeedWith $! responseServantErr err
+        Right x  -> return $! k x
 
 feedTo :: IO (RouteResult (a -> b)) -> a -> IO (RouteResult b)
 feedTo f x = (($ x) <$>) <$> f
 
 extractL :: RouteResult (a :<|> b) -> RouteResult a
-extractL (RR (Right (a :<|> _))) = RR (Right a)
-extractL (RR (Left err))         = RR (Left err)
+extractL (HandlerVal (a :<|> _)) = HandlerVal a
+extractL (Retriable x)           = Retriable x
+extractL (NonRetriable x)        = NonRetriable x
 
 extractR :: RouteResult (a :<|> b) -> RouteResult b
-extractR (RR (Right (_ :<|> b))) = RR (Right b)
-extractR (RR (Left err))         = RR (Left err)
+extractR (HandlerVal (_ :<|> b)) = HandlerVal b
+extractR (Retriable x)           = Retriable x
+extractR (NonRetriable x)        = NonRetriable x
 
-failWith :: RouteMismatch -> RouteResult a
-failWith = RR . Left
+-- | Fail with a @ServantErr@, but keep trying other paths and.
+failWith :: ServantErr -> RouteResult a
+failWith = Retriable
 
+-- | Fail with immediately @ServantErr@.
+failFatallyWith :: ServantErr -> RouteResult a
+failFatallyWith = NonRetriable
+
+-- | Return a value, and don't try other paths.
 succeedWith :: a -> RouteResult a
-succeedWith = RR . Right
+succeedWith = HandlerVal
 
 isMismatch :: RouteResult a -> Bool
-isMismatch (RR (Left _)) = True
+isMismatch (Retriable _) = True
 isMismatch _             = False
-

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -8,9 +8,7 @@
 module Servant.Server.Internal.RoutingApplication where
 
 #if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative                (Applicative, (<$>))
-import           Data.Monoid                        (Monoid, mappend, mempty,
-                                                     (<>))
+import           Control.Applicative                ((<$>))
 #endif
 import           Control.Monad.Trans.Except         (ExceptT, runExceptT)
 import qualified Data.ByteString                    as B
@@ -69,8 +67,6 @@ toApplication ra request respond = do
   routingRespond (FailFatal err) = respond $ responseServantErr err
   routingRespond (Route v)       = respond v
 
--- TODO: The above may not be quite right yet.
---
 -- We currently mix up the order in which we perform checks
 -- and the priority with which errors are reported.
 --
@@ -162,7 +158,8 @@ data Delayed :: * -> * where
           -> (a -> b -> RouteResult c)
           -> Delayed c
 
-deriving instance Functor Delayed
+instance Functor Delayed where
+   fmap f (Delayed a b c g) = Delayed a b c ((fmap.fmap.fmap) f g)
 
 -- | Add a capture to the end of the capture block.
 addCapture :: Delayed (a -> b)

--- a/servant-server/src/Servant/Server/Internal/ServantErr.hs
+++ b/servant-server/src/Servant/Server/Internal/ServantErr.hs
@@ -11,7 +11,7 @@ data ServantErr = ServantErr { errHTTPCode     :: Int
                              , errReasonPhrase :: String
                              , errBody         :: LBS.ByteString
                              , errHeaders      :: [HTTP.Header]
-                             } deriving (Show, Eq)
+                             } deriving (Show, Eq, Read)
 
 responseServantErr :: ServantErr -> Response
 responseServantErr ServantErr{..} = responseLBS status errHeaders errBody

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+module Servant.Server.ErrorSpec (spec) where
+
+import Test.Hspec
+import Data.Proxy
+import Test.Hspec.Wai (request, with, shouldRespondWith)
+import Network.HTTP.Types (methodGet, methodPost)
+import Data.Aeson (encode)
+
+import Servant
+
+
+-- 1) Check whether one or more endpoints have the right path. Otherwise return 404.
+-- 2) Check whether the one of those have the right method. Otherwise return
+-- 405. If so, pick the first. We've now commited to calling at most one handler. *
+-- 3) Check whether the Content-Type is known. Otherwise return 415.
+-- 4) Check whether that one deserializes the body. Otherwise return 400. If there
+-- was no Content-Type, try the first one of the API content-type list.
+-- 5) Check whether the request is authorized. Otherwise return a 401.
+-- 6) Check whether the request is forbidden. If so return 403.
+-- 7) Check whether the request has a known Accept. Otherwise return 406.
+-- 8) Check whether Accept-Language, Accept-Charset and Accept-Encoding exist and
+-- match. We can follow the webmachine order here.
+-- 9) Call the handler. Whatever it returns, we return.
+
+spec :: Spec
+spec = do
+    errorOrder
+
+
+type ErrorOrderApi = "home"
+                  :> ReqBody '[JSON] Int
+                  :> Capture "t" Int
+                  :> Post '[JSON] Int
+
+errorOrderApi :: Proxy ErrorOrderApi
+errorOrderApi = Proxy
+
+errorOrderServer :: Server ErrorOrderApi
+errorOrderServer = \_ _ -> return 10
+
+errorOrder :: Spec
+errorOrder = describe "HTTP error order"
+           $ with (return $ serve errorOrderApi errorOrderServer) $ do
+    let badContentType  = ("Content-Type", "text/plain")
+        badAccept       = ("Accept", "text/plain")
+        badMethod       = methodGet
+        badUrl          = "home/nonexistent"
+        badBody         = "nonsense"
+        goodContentType = ("Content-Type", "application/json")
+        goodAccept      = ("Accept", "application/json")
+        goodMethod      = methodPost
+        goodUrl         = "home/5"
+        goodBody        = encode (5 :: Int)
+
+    it "has 404 as its highest priority error" $ do
+        request badMethod badUrl [badContentType, badAccept] badBody
+            `shouldRespondWith` 404
+
+    it "has 405 as its second highest priority error" $ do
+        request badMethod goodUrl [badContentType, badAccept] badBody
+            `shouldRespondWith` 405
+
+    it "has 415 as its third highest priority error" $ do
+        request goodMethod goodUrl [badContentType, badAccept] badBody
+            `shouldRespondWith` 415
+
+    it "has 400 as its fourth highest priority error" $ do
+        request goodMethod goodUrl [goodContentType, badAccept] badBody
+            `shouldRespondWith` 400
+
+    it "has 406 as its fifth highest priority error" $ do
+        request goodMethod goodUrl [goodContentType, badAccept] goodBody
+            `shouldRespondWith` 406
+
+

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -1,15 +1,19 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Servant.Server.ErrorSpec (spec) where
 
-import Test.Hspec
-import Data.Proxy
-import Test.Hspec.Wai (request, with, shouldRespondWith)
-import Network.HTTP.Types (methodGet, methodPost)
-import Data.Aeson (encode)
+import           Data.Aeson                 (encode)
+import qualified Data.ByteString.Lazy.Char8 as BC
+import           Control.Monad.Trans.Either (left)
+import           Data.Proxy
+import           Network.HTTP.Types         (methodGet, methodPost)
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import Servant
+import           Servant
 
 
 -- 1) Check whether one or more endpoints have the right path. Otherwise return 404.
@@ -26,9 +30,12 @@ import Servant
 -- 9) Call the handler. Whatever it returns, we return.
 
 spec :: Spec
-spec = do
+spec = describe "HTTP Errors" $ do
     errorOrder
+    errorRetry
 
+------------------------------------------------------------------------------
+-- * Error Order {{{
 
 type ErrorOrderApi = "home"
                   :> ReqBody '[JSON] Int
@@ -39,40 +46,108 @@ errorOrderApi :: Proxy ErrorOrderApi
 errorOrderApi = Proxy
 
 errorOrderServer :: Server ErrorOrderApi
-errorOrderServer = \_ _ -> return 10
+errorOrderServer = \_ _ -> left err402
 
 errorOrder :: Spec
 errorOrder = describe "HTTP error order"
            $ with (return $ serve errorOrderApi errorOrderServer) $ do
-    let badContentType  = ("Content-Type", "text/plain")
-        badAccept       = ("Accept", "text/plain")
-        badMethod       = methodGet
-        badUrl          = "home/nonexistent"
-        badBody         = "nonsense"
-        goodContentType = ("Content-Type", "application/json")
-        goodAccept      = ("Accept", "application/json")
-        goodMethod      = methodPost
-        goodUrl         = "home/5"
-        goodBody        = encode (5 :: Int)
+  let badContentType  = ("Content-Type", "text/plain")
+      badAccept       = ("Accept", "text/plain")
+      badMethod       = methodGet
+      badUrl          = "home/nonexistent"
+      badBody         = "nonsense"
+      goodContentType = ("Content-Type", "application/json")
+      goodAccept      = ("Accept", "application/json")
+      goodMethod      = methodPost
+      goodUrl         = "home/5"
+      goodBody        = encode (5 :: Int)
 
-    it "has 404 as its highest priority error" $ do
-        request badMethod badUrl [badContentType, badAccept] badBody
-            `shouldRespondWith` 404
+  it "has 404 as its highest priority error" $ do
+    request badMethod badUrl [badContentType, badAccept] badBody
+      `shouldRespondWith` 404
 
-    it "has 405 as its second highest priority error" $ do
-        request badMethod goodUrl [badContentType, badAccept] badBody
-            `shouldRespondWith` 405
+  it "has 405 as its second highest priority error" $ do
+    request badMethod goodUrl [badContentType, badAccept] badBody
+      `shouldRespondWith` 405
 
-    it "has 415 as its third highest priority error" $ do
-        request goodMethod goodUrl [badContentType, badAccept] badBody
-            `shouldRespondWith` 415
+  it "has 415 as its third highest priority error" $ do
+    request goodMethod goodUrl [badContentType, badAccept] badBody
+      `shouldRespondWith` 415
 
-    it "has 400 as its fourth highest priority error" $ do
-        request goodMethod goodUrl [goodContentType, badAccept] badBody
-            `shouldRespondWith` 400
+  it "has 400 as its fourth highest priority error" $ do
+    request goodMethod goodUrl [goodContentType, badAccept] badBody
+      `shouldRespondWith` 400
 
-    it "has 406 as its fifth highest priority error" $ do
-        request goodMethod goodUrl [goodContentType, badAccept] goodBody
-            `shouldRespondWith` 406
+  it "has 406 as its fifth highest priority error" $ do
+    request goodMethod goodUrl [goodContentType, badAccept] goodBody
+      `shouldRespondWith` 406
 
+  it "returns handler errors as its lower priority errors" $ do
+    request goodMethod goodUrl [goodContentType, goodAccept] goodBody
+      `shouldRespondWith` 402
 
+-- }}}
+------------------------------------------------------------------------------
+-- * Error Retry {{{
+
+type ErrorRetryApi
+     = "a" :> ReqBody '[JSON] Int      :> Post '[JSON] Int                -- 0
+  :<|> "a" :> ReqBody '[PlainText] Int :> Post '[JSON] Int                -- 1
+  :<|> "a" :> ReqBody '[JSON] Int      :> Post '[PlainText] Int           -- 2
+  :<|> "a" :> ReqBody '[JSON] String   :> Post '[JSON] Int                -- 3
+  :<|> "a" :> ReqBody '[JSON] Int      :> Get  '[PlainText] Int           -- 4
+  :<|>        ReqBody '[JSON] Int      :> Get  '[JSON] Int                -- 5
+  :<|>        ReqBody '[JSON] Int      :> Get  '[JSON] Int                -- 6
+
+errorRetryApi :: Proxy ErrorRetryApi
+errorRetryApi = Proxy
+
+errorRetryServer :: Server ErrorRetryApi
+errorRetryServer
+     = (\_ -> return 0)
+  :<|> (\_ -> return 1)
+  :<|> (\_ -> return 2)
+  :<|> (\_ -> return 3)
+  :<|> (\_ -> return 4)
+  :<|> (\_ -> return 5)
+  :<|> (\_ -> return 6)
+
+errorRetry :: Spec
+errorRetry = describe "Handler search"
+           $ with (return $ serve errorRetryApi errorRetryServer) $ do
+  let plainCT     = ("Content-Type", "text/plain")
+      plainAccept = ("Accept", "text/plain")
+      jsonCT      = ("Content-Type", "application/json")
+      jsonAccept  = ("Accept", "application/json")
+      jsonBody    = encode (1797 :: Int)
+
+  it "should continue when URLs don't match" $ do
+    request methodPost "" [jsonCT, jsonAccept] jsonBody
+     `shouldRespondWith` 201 { matchBody = Just $ encode (5 :: Int) }
+
+  it "should continue when methods don't match" $ do
+    request methodGet "a" [jsonCT, jsonAccept] jsonBody
+     `shouldRespondWith` 200 { matchBody = Just $ encode (4 :: Int) }
+
+  it "should not continue when Content-Types don't match" $ do
+    request methodPost "a" [plainCT, jsonAccept] jsonBody
+     `shouldRespondWith` 415
+
+  it "should not continue when body can't be deserialized" $ do
+    request methodPost "a" [jsonCT, jsonAccept] (encode ("nonsense" :: String))
+     `shouldRespondWith` 400
+
+  it "should not continue when Accepts don't match" $ do
+    request methodPost "a" [jsonCT, plainAccept] jsonBody
+     `shouldRespondWith` 406
+
+-- }}}
+------------------------------------------------------------------------------
+-- * Instances {{{
+
+instance MimeUnrender PlainText Int where
+    mimeUnrender _ = Right . read . BC.unpack
+
+instance MimeRender PlainText Int where
+    mimeRender _ = BC.pack . show
+-- }}}

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -6,32 +6,38 @@
 module Servant.Server.ErrorSpec (spec) where
 
 import           Data.Aeson                 (encode)
-import qualified Data.ByteString.Lazy.Char8 as BC
+import qualified Data.ByteString.Lazy.Char8 as BCL
+import qualified Data.ByteString.Char8      as BC
 import           Data.Proxy
 import           Network.HTTP.Types         (hAccept, hContentType, methodGet,
-                                             methodPost)
+                                             methodPost, methodPut)
 import           Test.Hspec
 import           Test.Hspec.Wai
 
 import           Servant
 
 
--- 1) Check whether one or more endpoints have the right path. Otherwise return 404.
--- 2) Check whether the one of those have the right method. Otherwise return
--- 405. If so, pick the first. We've now commited to calling at most one handler. *
--- 3) Check whether the Content-Type is known. Otherwise return 415.
--- 4) Check whether that one deserializes the body. Otherwise return 400. If there
--- was no Content-Type, try the first one of the API content-type list.
--- 5) Check whether the request is authorized. Otherwise return a 401.
--- 6) Check whether the request is forbidden. If so return 403.
--- 7) Check whether the request has a known Accept. Otherwise return 406.
--- 8) Check whether Accept-Language, Accept-Charset and Accept-Encoding exist and
--- match. We can follow the webmachine order here.
--- 9) Call the handler. Whatever it returns, we return.
+-- The semantics of routing and handling requests should be as follows:
+--
+--    1) Check whether one or more endpoints have the right path. Otherwise
+--    return 404.
+--    2) Check whether the one of those have the right method. Otherwise return
+--    405. If so, pick the first. We've now committed to calling at most one
+--    handler.
+--    3) Check whether the Content-Type is known. Otherwise return 415.
+--    4) Check whether that one deserializes the body. Otherwise return 400. If
+--    there was no Content-Type, try the first one of the API content-type list.
+--    5) Check whether the request is authorized. Otherwise return a 401.
+--    6) Check whether the request is forbidden. If so return 403.
+--    7) Check whether the request has a known Accept. Otherwise return 406.
+--    8) Check whether Accept-Language, Accept-Charset and Accept-Encoding
+--    exist and match. We can follow the webmachine order here.
+--    9) Call the handler. Whatever it returns, we return.
 
 spec :: Spec
 spec = describe "HTTP Errors" $ do
     errorOrderSpec
+    prioErrorsSpec
     errorRetrySpec
     errorChoiceSpec
 
@@ -82,6 +88,52 @@ errorOrderSpec = describe "HTTP error order"
   it "has 406 as its fifth highest priority error" $ do
     request goodMethod goodUrl [goodContentType, badAccept] goodBody
       `shouldRespondWith` 406
+
+type PrioErrorsApi = ReqBody '[JSON] Integer :> "foo" :> Get '[JSON] Integer
+
+prioErrorsApi :: Proxy PrioErrorsApi
+prioErrorsApi = Proxy
+
+-- Check whether matching continues even if a 'ReqBody' or similar construct
+-- is encountered early in a path. We don't want to see a complaint about the
+-- request body unless the path actually matches.
+prioErrorsSpec :: Spec
+prioErrorsSpec = describe "PrioErrors" $ do
+  let server = return
+  with (return $ serve prioErrorsApi server) $ do
+    let check (mdescr, method) path (cdescr, ctype, body) resp =
+          it fulldescr $
+            Test.Hspec.Wai.request method path [(hContentType, ctype)] body
+              `shouldRespondWith` resp
+          where
+            fulldescr = "returns " ++ show (matchStatus resp) ++ " on " ++ mdescr
+                     ++ " " ++ (BC.unpack path) ++ " (" ++ cdescr ++ ")"
+
+        get' = ("GET", methodGet)
+        put' = ("PUT", methodPut)
+
+        txt   = ("text"        , "text/plain;charset=utf8"      , "42"        )
+        ijson = ("invalid json", "application/json;charset=utf8", "invalid"   )
+        vjson = ("valid json"  , "application/json;charset=utf8", encode (5 :: Int))
+
+    check get' "/"    txt   404
+    check get' "/bar" txt   404
+    check get' "/foo" txt   415
+    check put' "/"    txt   404
+    check put' "/bar" txt   404
+    check put' "/foo" txt   405
+    check get' "/"    ijson 404
+    check get' "/bar" ijson 404
+    check get' "/foo" ijson 400
+    check put' "/"    ijson 404
+    check put' "/bar" ijson 404
+    check put' "/foo" ijson 405
+    check get' "/"    vjson 404
+    check get' "/bar" vjson 404
+    check get' "/foo" vjson 200
+    check put' "/"    vjson 404
+    check put' "/bar" vjson 404
+    check put' "/foo" vjson 405
 
 -- }}}
 ------------------------------------------------------------------------------
@@ -190,8 +242,10 @@ errorChoiceSpec = describe "Multiple handlers return errors"
 -- * Instances {{{
 
 instance MimeUnrender PlainText Int where
-    mimeUnrender _ = Right . read . BC.unpack
+    mimeUnrender _ = Right . read . BCL.unpack
 
 instance MimeRender PlainText Int where
-    mimeRender _ = BC.pack . show
+    mimeRender _ = BCL.pack . show
 -- }}}
+--
+

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -18,24 +18,6 @@ import           Test.Hspec.Wai
 
 import           Servant
 
-
--- The semantics of routing and handling requests should be as follows:
---
---    1) Check whether one or more endpoints have the right path. Otherwise
---    return 404.
---    2) Check whether the one of those have the right method. Otherwise return
---    405. If so, pick the first. We've now committed to calling at most one
---    handler.
---    3) Check whether the Content-Type is known. Otherwise return 415.
---    4) Check whether that one deserializes the body. Otherwise return 400. If
---    there was no Content-Type, try the first one of the API content-type list.
---    5) Check whether the request is authorized. Otherwise return a 401.
---    6) Check whether the request is forbidden. If so return 403.
---    7) Check whether the request has a known Accept. Otherwise return 406.
---    8) Check whether Accept-Language, Accept-Charset and Accept-Encoding
---    exist and match. We can follow the webmachine order here.
---    9) Call the handler. Whatever it returns, we return.
-
 spec :: Spec
 spec = describe "HTTP Errors" $ do
     errorOrderSpec
@@ -174,9 +156,7 @@ errorRetrySpec :: Spec
 errorRetrySpec = describe "Handler search"
            $ with (return $ serve errorRetryApi errorRetryServer) $ do
 
-  let plainCT     = (hContentType, "text/plain")
-      plainAccept = (hAccept, "text/plain")
-      jsonCT      = (hContentType, "application/json")
+  let jsonCT      = (hContentType, "application/json")
       jsonAccept  = (hAccept, "application/json")
       jsonBody    = encode (1797 :: Int)
 

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -1,20 +1,12 @@
-<<<<<<< HEAD
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveGeneric        #-}
-=======
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleInstances    #-}
->>>>>>> Review fixes
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-<<<<<<< HEAD
 {-# LANGUAGE FlexibleInstances    #-}
-=======
->>>>>>> Review fixes
 
 module Servant.ServerSpec where
 
@@ -55,6 +47,7 @@ import           Test.Hspec                 (Spec, describe, it, shouldBe)
 import           Test.Hspec.Wai             (get, liftIO, matchHeaders,
                                              matchStatus, post, request,
                                              shouldRespondWith, with, (<:>))
+<<<<<<< HEAD
 import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
                                              Get, Header (..), Headers,
                                              HttpVersion, IsSecure (..), JSON,
@@ -63,12 +56,12 @@ import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
                                              Raw, RemoteHost, ReqBody,
                                              addHeader)
 import           Servant.Server             (Server, serve, ServantErr(..), err404)
+=======
+import           Servant.Server.Internal.RoutingApplication (toApplication, RouteResult(..))
+>>>>>>> Rebase cleanup and test fixes.
 import           Servant.Server.Internal.Router
                                             (tweakResponse, runRouter,
                                              Router, Router'(LeafRouter))
-import           Servant.Server.Internal.RoutingApplication
-                                            (RouteResult(..), RouteMismatch(..),
-                                             toApplication)
 
 
 -- * test data types
@@ -279,13 +272,13 @@ queryParamSpec = do
              }
 
           let params3'' = "?unknown="
-          response3' <- Network.Wai.Test.request defaultRequest{
+          response3'' <- Network.Wai.Test.request defaultRequest{
             rawQueryString = params3'',
             queryString = parseQuery params3'',
             pathInfo = ["b"]
            }
           liftIO $
-            decode' (simpleBody response3') `shouldBe` Just alice{
+            decode' (simpleBody response3'') `shouldBe` Just alice{
               name = "Alice"
              }
 
@@ -553,7 +546,7 @@ routerSpec = do
 
         router', router :: Router
         router' = tweakResponse (twk <$>) router
-        router = LeafRouter $ \_ cont -> cont (RR . Right $ responseBuilder (Status 201 "") [] "")
+        router = LeafRouter $ \_ cont -> cont (Route $ responseBuilder (Status 201 "") [] "")
 
         twk :: Response -> Response
         twk (ResponseBuilder (Status i s) hs b) = ResponseBuilder (Status (i + 1) s) hs b

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -36,29 +36,16 @@ import           Network.Wai.Test           (defaultRequest, request,
 import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
                                              Get, Header (..), Headers,
                                              HttpVersion, IsSecure (..), JSON,
-                                             MatrixFlag, MatrixParam,
-                                             MatrixParams, Patch, PlainText,
-                                             Post, Put, QueryFlag, QueryParam,
-                                             QueryParams, Raw, RemoteHost,
-                                             ReqBody, addHeader)
-import           Servant.Server             (ServantErr (..), Server, err404,
-                                             serve)
-import           Test.Hspec                 (Spec, describe, it, shouldBe)
-import           Test.Hspec.Wai             (get, liftIO, matchHeaders,
-                                             matchStatus, post, request,
-                                             shouldRespondWith, with, (<:>))
-<<<<<<< HEAD
-import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
-                                             Get, Header (..), Headers,
-                                             HttpVersion, IsSecure (..), JSON,
                                              Patch, PlainText, Post, Put,
                                              QueryFlag, QueryParam, QueryParams,
                                              Raw, RemoteHost, ReqBody,
                                              addHeader)
 import           Servant.Server             (Server, serve, ServantErr(..), err404)
-=======
+import           Test.Hspec                 (Spec, describe, it, shouldBe)
+import           Test.Hspec.Wai             (get, liftIO, matchHeaders,
+                                             matchStatus, post, request,
+                                             shouldRespondWith, with, (<:>))
 import           Servant.Server.Internal.RoutingApplication (toApplication, RouteResult(..))
->>>>>>> Rebase cleanup and test fixes.
 import           Servant.Server.Internal.Router
                                             (tweakResponse, runRouter,
                                              Router, Router'(LeafRouter))

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -1,11 +1,20 @@
+<<<<<<< HEAD
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveGeneric        #-}
+=======
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleInstances    #-}
+>>>>>>> Review fixes
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+<<<<<<< HEAD
 {-# LANGUAGE FlexibleInstances    #-}
+=======
+>>>>>>> Review fixes
 
 module Servant.ServerSpec where
 
@@ -32,6 +41,16 @@ import           Network.Wai                (Application, Request, pathInfo,
 import           Network.Wai.Internal       (Response(ResponseBuilder))
 import           Network.Wai.Test           (defaultRequest, request,
                                              runSession, simpleBody)
+import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
+                                             Get, Header (..), Headers,
+                                             HttpVersion, IsSecure (..), JSON,
+                                             MatrixFlag, MatrixParam,
+                                             MatrixParams, Patch, PlainText,
+                                             Post, Put, QueryFlag, QueryParam,
+                                             QueryParams, Raw, RemoteHost,
+                                             ReqBody, addHeader)
+import           Servant.Server             (ServantErr (..), Server, err404,
+                                             serve)
 import           Test.Hspec                 (Spec, describe, it, shouldBe)
 import           Test.Hspec.Wai             (get, liftIO, matchHeaders,
                                              matchStatus, post, request,
@@ -96,7 +115,6 @@ spec = do
   headerSpec
   rawSpec
   unionSpec
-  prioErrorsSpec
   routerSpec
   responseHeadersSpec
   miscReqCombinatorsSpec
@@ -525,55 +543,6 @@ responseHeadersSpec = describe "ResponseHeaders" $ do
       forM_ methods $ \(method,_) ->
         Test.Hspec.Wai.request method "" [(hAccept, "crazy/mime")] ""
           `shouldRespondWith` 406
-
-type PrioErrorsApi = ReqBody '[JSON] Person :> "foo" :> Get '[JSON] Integer
-
-prioErrorsApi :: Proxy PrioErrorsApi
-prioErrorsApi = Proxy
-
--- | Test the relative priority of error responses from the server.
---
--- In particular, we check whether matching continues even if a 'ReqBody'
--- or similar construct is encountered early in a path. We don't want to
--- see a complaint about the request body unless the path actually matches.
---
-prioErrorsSpec :: Spec
-prioErrorsSpec = describe "PrioErrors" $ do
-  let server = return . age
-  with (return $ serve prioErrorsApi server) $ do
-    let check (mdescr, method) path (cdescr, ctype, body) resp =
-          it fulldescr $
-            Test.Hspec.Wai.request method path [(hContentType, ctype)] body
-              `shouldRespondWith` resp
-          where
-            fulldescr = "returns " ++ show (matchStatus resp) ++ " on " ++ mdescr
-                     ++ " " ++ cs path ++ " (" ++ cdescr ++ ")"
-
-        get' = ("GET", methodGet)
-        put' = ("PUT", methodPut)
-
-        txt   = ("text"        , "text/plain;charset=utf8"      , "42"        )
-        ijson = ("invalid json", "application/json;charset=utf8", "invalid"   )
-        vjson = ("valid json"  , "application/json;charset=utf8", encode alice)
-
-    check get' "/"    txt   404
-    check get' "/bar" txt   404
-    check get' "/foo" txt   415
-    check put' "/"    txt   404
-    check put' "/bar" txt   404
-    check put' "/foo" txt   405
-    check get' "/"    ijson 404
-    check get' "/bar" ijson 404
-    check get' "/foo" ijson 400
-    check put' "/"    ijson 404
-    check put' "/bar" ijson 404
-    check put' "/foo" ijson 405
-    check get' "/"    vjson 404
-    check get' "/bar" vjson 404
-    check get' "/foo" vjson 200
-    check put' "/"    vjson 404
-    check put' "/bar" vjson 404
-    check put' "/foo" vjson 405
 
 
 routerSpec :: Spec

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -6,6 +6,7 @@ HEAD
 * Add more instances for (:<|>)
 * Use `http-api-data` instead of `Servant.Common.Text`
 * Remove matrix params.
+* Add PlainText String MimeRender and MimeUnrender instances.
 
 0.4.2
 -----

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -57,12 +57,14 @@ module Servant.API.ContentTypes
     , AcceptHeader(..)
     , AllCTRender(..)
     , AllCTUnrender(..)
+    , AllMime(..)
     , AllMimeRender(..)
     , AllMimeUnrender(..)
     , FromFormUrlEncoded(..)
     , ToFormUrlEncoded(..)
     , IsNonEmpty
     , eitherDecodeLenient
+    , canHandleAcceptH
     ) where
 
 #if !MIN_VERSION_base(4,8,0)
@@ -81,6 +83,7 @@ import           Data.ByteString.Lazy             (ByteString, fromStrict,
                                                    toStrict)
 import qualified Data.ByteString.Lazy             as B
 import qualified Data.ByteString.Lazy.Char8       as BC
+import           Data.Maybe                       (isJust)
 import           Data.Monoid
 import           Data.String.Conversions          (cs)
 import qualified Data.Text                        as TextS
@@ -156,14 +159,13 @@ newtype AcceptHeader = AcceptHeader BS.ByteString
 class Accept ctype => MimeRender ctype a where
     mimeRender  :: Proxy ctype -> a -> ByteString
 
-class AllCTRender (list :: [*]) a where
+class (AllMimeRender list a) => AllCTRender (list :: [*]) a where
     -- If the Accept header can be matched, returns (Just) a tuple of the
     -- Content-Type and response (serialization of @a@ into the appropriate
     -- mimetype).
     handleAcceptH :: Proxy list -> AcceptHeader -> a -> Maybe (ByteString, ByteString)
 
-instance ( AllMimeRender ctyps a, IsNonEmpty ctyps
-         ) => AllCTRender ctyps a where
+instance (AllMimeRender ctyps a, IsNonEmpty ctyps) => AllCTRender ctyps a where
     handleAcceptH _ (AcceptHeader accept) val = M.mapAcceptMedia lkup accept
       where pctyps = Proxy :: Proxy ctyps
             amrs = allMimeRender pctyps val
@@ -211,11 +213,24 @@ instance ( AllMimeUnrender ctyps a, IsNonEmpty ctyps
 --------------------------------------------------------------------------
 -- * Utils (Internal)
 
+class AllMime (list :: [*]) where
+    allMime :: Proxy list -> [M.MediaType]
+
+instance AllMime '[] where
+    allMime _ = []
+
+instance (Accept ctyp, AllMime ctyps) => AllMime (ctyp ': ctyps) where
+    allMime _ = (contentType pctyp):allMime pctyps
+      where pctyp  = Proxy :: Proxy ctyp
+            pctyps = Proxy :: Proxy ctyps
+
+canHandleAcceptH :: AllMime list => Proxy list -> AcceptHeader -> Bool
+canHandleAcceptH p (AcceptHeader h ) = isJust $ M.matchAccept (allMime p) h
 
 --------------------------------------------------------------------------
 -- Check that all elements of list are instances of MimeRender
 --------------------------------------------------------------------------
-class AllMimeRender (list :: [*]) a where
+class (AllMime list) => AllMimeRender (list :: [*]) a where
     allMimeRender :: Proxy list
                   -> a                              -- value to serialize
                   -> [(M.MediaType, ByteString)]    -- content-types/response pairs
@@ -239,7 +254,7 @@ instance AllMimeRender '[] a where
 --------------------------------------------------------------------------
 -- Check that all elements of list are instances of MimeUnrender
 --------------------------------------------------------------------------
-class AllMimeUnrender (list :: [*]) a where
+class (AllMime list) => AllMimeUnrender (list :: [*]) a where
     allMimeUnrender :: Proxy list
                     -> ByteString
                     -> [(M.MediaType, Either String a)]

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -80,6 +80,7 @@ import qualified Data.ByteString                  as BS
 import           Data.ByteString.Lazy             (ByteString, fromStrict,
                                                    toStrict)
 import qualified Data.ByteString.Lazy             as B
+import qualified Data.ByteString.Lazy.Char8       as BC
 import           Data.Monoid
 import           Data.String.Conversions          (cs)
 import qualified Data.Text                        as TextS
@@ -279,6 +280,10 @@ instance MimeRender PlainText TextL.Text where
 instance MimeRender PlainText TextS.Text where
     mimeRender _ = fromStrict . TextS.encodeUtf8
 
+-- | @BC.pack@
+instance MimeRender PlainText String where
+    mimeRender _ = BC.pack
+
 -- | @id@
 instance MimeRender OctetStream ByteString where
     mimeRender _ = id
@@ -327,6 +332,10 @@ instance MimeUnrender PlainText TextL.Text where
 -- | @left show . TextS.decodeUtf8' . toStrict@
 instance MimeUnrender PlainText TextS.Text where
     mimeUnrender _ = left show . TextS.decodeUtf8' . toStrict
+
+-- | @Right . BC.unpack@
+instance MimeUnrender PlainText String where
+    mimeUnrender _ = Right . BC.unpack
 
 -- | @Right . id@
 instance MimeUnrender OctetStream ByteString where

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PolyKinds             #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Servant.API.ContentTypesSpec where
 
@@ -33,6 +34,20 @@ import           Servant.API.ContentTypes
 
 spec :: Spec
 spec = describe "Servant.API.ContentTypes" $ do
+
+    describe "handleAcceptH" $ do
+        let p = Proxy :: Proxy '[PlainText]
+
+        it "matches any charset if none were provided" $ do
+            let without = handleAcceptH p (AcceptHeader "text/plain")
+                with    = handleAcceptH p (AcceptHeader "text/plain;charset=utf-8")
+                wisdom  = "ubi sub ubi" :: String
+            without wisdom `shouldBe` with wisdom
+
+        it "does not match non utf-8 charsets" $  do
+            let badCharset = handleAcceptH p (AcceptHeader "text/plain;charset=whoknows")
+                s          = "cheese" :: String
+            badCharset s `shouldBe` Nothing
 
     describe "The JSON Content-Type type" $ do
         let p = Proxy :: Proxy JSON


### PR DESCRIPTION
Looking pretty bad:
```
servant-server-0.5: test (suite: doctests, args: -m "HTTP Errors")
Examples: 7  Tried: 7  Errors: 0  Failures: 0
servant-server-0.5: test (suite: spec, args: -m "HTTP Errors")

Servant.Server.Error
  HTTP Errors
    HTTP error order
      has 404 as its highest priority error FAILED [1]
      has 405 as its second highest priority error
      has 415 as its third highest priority error
      has 400 as its fourth highest priority error
      has 406 as its fifth highest priority error FAILED [2]
      returns handler errors as its lower priority errors
    Handler search
      should continue when URLs don't match FAILED [3]
      should continue when methods don't match FAILED [4]
      should not continue when Content-Types don't match
      should not continue when body can't be deserialized FAILED [5]
      should not continue when Accepts don't match FAILED [6]

Failures:

  test/Servant/Server/ErrorSpec.hs:65:
  1) Servant.Server.Error, HTTP Errors, HTTP error order, has 404 as its highest priority error
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 404
         but got:  405

  test/Servant/Server/ErrorSpec.hs:81:
  2) Servant.Server.Error, HTTP Errors, HTTP error order, has 406 as its fifth highest priority error
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 406
         but got:  402

  test/Servant/Server/ErrorSpec.hs:124:
  3) Servant.Server.Error, HTTP Errors, Handler search, should continue when URLs don't match
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 201
         but got:  405
       body mismatch:
         expected: 5
         but got:  method not allowed

  test/Servant/Server/ErrorSpec.hs:128:
  4) Servant.Server.Error, HTTP Errors, Handler search, should continue when methods don't match
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 200
         but got:  415
       body mismatch:
         expected: 4
         but got:  unsupported media type

  test/Servant/Server/ErrorSpec.hs:136:
  5) Servant.Server.Error, HTTP Errors, Handler search, should not continue when body can't be deserialized
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 400
         but got:  201

  test/Servant/Server/ErrorSpec.hs:140:
  6) Servant.Server.Error, HTTP Errors, Handler search, should not continue when Accepts don't match
       src/Test/Hspec/Wai.hs:101:
       status mismatch:
         expected: 406
         but got:  201

Randomized with seed 515273500

Finished in 0.0034 seconds
11 examples, 6 failures
Test suite failure for package servant-server-0.5
    spec:  exited with: ExitFailure 1
Logs printed to console

```