### PR TITLE
Type information in servant-foreign.

### DIFF
--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -11,7 +11,7 @@ description:
   <https://github.com/haskell-servant/servant/blob/master/servant-foreign/CHANGELOG.md CHANGELOG>
 license:             BSD3
 license-file:        LICENSE
-author:              Denis Redozubov
+author:              Denis Redozubov, Maksymilian Owsianny
 maintainer:          denis.redozubov@gmail.com
 copyright:           2015 Denis Redozubov, Alp Mestanogullari
 category:            Web

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -2,6 +2,7 @@
 -- arbitrary programming languages.
 module Servant.Foreign
   ( HasForeign(..)
+  , HasForeignType(..)
   , Segment(..)
   , SegmentType(..)
   , FunctionName
@@ -24,6 +25,7 @@ module Servant.Foreign
   , reqBody
   , reqHeaders
   , reqMethod
+  , reqReturnType
   , segment
   , queryStr
   -- re-exports

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -28,6 +28,8 @@ module Servant.Foreign
   , reqReturnType
   , segment
   , queryStr
+  , listFromAPI
+  , GenerateList(..)
   -- re-exports
   , module Servant.API
   ) where

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -30,6 +30,7 @@ module Servant.Foreign
   , queryStr
   , listFromAPI
   , GenerateList(..)
+  , NoTypes
   -- re-exports
   , module Servant.API
   ) where

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -130,11 +130,6 @@ type family Elem (a :: *) (ls::[*]) :: Constraint where
 -- > -- instances.
 -- > data LangX
 -- >
--- > -- If the language __X__ is dynamically typed then you only need
--- > -- a catch all instance of a form
--- > instance HasForeignType LangX a where
--- >    typeFor _ _ = empty
--- >
 -- > -- Otherwise you define instances for the types you need
 -- > instance HasForeignType LangX Int where
 -- >    typeFor _ _ = "intX"
@@ -150,8 +145,20 @@ type family Elem (a :: *) (ls::[*]) :: Constraint where
 -- >              => Proxy api -> [Req]
 -- > getEndpoints api = listFromAPI (Proxy :: Proxy LangX) api
 --
+-- > -- If language __X__ is dynamically typed then you can use
+-- > -- a predefined NoTypes parameter
+-- > getEndpoints :: (HasForeign NoTypes api, GenerateList (Foreign api))
+-- >              => Proxy api -> [Req]
+-- > getEndpoints api = listFromAPI (Proxy :: Proxy NoTypes) api
+-- >
+--
 class HasForeignType lang a where
     typeFor :: Proxy lang -> Proxy a -> ForeignType
+
+data NoTypes
+
+instance HasForeignType NoTypes a where
+    typeFor _ _ = empty
 
 class HasForeign lang (layout :: *) where
   type Foreign layout :: *

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -219,7 +219,7 @@ instance (KnownSymbol sym, HasForeignType lang a, HasForeign lang sublayout)
     str = pack . symbolVal $ (Proxy :: Proxy sym)
     arg = (str, typeFor lang (Proxy :: Proxy a))
 
-instance (KnownSymbol sym, HasForeignType lang a, HasForeign lang sublayout)
+instance (KnownSymbol sym, HasForeignType lang [a], HasForeign lang sublayout)
       => HasForeign lang (QueryParams sym a :> sublayout) where
   type Foreign (QueryParams sym a :> sublayout) = Foreign sublayout
 
@@ -229,7 +229,7 @@ instance (KnownSymbol sym, HasForeignType lang a, HasForeign lang sublayout)
 
     where
     str = pack . symbolVal $ (Proxy :: Proxy sym)
