### PR TITLE
Mega api

### DIFF
--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -203,6 +203,17 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient sublayout)
 
     where hname = symbolVal (Proxy :: Proxy sym)
 
+-- | Using a 'HttpVersion' combinator in your API doesn't affect the client
+-- functions.
+instance HasClient sublayout
+  => HasClient (HttpVersion :> sublayout) where
+
+  type Client (HttpVersion :> sublayout) =
+    Client sublayout
+
+  clientWithRoute Proxy =
+    clientWithRoute (Proxy :: Proxy sublayout)
+
 -- | If you use a 'QueryParam' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take
 -- an additional argument of the type specified by your 'QueryParam',

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -49,8 +49,11 @@ import           Test.HUnit
 import           Test.QuickCheck
 
 import           Servant.API
+import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Client
 import           Servant.Server
+
+_ = client comprehensiveAPI
 
 spec :: Spec
 spec = describe "Servant.Client" $ do

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -53,6 +53,7 @@ import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Client
 import           Servant.Server
 
+-- This declaration simply checks that all instances are in place.
 _ = client comprehensiveAPI
 
 spec :: Spec

--- a/servant-docs/.ghci
+++ b/servant-docs/.ghci
@@ -1,0 +1,1 @@
+:set -itest -isrc -Iinclude

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -18,7 +18,23 @@ import           GHC.Generics
 import           Test.Hspec
 
 import           Servant.API
+import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Docs.Internal
+
+-- * comprehensive api
+
+_ = docs comprehensiveAPI
+
+instance ToParam (QueryParam "foo" Int) where
+  toParam = error "unused"
+instance ToParam (QueryParams "foo" Int) where
+  toParam = error "unused"
+instance ToParam (QueryFlag "foo") where
+  toParam = error "unused"
+instance ToCapture (Capture "foo" Int) where
+  toCapture = error "unused"
+
+-- * specs
 
 spec :: Spec
 spec = describe "Servant.Docs" $ do

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -23,6 +23,7 @@ import           Servant.Docs.Internal
 
 -- * comprehensive api
 
+-- This declaration simply checks that all instances are in place.
 _ = docs comprehensiveAPI
 
 instance ToParam (QueryParam "foo" Int) where

--- a/servant-js/test/Servant/JSSpec.hs
+++ b/servant-js/test/Servant/JSSpec.hs
@@ -32,7 +32,8 @@ import           Servant.JSSpec.CustomHeaders
 
 -- * comprehensive api
 
-_ = (jsForAPI comprehensiveAPI vanillaJS :: Text)
+-- This declaration simply checks that all instances are in place.
+_ = jsForAPI comprehensiveAPI vanillaJS :: Text
 
 -- * specs
 

--- a/servant-js/test/Servant/JSSpec.hs
+++ b/servant-js/test/Servant/JSSpec.hs
@@ -21,6 +21,7 @@ import qualified Data.Text                    as T
 import           Language.ECMAScript3.Parser  (program, parse)
 import           Test.Hspec  hiding (shouldContain, shouldNotContain)
 
+import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.JS
 import           Servant.JS.Internal
 import qualified Servant.JS.Angular           as NG
@@ -28,6 +29,12 @@ import qualified Servant.JS.Axios             as AX
 import qualified Servant.JS.JQuery            as JQ
 import qualified Servant.JS.Vanilla           as JS
 import           Servant.JSSpec.CustomHeaders
+
+-- * comprehensive api
+
+_ = (jsForAPI comprehensiveAPI vanillaJS :: Text)
+
+-- * specs
 
 type TestAPI = "simple" :> ReqBody '[JSON,FormUrlEncoded] Text :> Post '[JSON] Bool
           :<|> "has.extension" :> Get '[FormUrlEncoded,JSON] Bool

--- a/servant-mock/.ghci
+++ b/servant-mock/.ghci
@@ -1,0 +1,1 @@
+:set -Wall -itest -isrc -optP-include -optPdist/build/autogen/cabal_macros.h -Iinclude

--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -63,4 +63,6 @@ test-suite spec
     servant,
     servant-server,
     servant-mock,
-    aeson
+    aeson,
+    bytestring-conversion,
+    wai

--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -45,3 +45,18 @@ executable mock-app
     buildable: True
   else
     buildable: False
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options:
+    -Wall -fno-warn-name-shadowing
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+    Servant.MockSpec
+  build-depends:
+    base,
+    hspec,
+    servant,
+    servant-mock

--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -58,5 +58,9 @@ test-suite spec
   build-depends:
     base,
     hspec,
+    hspec-wai,
+    QuickCheck,
     servant,
-    servant-mock
+    servant-server,
+    servant-mock,
+    aeson

