### PR TITLE
[servant-docs] Removed redundant imports.

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal/Pretty.hs
+++ b/servant-docs/src/Servant/Docs/Internal/Pretty.hs
@@ -14,8 +14,6 @@ import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Proxy               (Proxy(Proxy))
 import Network.HTTP.Media       ((//))
 import Servant.API
-import Servant.API.ContentTypes
-import Servant.Utils.Links
 
 -- | PrettyJSON content type.
 data PrettyJSON


### PR DESCRIPTION
Launching `nix-shell` with `./servant-examples/shell.nix` generated by `./scripts/generate-nix-files.sh` gives an error:
```
Building servant-docs-0.5...
Preprocessing library servant-docs-0.5...
[1 of 3] Compiling Servant.Docs.Internal.Pretty ( src/Servant/Docs/Internal/Pretty.hs, dist/build/Servant/Docs/Internal/Pretty.o )

src/Servant/Docs/Internal/Pretty.hs:17:1: Warning:
The import of ‘Servant.API.ContentTypes’ is redundant
except perhaps to import instances from ‘Servant.API.ContentTypes’
To import instances alone, use: import Servant.API.ContentTypes()

src/Servant/Docs/Internal/Pretty.hs:18:1: Warning:
The import of ‘Servant.Utils.Links’ is redundant
except perhaps to import instances from ‘Servant.Utils.Links’
To import instances alone, use: import Servant.Utils.Links()

<no location info>:
Failing due to -Werror.
```
Removing those two imports fixes this.