### PR TITLE
[servant-js] README-md - Fix broken link

### DIFF
--- a/servant-js/README.md
+++ b/servant-js/README.md
@@ -9,7 +9,7 @@ vanilla (framework-free) javascript code.
 
 ## Example
 
-Read more about the following example [here](https://github.com/haskell-servant/servant/tree/master/servant-js/tree/master/examples#examples).
+Read more about the following example [here](https://github.com/haskell-servant/servant/tree/master/servant-js/examples#examples).
 
 ``` haskell
 {-# LANGUAGE DataKinds #-}


### PR DESCRIPTION
This PR fix a broken link at the [README.md](https://github.com/haskell-servant/servant/blob/master/servant-js/README.md) file.