### PR TITLE
Allow IO when unrendering content types

### DIFF
--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -186,7 +186,8 @@ performRequestCT ct reqMethod req manager reqHost = do
   (_status, respBody, respCT, hdrs, _response) <-
     performRequest reqMethod (req { reqAccept = [acceptCT] }) manager reqHost
   unless (matches respCT (acceptCT)) $ throwE $ UnsupportedContentType respCT respBody
-  case mimeUnrender ct respBody of
+  unrenderResult <- liftIO . runExceptT $ mimeUnrender ct respBody
+  case unrenderResult of
     Left err -> throwE $ DecodeFailure err respCT respBody
     Right val -> return (hdrs, val)
 

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -266,7 +266,7 @@ errorChoiceSpec = describe "Multiple handlers return errors"
 -- * Instances {{{
 
 instance MimeUnrender PlainText Int where
-    mimeUnrender _ x = maybe (Left "no parse") Right (readMay $ BCL.unpack x)
+    mimeUnrender _ x = maybe (throwE "no parse") return (readMay $ BCL.unpack x)
 
 instance MimeRender PlainText Int where
     mimeRender _ = BCL.pack . show

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -109,6 +109,7 @@ test-suite spec
     , attoparsec
     , bytestring
     , hspec == 2.*
+    , mtl >= 2 && < 3
     , QuickCheck
     , quickcheck-instances
     , servant


### PR DESCRIPTION
This makes path to `multipart/form-data` content type, as mentioned in https://github.com/haskell-servant/servant/issues/133#issuecomment-151204917.