-    arg = (str, typeFor lang (Proxy :: Proxy a))
+    arg = (str, typeFor lang (Proxy :: Proxy [a]))
 
 instance (KnownSymbol sym, HasForeignType lang a, a ~ Bool, HasForeign lang sublayout)
       => HasForeign lang (QueryFlag sym :> sublayout) where

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -122,6 +122,34 @@ type family Elem (a :: *) (ls::[*]) :: Constraint where
   Elem a (a ': list) = ()
   Elem a (b ': list) = Elem a list
 
+-- | 'HasForeignType' maps Haskell types with types in the target
+-- language of your backend. For example, let's say you're
+-- implementing a backend to some language __X__:
+--
+-- > -- First you need to create a dummy type to parametrize your
+-- > -- instances.
+-- > data LangX
+-- >
+-- > -- If the language __X__ is dynamically typed then you only need
+-- > -- a catch all instance of a form
+-- > instance HasForeignType LangX a where
+-- >    typeFor _ _ = empty
+-- >
+-- > -- Otherwise you define instances for the types you need
+-- > instance HasForeignType LangX Int where
+-- >    typeFor _ _ = "intX"
+-- >
+-- > -- Or for example in case of lists
+-- > instance HasForeignType LangX a => HasForeignType LangX [a] where
+-- >    typeFor lang _ = "listX of " <> typeFor lang (Proxy :: Proxy a)
+--
+-- Finally to generate list of information about all the endpoints for
+-- an API you create a function of a form:
+--
+-- > getEndpoints :: (HasForeign LangX api, GenerateList (Foreign api))
+-- >              => Proxy api -> [Req]
+-- > getEndpoints api = listFromAPI (Proxy :: Proxy LangX) api
+--
 class HasForeignType lang a where
     typeFor :: Proxy lang -> Proxy a -> ForeignType
 

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -1,17 +1,110 @@
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Servant.ForeignSpec where
 
-import Servant.Foreign (camelCase)
+import Data.Monoid ((<>))
+import Data.Proxy
+import Servant.Foreign
+import Servant.Foreign.Internal
 
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Servant.Foreign" $ do
   camelCaseSpec
+  listFromAPISpec
 
 camelCaseSpec :: Spec
 camelCaseSpec = describe "camelCase" $ do
   it "converts FunctionNames to camelCase" $ do
     camelCase ["post", "counter", "inc"] `shouldBe` "postCounterInc"
     camelCase ["get", "hyphen-ated", "counter"] `shouldBe` "getHyphenatedCounter"
+
+----------------------------------------------------------------------
+
+data LangX
+
+instance HasForeignType LangX () where
+    typeFor _ _ = "voidX"
+instance HasForeignType LangX Int where
+    typeFor _ _ = "intX"
+instance HasForeignType LangX Bool where
+    typeFor _ _ = "boolX"
+instance {-# Overlapping #-} HasForeignType LangX String where
+    typeFor _ _ = "stringX"
+instance {-# Overlapable #-} HasForeignType LangX a => HasForeignType LangX [a] where
+    typeFor lang _ = "listX of " <> typeFor lang (Proxy :: Proxy a)
+
+type TestApi
+    = "test" :> Header "header" [String] :> QueryFlag "flag" :> Get '[JSON] Int
+ :<|> "test" :> QueryParam "param" Int :> ReqBody '[JSON] [String] :> Post '[JSON] ()
+ :<|> "test" :> QueryParams "params" Int :> ReqBody '[JSON] String :> Put '[JSON] ()
+ :<|> "test" :> Capture "id" Int :> Delete '[JSON] ()
+
+testApi :: [Req]
+testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy TestApi)
+
+listFromAPISpec :: Spec
+listFromAPISpec = describe "listFromAPI" $ do
+    it "generates 4 endpoints for TestApi" $ do
+        length testApi `shouldBe` 4
+
+    let [getReq, postReq, putReq, deleteReq] = testApi
+
+    it "collects all info for get request" $ do
+        shouldBe getReq $ defReq
+            { _reqUrl        = Url
+                [ Segment $ Static "test" ]
+                [ QueryArg ("flag", "boolX") Flag ]
+            , _reqMethod     = "GET"
+            , _reqHeaders    = [HeaderArg ("header", "listX of stringX")]
+            , _reqBody       = Nothing
+            , _reqReturnType = "intX"
+            , _funcName      = ["get", "test"]
+            }
+
+    it "collects all info for post request" $ do
+        shouldBe postReq $ defReq
+            { _reqUrl        = Url
+                [ Segment $ Static "test" ]
+                [ QueryArg ("param", "intX") Normal ]
+            , _reqMethod     = "POST"
+            , _reqHeaders    = []
+            , _reqBody       = Just "listX of stringX"
+            , _reqReturnType = "voidX"
+            , _funcName      = ["post", "test"]
+            }
+
+    it "collects all info for put request" $ do
+        shouldBe putReq $ defReq
+            { _reqUrl        = Url
+                [ Segment $ Static "test" ]
+                -- Shoud this be |intX| or |listX of intX| ?
+                [ QueryArg ("params", "listX of intX") List ]
+            , _reqMethod     = "PUT"
+            , _reqHeaders    = []
+            , _reqBody       = Just "stringX"
+            , _reqReturnType = "voidX"
+            , _funcName      = ["put", "test"]
+            }
+
+    it "collects all info for delete request" $ do
+        shouldBe deleteReq $ defReq
+            { _reqUrl        = Url
+                [ Segment $ Static "test"
+                , Segment $ Cap ("id", "intX") ]
+                []
+            , _reqMethod     = "DELETE"
+            , _reqHeaders    = []
+            , _reqBody       = Nothing
+            , _reqReturnType = "voidX"
+            , _funcName      = ["delete", "test", "by", "id"]
+            }
+

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -6,6 +6,10 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE CPP                   #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances  #-}
+#endif
 
 module Servant.ForeignSpec where
 
@@ -39,7 +43,7 @@ instance HasForeignType LangX Bool where
     typeFor _ _ = "boolX"
 instance {-# Overlapping #-} HasForeignType LangX String where
     typeFor _ _ = "stringX"
-instance {-# Overlapable #-} HasForeignType LangX a => HasForeignType LangX [a] where
+instance {-# Overlappable #-} HasForeignType LangX a => HasForeignType LangX [a] where
     typeFor lang _ = "listX of " <> typeFor lang (Proxy :: Proxy a)
 
 type TestApi

--- a/servant-js/servant-js.cabal
+++ b/servant-js/servant-js.cabal
@@ -13,7 +13,7 @@ description:
   <https://github.com/haskell-servant/servant/blob/master/servant-js/CHANGELOG.md CHANGELOG>
 license:             BSD3
 license-file:        LICENSE
-author:              Alp Mestanogullari
+author:              Alp Mestanogullari, Maksymilian Owsianny
 maintainer:          alpmestan@gmail.com
 copyright:           2014 Alp Mestanogullari
 category:            Web

--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Servant.JS
@@ -122,16 +123,19 @@ import           Servant.JS.Internal
 import           Servant.JS.JQuery
 import           Servant.JS.Vanilla
 
+-- Dummy type specifying target language
+data LangJS
+
 -- | Generate the data necessary to generate javascript code
 --   for all the endpoints of an API, as ':<|>'-separated values
 --   of type 'AjaxReq'.
-javascript :: HasForeign layout => Proxy layout -> Foreign layout
-javascript p = foreignFor p defReq
+javascript :: HasForeign LangJS layout => Proxy layout -> Foreign layout
+javascript p = foreignFor (Proxy :: Proxy LangJS) p defReq
 
 -- | Directly generate all the javascript functions for your API
 --   from a 'Proxy' for your API type. You can then write it to
 --   a file or integrate it in a page, for example.
-jsForAPI :: (HasForeign api, GenerateList (Foreign api))
+jsForAPI :: (HasForeign LangJS api, GenerateList (Foreign api))
          => Proxy api -- ^ proxy for your API type
          -> JavaScriptGenerator -- ^ js code generator to use (angular, vanilla js, jquery, others)
          -> Text                -- ^ a text that you can embed in your pages or write to a file
@@ -140,7 +144,7 @@ jsForAPI p gen = gen (listFromAPI p)
 -- | Directly generate all the javascript functions for your API
 --   from a 'Proxy' for your API type using the given generator
 --   and write the resulting code to a file at the given path.
-writeJSForAPI :: (HasForeign api, GenerateList (Foreign api))
+writeJSForAPI :: (HasForeign LangJS api, GenerateList (Foreign api))
               => Proxy api -- ^ proxy for your API type
               -> JavaScriptGenerator -- ^ js code generator to use (angular, vanilla js, jquery, others)
               -> FilePath -- ^ path to the file you want to write the resulting javascript code into
@@ -148,8 +152,8 @@ writeJSForAPI :: (HasForeign api, GenerateList (Foreign api))
 writeJSForAPI p gen fp = writeFile fp (jsForAPI p gen)
 
 -- A catch all instance since JavaScript has no types.
-instance HasForeignType a where
-    typeFor _ = empty
+instance HasForeignType LangJS a where
+    typeFor _ _ = empty
 
 -- | Utility class used by 'jsForAPI' which computes
 --   the data needed to generate a function for each endpoint
@@ -165,6 +169,6 @@ instance (GenerateList start, GenerateList rest) => GenerateList (start :<|> res
 
 -- | Generate the necessary data for JS codegen as a list, each 'AjaxReq'
 --   describing one endpoint from your API type.
-listFromAPI :: (HasForeign api, GenerateList (Foreign api)) => Proxy api -> [AjaxReq]
+listFromAPI :: (HasForeign LangJS api, GenerateList (Foreign api)) => Proxy api -> [AjaxReq]
 listFromAPI p = generateList (javascript p)
 

--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -147,6 +147,10 @@ writeJSForAPI :: (HasForeign api, GenerateList (Foreign api))
               -> IO ()
 writeJSForAPI p gen fp = writeFile fp (jsForAPI p gen)
 
+-- A catch all instance since JavaScript has no types.
+instance HasForeignType a where
+    typeFor _ = empty
+
 -- | Utility class used by 'jsForAPI' which computes
 --   the data needed to generate a function for each endpoint
 --   and hands it all back in a list.

--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -110,7 +110,7 @@ module Servant.JS
   , -- * Misc.
     listFromAPI
   , javascript
-  , LangJS
+  , NoTypes
   , GenerateList(..)
   ) where
 
@@ -123,37 +123,30 @@ import           Servant.JS.Axios
 import           Servant.JS.Internal
 import           Servant.JS.JQuery
 import           Servant.JS.Vanilla
-import           Servant.Foreign (GenerateList(..), listFromAPI)
-
--- Dummy type specifying target language
-data LangJS
+import           Servant.Foreign (GenerateList(..), listFromAPI, NoTypes)
 
 -- | Generate the data necessary to generate javascript code
 --   for all the endpoints of an API, as ':<|>'-separated values
 --   of type 'AjaxReq'.
-javascript :: HasForeign LangJS layout => Proxy layout -> Foreign layout
-javascript p = foreignFor (Proxy :: Proxy LangJS) p defReq
+javascript :: HasForeign NoTypes layout => Proxy layout -> Foreign layout
+javascript p = foreignFor (Proxy :: Proxy NoTypes) p defReq
 
 -- | Directly generate all the javascript functions for your API
 --   from a 'Proxy' for your API type. You can then write it to
 --   a file or integrate it in a page, for example.
-jsForAPI :: (HasForeign LangJS api, GenerateList (Foreign api))
+jsForAPI :: (HasForeign NoTypes api, GenerateList (Foreign api))
          => Proxy api -- ^ proxy for your API type
          -> JavaScriptGenerator -- ^ js code generator to use (angular, vanilla js, jquery, others)
          -> Text                -- ^ a text that you can embed in your pages or write to a file
-jsForAPI p gen = gen (listFromAPI (Proxy :: Proxy LangJS) p)
+jsForAPI p gen = gen (listFromAPI (Proxy :: Proxy NoTypes) p)
 
 -- | Directly generate all the javascript functions for your API
 --   from a 'Proxy' for your API type using the given generator
 --   and write the resulting code to a file at the given path.
-writeJSForAPI :: (HasForeign LangJS api, GenerateList (Foreign api))
+writeJSForAPI :: (HasForeign NoTypes api, GenerateList (Foreign api))
               => Proxy api -- ^ proxy for your API type
               -> JavaScriptGenerator -- ^ js code generator to use (angular, vanilla js, jquery, others)
               -> FilePath -- ^ path to the file you want to write the resulting javascript code into
               -> IO ()
 writeJSForAPI p gen fp = writeFile fp (jsForAPI p gen)
-
--- A catch all instance since JavaScript has no types.
-instance HasForeignType LangJS a where
-    typeFor _ _ = empty
 

--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -110,6 +110,7 @@ module Servant.JS
   , -- * Misc.
     listFromAPI
   , javascript
+  , LangJS
   , GenerateList(..)
   ) where
 

--- a/servant-js/src/Servant/JS/Internal.hs
+++ b/servant-js/src/Servant/JS/Internal.hs
@@ -18,6 +18,7 @@ module Servant.JS.Internal
   , defReq
   , reqHeaders
   , HasForeign(..)
+  , HasForeignType(..)
   , HeaderArg(..)
   , concatCase
   , snakeCase
@@ -31,7 +32,7 @@ module Servant.JS.Internal
   , Header
   ) where
 
-import           Control.Lens                  ((^.))
+import           Control.Lens                  ((^.), _1)
 import qualified Data.CharSet as Set
 import qualified Data.CharSet.Unicode.Category as Set
 import           Data.Monoid
@@ -115,7 +116,7 @@ toValidFunctionName t =
                     ]
 
 toJSHeader :: HeaderArg -> Text
-toJSHeader (HeaderArg n)          = toValidFunctionName ("header" <> n)
+toJSHeader (HeaderArg n)          = toValidFunctionName ("header" <> fst n)
 toJSHeader (ReplaceHeaderArg n p)
   | pn `T.isPrefixOf` p = pv <> " + \"" <> rp <> "\""
   | pn `T.isSuffixOf` p = "\"" <> rp <> "\" + " <> pv
@@ -123,8 +124,8 @@ toJSHeader (ReplaceHeaderArg n p)
                              <> "\""
   | otherwise         = p
   where
-    pv = toValidFunctionName ("header" <> n)
-    pn = "{" <> n <> "}"
+    pv = toValidFunctionName ("header" <> fst n)
+    pn = "{" <> fst n <> "}"
     rp = T.replace pn "" p
 
 jsSegments :: [Segment] -> Text
@@ -138,7 +139,7 @@ segmentToStr (Segment st) notTheEnd =
 
 segmentTypeToStr :: SegmentType -> Text
 segmentTypeToStr (Static s) = s
-segmentTypeToStr (Cap s)    = "' + encodeURIComponent(" <> s <> ") + '"
+segmentTypeToStr (Cap s)    = "' + encodeURIComponent(" <> fst s <> ") + '"
 
 jsGParams :: Text -> [QueryArg] -> Text
 jsGParams _ []     = ""
@@ -160,4 +161,4 @@ paramToStr qarg notTheEnd =
            <> "[]=' + encodeURIComponent("
            <> name
            <> if notTheEnd then ") + '" else ")"
-  where name = qarg ^. argName
+  where name = qarg ^. argName . _1

--- a/servant-js/test/Servant/JSSpec.hs
+++ b/servant-js/test/Servant/JSSpec.hs
@@ -98,7 +98,7 @@ a `shouldNotContain` b  = shouldNotSatisfy a (T.isInfixOf b)
 
 axiosSpec :: Spec
 axiosSpec = describe specLabel $ do
-    let reqList = listFromAPI (Proxy :: Proxy LangJS) (Proxy :: Proxy TestAPI)
+    let reqList = listFromAPI (Proxy :: Proxy NoTypes) (Proxy :: Proxy TestAPI)
     it "should add withCredentials when needed" $ do
         let jsText = genJS withCredOpts $ reqList
         output jsText
@@ -122,7 +122,7 @@ axiosSpec = describe specLabel $ do
 
 angularSpec :: TestNames -> Spec
 angularSpec test = describe specLabel $ do
-    let reqList = listFromAPI (Proxy :: Proxy LangJS) (Proxy :: Proxy TestAPI)
+    let reqList = listFromAPI (Proxy :: Proxy NoTypes) (Proxy :: Proxy TestAPI)
     it "should implement a service globally" $ do
         let jsText = genJS reqList
         output jsText

--- a/servant-js/test/Servant/JSSpec.hs
+++ b/servant-js/test/Servant/JSSpec.hs
@@ -98,16 +98,17 @@ a `shouldNotContain` b  = shouldNotSatisfy a (T.isInfixOf b)
 
 axiosSpec :: Spec
 axiosSpec = describe specLabel $ do
+    let reqList = listFromAPI (Proxy :: Proxy LangJS) (Proxy :: Proxy TestAPI)
     it "should add withCredentials when needed" $ do
-        let jsText = genJS withCredOpts $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS withCredOpts $ reqList
         output jsText
         jsText `shouldContain` "withCredentials: true"
     it "should add xsrfCookieName when needed" $ do
-        let jsText = genJS cookieOpts $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS cookieOpts $ reqList
         output jsText
         jsText `shouldContain` ("xsrfCookieName: 'MyXSRFcookie'")
     it "should add withCredentials when needed" $ do
-        let jsText = genJS headerOpts $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS headerOpts $ reqList
         output jsText
         jsText `shouldContain` ("xsrfHeaderName: 'MyXSRFheader'")
     where
@@ -121,18 +122,19 @@ axiosSpec = describe specLabel $ do
 
 angularSpec :: TestNames -> Spec
 angularSpec test = describe specLabel $ do
+    let reqList = listFromAPI (Proxy :: Proxy LangJS) (Proxy :: Proxy TestAPI)
     it "should implement a service globally" $ do
-        let jsText = genJS $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS reqList
         output jsText
         jsText `shouldContain` (".service('" <> testName <> "'")
 
     it "should depend on $http service globally" $ do
-        let jsText = genJS $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS reqList
         output jsText
         jsText `shouldContain` ("('" <> testName <> "', function($http) {")
 
     it "should not depend on $http service in handlers" $ do
-        let jsText = genJS $ listFromAPI (Proxy :: Proxy TestAPI)
+        let jsText = genJS reqList
         output jsText
         jsText `shouldNotContain` "getsomething($http, "
     where

--- a/servant-js/test/Servant/JSSpec/CustomHeaders.hs
+++ b/servant-js/test/Servant/JSSpec/CustomHeaders.hs
@@ -26,7 +26,7 @@ instance (KnownSymbol sym, HasForeign sublayout)
     type Foreign (Authorization sym a :> sublayout) = Foreign sublayout
 
     foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
-        req & reqHeaders <>~ [ ReplaceHeaderArg "Authorization" $
+        req & reqHeaders <>~ [ ReplaceHeaderArg ("Authorization", "") $
                                tokenType (pack . symbolVal $ (Proxy :: Proxy sym)) ]
       where
         tokenType t = t <> " {Authorization}"
@@ -39,7 +39,7 @@ instance (HasForeign sublayout)
     type Foreign (MyLovelyHorse a :> sublayout) = Foreign sublayout
 
     foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
-        req & reqHeaders <>~ [ ReplaceHeaderArg "X-MyLovelyHorse" tpl ]
+        req & reqHeaders <>~ [ ReplaceHeaderArg ("X-MyLovelyHorse", "") tpl ]
       where
         tpl = "I am good friends with {X-MyLovelyHorse}"
 
@@ -51,6 +51,6 @@ instance (HasForeign sublayout)
     type Foreign (WhatsForDinner a :> sublayout) = Foreign sublayout
 
     foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
-        req & reqHeaders <>~ [ ReplaceHeaderArg "X-WhatsForDinner" tpl ]
+        req & reqHeaders <>~ [ ReplaceHeaderArg ("X-WhatsForDinner", "") tpl ]
       where
         tpl = "I would like {X-WhatsForDinner} with a cherry on top."

--- a/servant-js/test/Servant/JSSpec/CustomHeaders.hs
+++ b/servant-js/test/Servant/JSSpec/CustomHeaders.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Servant.JSSpec.CustomHeaders where
 
@@ -21,11 +22,11 @@ import           Servant.JS.Internal
 -- using -- Basic, Digest, whatever.
 data Authorization (sym :: Symbol) a
 
-instance (KnownSymbol sym, HasForeign sublayout)
-    => HasForeign (Authorization sym a :> sublayout) where
+instance (KnownSymbol sym, HasForeign lang sublayout)
+    => HasForeign lang (Authorization sym a :> sublayout) where
     type Foreign (Authorization sym a :> sublayout) = Foreign sublayout
 
-    foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
+    foreignFor lang Proxy req = foreignFor lang (Proxy :: Proxy sublayout) $
         req & reqHeaders <>~ [ ReplaceHeaderArg ("Authorization", "") $
                                tokenType (pack . symbolVal $ (Proxy :: Proxy sym)) ]
       where
@@ -34,11 +35,11 @@ instance (KnownSymbol sym, HasForeign sublayout)
 -- | This is a combinator that fetches an X-MyLovelyHorse header.
 data MyLovelyHorse a
 
-instance (HasForeign sublayout)
-    => HasForeign (MyLovelyHorse a :> sublayout) where
+instance (HasForeign lang sublayout)
+    => HasForeign lang (MyLovelyHorse a :> sublayout) where
     type Foreign (MyLovelyHorse a :> sublayout) = Foreign sublayout
 
-    foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
+    foreignFor lang Proxy req = foreignFor lang (Proxy :: Proxy sublayout) $
         req & reqHeaders <>~ [ ReplaceHeaderArg ("X-MyLovelyHorse", "") tpl ]
       where
         tpl = "I am good friends with {X-MyLovelyHorse}"
@@ -46,11 +47,11 @@ instance (HasForeign sublayout)
 -- | This is a combinator that fetches an X-WhatsForDinner header.
 data WhatsForDinner a
 
-instance (HasForeign sublayout)
-    => HasForeign (WhatsForDinner a :> sublayout) where
+instance (HasForeign lang sublayout)
+    => HasForeign lang (WhatsForDinner a :> sublayout) where
     type Foreign (WhatsForDinner a :> sublayout) = Foreign sublayout
 
-    foreignFor Proxy req = foreignFor (Proxy :: Proxy sublayout) $
+    foreignFor lang Proxy req = foreignFor lang (Proxy :: Proxy sublayout) $
         req & reqHeaders <>~ [ ReplaceHeaderArg ("X-WhatsForDinner", "") tpl ]
       where
         tpl = "I would like {X-WhatsForDinner} with a cherry on top."


### PR DESCRIPTION
I'm creating [C# backend](https://github.com/MaxOw/servant-sharp) to servant and need access to types. All this is basically a `HasForeignType` class and all the piping around it. Then when creating backend you just provide equivalent backend language types for all haskell types that you are interested in, by providing instances to that class. Specifically in dynamic languages you just need to provide empty, catch all, instance. 