### PR TITLE
server/docs: fix formatting inconsistency

### DIFF
--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -63,7 +63,7 @@ module Servant.Server
   , err415
   , err416
   , err417
-   -- * 5XX
+   -- ** 5XX
   , err500
   , err501
   , err502


### PR DESCRIPTION
Or was there a good reason for this section being different than the others?