--- a/servant-mock/src/Servant/Mock.hs
+++ b/servant-mock/src/Servant/Mock.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
+#include "overlapping-compat.h"
+
 -- |
 -- Module     : Servant.Mock
 -- Copyright  : 2015 Alp Mestanogullari
@@ -144,6 +147,12 @@ instance (Arbitrary a, KnownNat status, ReflectMethod method, AllCTRender ctypes
     => HasMock (Verb method status ctypes a) where
   mock _ = mockArbitrary
 
+instance OVERLAPPING_
+    (GetHeaders (Headers headerTypes a), Arbitrary (HList headerTypes),
+     Arbitrary a, KnownNat status, ReflectMethod method, AllCTRender ctypes a)
+    => HasMock (Verb method status ctypes (Headers headerTypes a)) where
+  mock _ = mockArbitrary
+
 instance HasMock Raw where
   mock _ = \_req respond -> do
     bdy <- genBody
@@ -165,5 +174,3 @@ instance Arbitrary (HList '[]) where
 instance (Arbitrary a, Arbitrary (HList hs))
       => Arbitrary (HList (Header h a ': hs)) where
   arbitrary = HCons <$> fmap Header arbitrary <*> arbitrary
-
-

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -20,6 +20,7 @@ import           Servant
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Mock
 
+-- This declaration simply checks that all instances are in place.
 _ = mock comprehensiveAPI
 
 data Body

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -1,0 +1,12 @@
+
+module Servant.MockSpec where
+
+import           Test.Hspec
+
+import           Servant.API.Internal.Test.ComprehensiveAPI
+import           Servant.Mock
+
+_ = mock comprehensiveAPI
+
+spec :: Spec
+spec = return ()

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -1,12 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Servant.MockSpec where
 
-import           Test.Hspec
+import           Data.Aeson as Aeson
+import           Data.Proxy
+import           GHC.Generics
+import           Servant.API
+import           Test.Hspec hiding (pending)
+import           Test.Hspec.Wai
+import           Test.QuickCheck
 
+import           Servant
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Mock
 
 _ = mock comprehensiveAPI
 
+data Body
+  = Body
+  | ArbitraryBody
+  deriving (Generic, ToJSON)
+
+instance Arbitrary Body where
+  arbitrary = return ArbitraryBody
+
 spec :: Spec
-spec = return ()
+spec = do
+  describe "mock" $ do
+    context "Get" $ do
+      let api :: Proxy (Get '[JSON] Body)
+          api = Proxy
+          app = serve api (mock api)
+      with (return app) $ do
+        it "serves arbitrary response bodies" $ do
+          get "/" `shouldRespondWith` 200{
+            matchBody = Just $ Aeson.encode ArbitraryBody
+          }

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
@@ -7,8 +6,11 @@
 module Servant.MockSpec where
 
 import           Data.Aeson as Aeson
+import           Data.ByteString.Conversion.To
 import           Data.Proxy
+import           Data.String
 import           GHC.Generics
+import           Network.Wai
 import           Servant.API
 import           Test.Hspec hiding (pending)
 import           Test.Hspec.Wai
@@ -23,10 +25,23 @@ _ = mock comprehensiveAPI
 data Body
   = Body
   | ArbitraryBody
-  deriving (Generic, ToJSON)
+  deriving (Generic)
+
+instance ToJSON Body
 
 instance Arbitrary Body where
   arbitrary = return ArbitraryBody
+
+data TestHeader
+  = TestHeader
+  | ArbitraryHeader
+  deriving (Show)
+
+instance ToByteString TestHeader where
+  builder = fromString . show
+
+instance Arbitrary TestHeader where
+  arbitrary = return ArbitraryHeader
 
 spec :: Spec
 spec = do
@@ -39,4 +54,29 @@ spec = do
         it "serves arbitrary response bodies" $ do
           get "/" `shouldRespondWith` 200{
             matchBody = Just $ Aeson.encode ArbitraryBody
+          }
+
+    context "response headers" $ do
+      let withHeader :: Proxy (Get '[JSON] (Headers '[Header "foo" TestHeader] Body))
+          withHeader = Proxy
+          withoutHeader :: Proxy (Get '[JSON] (Headers '[] Body))
+          withoutHeader = Proxy
+          toApp :: HasMock api => Proxy api -> IO Application
+          toApp api = return $ serve api (mock api)
+      with (toApp withHeader) $ do
+        it "serves arbitrary response bodies" $ do
+          get "/" `shouldRespondWith` 200{
+            matchHeaders = return $ MatchHeader $ \ h ->
+             if h == [("Content-Type", "application/json"), ("foo", "ArbitraryHeader")]
+                then Nothing
+                else Just ("headers not correct\n")
+          }
+
+      with (toApp withoutHeader) $ do
+        it "works for no additional headers" $ do
+          get "/" `shouldRespondWith` 200{
+            matchHeaders = return $ MatchHeader $ \ h ->
+             if h == [("Content-Type", "application/json")]
+                then Nothing
+                else Just ("headers not correct\n")
           }

--- a/servant-mock/test/Spec.hs
+++ b/servant-mock/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -46,6 +46,7 @@ import           Servant.API                ((:<|>) (..), (:>), Capture, Delete,
                                              QueryFlag, QueryParam, QueryParams,
                                              Raw, RemoteHost, ReqBody,
                                              StdMethod (..), Verb, addHeader)
+import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Server             (ServantErr (..), Server, err404,
                                              serve)
 import           Test.Hspec                 (Spec, context, describe, it,
@@ -60,6 +61,9 @@ import           Servant.Server.Internal.Router
                                             (tweakResponse, runRouter,
                                              Router, Router'(LeafRouter))
 
+-- * comprehensive api test
+
+_ = serve comprehensiveAPI (error "unused") (error "unused")
 
 -- * Specs
 

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -63,7 +63,8 @@ import           Servant.Server.Internal.Router
 
 -- * comprehensive api test
 
-_ = serve comprehensiveAPI (error "unused") (error "unused")
+-- This declaration simply checks that all instances are in place.
+_ = serve comprehensiveAPI
 
 -- * Specs
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -31,6 +31,7 @@ library
     Servant.API.ContentTypes
     Servant.API.Header
     Servant.API.HttpVersion
+    Servant.API.Internal.Test.ComprehensiveAPI
     Servant.API.IsSecure
     Servant.API.QueryParam
     Servant.API.Raw

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -14,7 +14,7 @@ type ComprehensiveAPI =
   Get '[JSON] Int :<|>
   Capture "foo" Int :> GET :<|>
   Header "foo" Int :> GET :<|>
--- HttpVersion :> GET :<|>
+  HttpVersion :> GET :<|>
   IsSecure :> GET :<|>
   QueryParam "foo" Int :> GET :<|>
   QueryParams "foo" Int :> GET :<|>

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -20,7 +20,7 @@ type ComprehensiveAPI =
   QueryParams "foo" Int :> GET :<|>
   QueryFlag "foo" :> GET :<|>
 -- Raw :<|>
--- RemoteHost :<|>
+  RemoteHost :> GET :<|>
   ReqBody '[JSON] Int :> GET :<|>
 -- Get '[JSON] (Headers '[Header "foo" Int] ()) :<|>
   "foo" :> GET :<|>

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Servant.API.Internal.Test.ComprehensiveAPI where
+
+import           Data.Proxy
+
+import           Servant.API
+
+type GET = Get '[JSON] ()
+
+type ComprehensiveAPI =
+  GET :<|>
+  Get '[JSON] Int :<|>
+  Capture "foo" Int :> GET :<|>
+  Header "foo" Int :> GET :<|>
+-- HttpVersion :> GET :<|>
+  IsSecure :> GET :<|>
+  QueryParam "foo" Int :> GET :<|>
+  QueryParams "foo" Int :> GET :<|>
+  QueryFlag "foo" :> GET :<|>
+-- Raw :<|>
+-- RemoteHost :<|>
+  ReqBody '[JSON] Int :> GET :<|>
+-- Get '[JSON] (Headers '[Header "foo" Int] ()) :<|>
+  "foo" :> GET :<|>
+  Vault :> GET :<|>
+  Verb 'POST 204 '[JSON] () :<|>
+  Verb 'POST 204 '[JSON] Int
+
+comprehensiveAPI :: Proxy ComprehensiveAPI
+comprehensiveAPI = Proxy

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- | This is a module containing an API with all `Servant.API` combinators. It
+-- is used for testing only (in particular, checking that instances exist for
+-- the core servant classes for each combinator), and should not be imported.
 module Servant.API.Internal.Test.ComprehensiveAPI where
 
 import           Data.Proxy

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -22,7 +22,7 @@ type ComprehensiveAPI =
 -- Raw :<|>
   RemoteHost :> GET :<|>
   ReqBody '[JSON] Int :> GET :<|>
--- Get '[JSON] (Headers '[Header "foo" Int] ()) :<|>
+  Get '[JSON] (Headers '[Header "foo" Int] ()) :<|>
   "foo" :> GET :<|>
   Vault :> GET :<|>
   Verb 'POST 204 '[JSON] () :<|>


### PR DESCRIPTION
This PR adds tests that we have instances for all core interpretations and all core combinators.

Can someone who knows more about `servant-foreign` and `servant-js` help with the instances for `Raw`, please? `servant-js` fails for `Raw`. That would be awesome. (Uncomment this line and fix the errors: https://github.com/haskell-servant/servant/blob/mega-api/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs#L22) (cc: @jkarni @MaxOw @arianvp @dredozubov)