### PR TITLE
servant-js: export CommonGeneratorOptions constructors

### DIFF
--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -76,7 +76,7 @@ module Servant.JS
   , JavaScriptGenerator
 
   , -- * Options common to all generators
-    CommonGeneratorOptions
+    CommonGeneratorOptions(..)
   , defCommonGeneratorOptions
 
   , -- * Function renamers


### PR DESCRIPTION
Allow `defCommonGeneratorOptions` to be customized using record update syntax.

Without the re-export, we can't do things like:

```haskell
import qualified Servant.JS as SJS

myOptions =
  SJS.defCommonGeneratorOptions
    { SJS.moduleName = "myModule"
    , SJS.urlPrefix = "http://localhost"
    }
```