### PR TITLE
Remove redundant build from .travis.yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install:
 
 script:
   - stack setup
-  - stack build --ghc-options "-Werror"
-  - stack test
+  - stack build --test --ghc-options "-Werror"
 
 cache:
   directories:


### PR DESCRIPTION
The `build` in the `.travis.yml` file is redundant. `stack test` is just
an alias for `stack build --test`.

Also in the old way of doing things,  `-Werror` is actually not set when
running tests. So it is ignored for  test files..

Now also test files need to have no warnings.