### PR TITLE
File extensions

### DIFF
--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -35,6 +35,7 @@ import           Network.Wai.Test           (defaultRequest, request,
                                              runSession, simpleBody)
 import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
                                              Get, Header (..), Headers,
+                                             Ext(..),
                                              HttpVersion, IsSecure (..), JSON,
                                              Patch, PlainText, Post, Put,
                                              QueryFlag, QueryParam, QueryParams,
@@ -86,6 +87,7 @@ tweety = Animal "Bird" 2
 spec :: Spec
 spec = do
   captureSpec
+  captureFilenameSpec
   getSpec
   headSpec
   postSpec
@@ -127,6 +129,37 @@ captureSpec = do
             respond $ responseLBS ok200 [] (cs $ show $ pathInfo request_)))) $ do
       it "strips the captured path snippet from pathInfo" $ do
         get "/captured/foo" `shouldRespondWith` (fromString (show ["foo" :: String]))
+
+
+
+type CaptureFilenameApi = Capture "filename" (Ext "png") :> Get '[PlainText] String
+captureFilenameApi :: Proxy CaptureFilenameApi
+captureFilenameApi = Proxy
+captureFilenameServer :: Ext "png" -> ExceptT ServantErr IO String
+captureFilenameServer ext = do
+  liftIO $ print ("Png:"::String, ext)
+  return . show $ ext
+
+captureFilenameSpec :: Spec
+captureFilenameSpec = do
+  describe "Servant.API.FileExtension" $ do
+    with (return (serve captureFilenameApi captureFilenameServer)) $ do
+
+      it "can capture parts of the 'pathInfo'" $ do
+        response <- get "/foo%20bar.png"
+        liftIO $ simpleBody response `shouldBe` "\"foo bar.png\""
+
+      it "returns 404 when extension is not present" $ do
+        get "/noExt" `shouldRespondWith` 404
+
+    with (return (serve
+        (Proxy :: Proxy (Capture "captured" (Ext "png") :> Raw))
+        (\(Ext "foo") request_ respond ->
+            respond $ responseLBS ok200 [] (cs $ show $ pathInfo request_)))) $ do
+      it "strips the captured filename from pathInfo" $ do
+        get "/foo.png/foo" `shouldRespondWith` (fromString (show ["foo" :: String]))
+
+
 
 
 type GetApi = Get '[JSON] Person

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -136,9 +136,7 @@ type CaptureFilenameApi = Capture "filename" (Ext "png") :> Get '[PlainText] Str
 captureFilenameApi :: Proxy CaptureFilenameApi
 captureFilenameApi = Proxy
 captureFilenameServer :: Ext "png" -> ExceptT ServantErr IO String
-captureFilenameServer ext = do
-  liftIO $ print ("Png:"::String, ext)
-  return . show $ ext
+captureFilenameServer = return . show
 
 captureFilenameSpec :: Spec
 captureFilenameSpec = do

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -30,6 +30,7 @@ library
     Servant.API.ContentTypes
     Servant.API.Delete
     Servant.API.Get
