### PR TITLE
Fix camelCase

### DIFF
--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -33,3 +33,16 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
+
+
+test-suite spec
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    test
+  ghc-options:       -Wall
+  main-is:           Spec.hs
+  other-modules:
+      Servant.ForeignSpec
+  build-depends:     base
+                   , hspec >= 2.1.8
+                   , servant-foreign
+  default-language:  Haskell2010

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -47,6 +47,7 @@ module Servant.Foreign
   ) where
 
 import           Control.Lens (makeLenses, (%~), (&), (.~), (<>~))
+import qualified Data.Char    as C
 import           Data.Proxy
 import           Data.Text
 import           GHC.Exts     (Constraint)
@@ -66,10 +67,11 @@ snakeCase = intercalate "_"
 -- | Function name builder using the CamelCase convention.
 -- each part begins with an upper case character.
 camelCase :: FunctionName -> Text
-camelCase [] = ""
-camelCase (p:ps) = concat $ p : camelCase' ps
-   where camelCase' [] = []
-         camelCase' (r:rs) = toUpper r : camelCase' rs
+camelCase = camelCase' . Prelude.map (replace "-" "")
+  where camelCase' []     = ""
+        camelCase' (p:ps) = concat $ p : Prelude.map capitalize ps
+        capitalize ""   = ""
+        capitalize name = C.toUpper (Data.Text.head name) `cons` Data.Text.tail name
 
 type Arg = Text
 

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings     #-}
+
+module Servant.ForeignSpec where
+
+import Servant.Foreign (camelCase)
+
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Servant.Foreign" $ do
+  camelCaseSpec
+
+camelCaseSpec :: Spec
+camelCaseSpec = describe "camelCase" $ do
+  it "converts FunctionNames to camelCase" $ do
+    camelCase ["post", "counter", "inc"] `shouldBe` "postCounterInc"
+    camelCase ["get", "hyphen-ated", "counter"] `shouldBe` "getHyphenatedCounter"

--- a/servant-foreign/test/Spec.hs
+++ b/servant-foreign/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Previous behaviour was a bit shouty (and dashes aren't allowed in JS variable names):

```haskell
camelCase ["one", "two", "thirty-three"] -- => "oneTWOTHIRTY-THREE"
```

New behaviour:

```haskell
camelCase ["one", "two", "thirty-three"] -- => "oneTwoThirtythree"
```