### PR TITLE
MimeUnrender and MimeRender instances for Cassava

### DIFF
--- a/servant-cassava/src/Servant/CSV/Cassava.hs
+++ b/servant-cassava/src/Servant/CSV/Cassava.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -16,6 +17,9 @@
 -- >>> type EgDefault = Get '[CSV] [(Int, String)]
 module Servant.CSV.Cassava where
 
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative        ((<$>))
+#endif
 import           Data.Csv
 import           Data.Proxy         (Proxy (..))
 import           Data.Typeable      (Typeable)


### PR DESCRIPTION
This allows the same API type to be used for `serve` and `client`.