### PR TITLE
fix for lens-4.13

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -22,7 +22,7 @@ module Servant.Docs.Internal where
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
-import           Control.Lens
+import           Control.Lens               hiding (List)
 import           Data.ByteString.Conversion (ToByteString, toByteString)
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.CaseInsensitive       as CI

--- a/servant-js/src/Servant/JS/Internal.hs
+++ b/servant-js/src/Servant/JS/Internal.hs
@@ -13,7 +13,7 @@ module Servant.JS.Internal where
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 #endif
-import Control.Lens
+import Control.Lens hiding (List)
 import Data.Char (toLower, toUpper)
 import qualified Data.CharSet as Set
 import qualified Data.CharSet.Unicode.Category as Set


### PR DESCRIPTION
`List` is a pattern synonym added in `lens-4.13`. (It doesn't show up in the documentation on hackage currently -- I assume haddock doesn't support pattern synonyms?)