+    Servant.API.FileExtension
     Servant.API.Header
     Servant.API.HttpVersion
     Servant.API.IsSecure

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -9,6 +9,8 @@ module Servant.API (
   -- * Accessing information from the request
   module Servant.API.Capture,
   -- | Capturing parts of the url path as parsed values: @'Capture'@
+  module Servant.API.FileExtension,
+  -- | Capture file names with a given extension
   module Servant.API.Header,
   -- | Retrieving specific headers from the request
   module Servant.API.HttpVersion,
@@ -66,6 +68,7 @@ import           Servant.API.ContentTypes    (Accept (..), FormUrlEncoded,
                                               PlainText, ToFormUrlEncoded (..))
 import           Servant.API.Delete          (Delete)
 import           Servant.API.Get             (Get)
+import           Servant.API.FileExtension   (Ext(..))
 import           Servant.API.Header          (Header (..))
 import           Servant.API.HttpVersion     (HttpVersion (..))
 import           Servant.API.IsSecure        (IsSecure (..))

--- a/servant/src/Servant/API/FileExtension.hs
+++ b/servant/src/Servant/API/FileExtension.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+module Servant.API.FileExtension
+    ( Ext(..)
+    , getExt
+    , parseExt
+    ) where
+
+import           Data.Typeable (Typeable)
+import           GHC.TypeLits  -- (Symbol)
+import           Web.HttpApiData
+import           Data.Text (Text, pack, stripSuffix)
+import           Data.Proxy
+import           Data.Maybe (catMaybes)
+import           Control.Monad ((>=>))
+
+-- | A wrapper around a time type which can be parsed/rendered to with `format',
+-- as specified in 'Data.Time.Format'.
+--
+-- Example:
+-- >>>            -- GET /file/:filename.png
+-- >>> type MyApi = "file" :> Capture "filename" (Ext "png") :> Get '[JSON] Text
+newtype Ext (ext :: Symbol) = Ext {getFileName :: Text}
+    deriving (Typeable, Eq, Ord)
+
+instance (KnownSymbol ext) => Show (Ext ext) where
+    showsPrec i tt@(Ext t) = showsPrec i (mappend t . pack $ '.':getExt tt)
+
+instance (KnownSymbol ext) => Read (Ext ext) where
+    readsPrec i str = res
+        where
+            -- res :: [(Ext ext t, String)]
+            res = catMaybes . map f . readsPrec (i+1) $ str
+
+            f :: (Text,String) -> Maybe (Ext ext,String)
+            f (t,s) = fmap (\txt -> (Ext txt,s)) $ stripSuffix (pack $ '.':ext) t
+
+            toExtTy :: [(Ext ext, String)] -> Ext ext
+            toExtTy _ = undefined
+
+            ext = getExt (toExtTy res)
+
+
+
+instance (KnownSymbol ext) => ToHttpApiData (Ext ext) where
+    toUrlPiece   = toUrlPiece   . show
+    toHeader     = toHeader     . show
+    toQueryParam = toQueryParam . show
+
+
+instance (KnownSymbol ext) => FromHttpApiData (Ext ext) where
+    parseUrlPiece   = parseUrlPiece   >=> parseExt
+    parseHeader     = parseHeader     >=> parseExt
+    parseQueryParam = parseQueryParam >=> parseExt
+
+
+toExtProxy :: Ext ext-> Proxy ext
+toExtProxy _ = Proxy
+
+getExt :: KnownSymbol ext => Ext ext -> String
+getExt t = symbolVal (toExtProxy t)
+
+parseExt :: (KnownSymbol ext) => String -> Either Text (Ext ext)
+parseExt str = res
+    where
+        res = case stripSuffix (pack ext) (pack str) of
+                Nothing -> Left . pack $ "The filename \"" ++ str ++ "\" does not end with extension \"" ++ ext ++ "\""
+                Just txt -> Right (Ext txt)
+
+        ext = '.':getExt (toExtTy res)
+
+        toExtTy :: Either Text (Ext ext) -> Ext ext
+        toExtTy _ = undefined
+
+
+
+-- $setup
+-- >>> import Servant.API
+-- >>> import Data.Aeson
+-- >>> import Data.Text
+

--- a/servant/src/Servant/API/FileExtension.hs
+++ b/servant/src/Servant/API/FileExtension.hs
@@ -50,9 +50,9 @@ instance (KnownSymbol ext) => Read (Ext ext) where
 
 
 instance (KnownSymbol ext) => ToHttpApiData (Ext ext) where
-    toUrlPiece   = toUrlPiece   . show
-    toHeader     = toHeader     . show
-    toQueryParam = toQueryParam . show
+    toUrlPiece   = toUrlPiece   . renderExt
+    toHeader     = toHeader     . renderExt
+    toQueryParam = toQueryParam . renderExt
 
 
 instance (KnownSymbol ext) => FromHttpApiData (Ext ext) where
@@ -79,6 +79,8 @@ parseExt str = res
         toExtTy :: Either Text (Ext ext) -> Ext ext
         toExtTy _ = undefined
 
+renderExt :: KnownSymbol ext => Ext ext -> Text
+renderExt ee@(Ext t) = mappend t (pack $ '.':getExt ee)
 
 
 -- $setup

--- a/servant/src/Servant/API/FileExtension.hs
+++ b/servant/src/Servant/API/FileExtension.hs
@@ -37,8 +37,7 @@ import           Data.Monoid     (mappend)
 -- >>>            -- GET /file/:filename.png
 -- >>> type MyApi = "file" :> Capture "filename" (Ext "png") :> Get '[JSON] Text
 --
--- >>> x :: Ext "png"
--- >>> x = Ext "mypic"
+-- >>> let x = Ext "mypic" :: Ext "png"
 -- >>> renderExt x
 -- "mypic.png"
 --


### PR DESCRIPTION
Adds the ability to capture `Text` file names with an extension specified in the type.

``` haskell
           -- GET /file/:filename.png
type MyApi = "file" :> Capture "filename" (Ext "json") :> Get '[JSON] Text

-- when accessing "/file/foo.json", prints:
--     foo.json
--     foo
handler :: Ext "json" -> ExceptT ServantErr IO Text
handler t@(Ext n) = return (renderExt t <> "\n" <> n)
```

We serve several server generated CSV and PNG files which currently have URLs which do not contain the file extension, which confuses some browsers, despite the correct content type.

I tried using something more generic than Text for the file name, but it proved to be not very useful - supporting a generic `From/ToHttpApiData` type only makes sense sometimes.
