### PR TITLE
Relax upper version bound for http-api-data ...

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -34,7 +34,7 @@ library
     , attoparsec
     , bytestring
     , exceptions
-    , http-api-data >= 0.1  && < 0.2
+    , http-api-data >= 0.1  && < 0.3
     , http-client
     , http-client-tls
     , http-media

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -47,7 +47,7 @@ library
       , attoparsec         >= 0.12 && < 0.14
       , bytestring         >= 0.10 && < 0.11
       , containers         >= 0.5  && < 0.6
-      , http-api-data      >= 0.1  && < 0.2
+      , http-api-data      >= 0.1  && < 0.3
       , http-types         >= 0.8  && < 0.10
       , network-uri        >= 2.6  && < 2.7
       , mtl                >= 2    && < 3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -51,7 +51,7 @@ library
     , bytestring == 0.10.*
     , bytestring-conversion == 0.3.*
     , case-insensitive >= 1.2
-    , http-api-data >= 0.1  && < 0.2
+    , http-api-data >= 0.1  && < 0.3
     , http-media >= 0.4 && < 0.7
     , http-types >= 0.8 && < 0.10
     , text >= 1 && < 2


### PR DESCRIPTION
... in order to include http-api-data-0.2.1, which is currently in LTS
Haskell (lts-3.16).