### PR TITLE
Make servant-foreign code nicer

### DIFF
--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -1,36 +1,50 @@
 -- | Generalizes all the data needed to make code generation work with
 -- arbitrary programming languages.
 module Servant.Foreign
-  ( HasForeign(..)
-  , HasForeignType(..)
+  ( ArgType(..)
+  , HeaderArg(..)
+  , QueryArg(..)
+  , Req(..)
   , Segment(..)
   , SegmentType(..)
+  , Url(..)
+    -- aliases
+  , Path
+  , ForeignType
+  , Arg
   , FunctionName
-  , QueryArg(..)
-  , HeaderArg(..)
-  , ArgType(..)
-  , Req
+    -- lenses
+  , reqUrl
+  , reqMethod
+  , reqHeaders
+  , reqBody
+  , reqReturnType
+  , reqFuncName
+  , path
+  , queryStr
+  , argName
+  , argType
+    -- prisms
+  , _HeaderArg
+  , _ReplaceHeaderArg
+  , _Static
+  , _Cap
+  , _Normal
+  , _Flag
+  , _List
+    -- rest of it
+  , HasForeign(..)
+  , HasForeignType(..)
+  , HasNoForeignType
+  , GenerateList(..)
+  , NoTypes
   , captureArg
-  , defReq
+  , isCapture
   , concatCase
   , snakeCase
   , camelCase
-  -- lenses
-  , argType
-  , argName
-  , isCapture
-  , funcName
-  , path
-  , reqUrl
-  , reqBody
-  , reqHeaders
-  , reqMethod
-  , reqReturnType
-  , segment
-  , queryStr
+  , defReq
   , listFromAPI
-  , GenerateList(..)
-  , NoTypes
   -- re-exports
   , module Servant.API
   ) where

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -15,7 +15,6 @@ module Servant.ForeignSpec where
 import Data.Monoid ((<>))
 import Data.Proxy
 import Servant.Foreign
-import Servant.Foreign.Internal
 
 import Test.Hspec
 
@@ -35,15 +34,19 @@ camelCaseSpec = describe "camelCase" $ do
 data LangX
 
 instance HasForeignType LangX () where
-    typeFor _ _ = "voidX"
+  typeFor _ _ = "voidX"
+
 instance HasForeignType LangX Int where
-    typeFor _ _ = "intX"
+  typeFor _ _ = "intX"
+
 instance HasForeignType LangX Bool where
-    typeFor _ _ = "boolX"
+  typeFor _ _ = "boolX"
+
 instance OVERLAPPING_ HasForeignType LangX String where
-    typeFor _ _ = "stringX"
+  typeFor _ _ = "stringX"
+
 instance OVERLAPPABLE_ HasForeignType LangX a => HasForeignType LangX [a] where
-    typeFor lang _ = "listX of " <> typeFor lang (Proxy :: Proxy a)
+  typeFor lang _ = "listX of " <> typeFor lang (Proxy :: Proxy a)
 
 type TestApi
     = "test" :> Header "header" [String] :> QueryFlag "flag" :> Get '[JSON] Int
@@ -56,58 +59,57 @@ testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy TestApi)
 
 listFromAPISpec :: Spec
 listFromAPISpec = describe "listFromAPI" $ do
-    it "generates 4 endpoints for TestApi" $ do
-        length testApi `shouldBe` 4
+  it "generates 4 endpoints for TestApi" $ do
+    length testApi `shouldBe` 4
 
-    let [getReq, postReq, putReq, deleteReq] = testApi
+  let [getReq, postReq, putReq, deleteReq] = testApi
 
-    it "collects all info for get request" $ do
-        shouldBe getReq $ defReq
-            { _reqUrl        = Url
-                [ Segment $ Static "test" ]
-                [ QueryArg ("flag", "boolX") Flag ]
-            , _reqMethod     = "GET"
-            , _reqHeaders    = [HeaderArg ("header", "listX of stringX")]
-            , _reqBody       = Nothing
-            , _reqReturnType = "intX"
-            , _funcName      = ["get", "test"]
-            }
+  it "collects all info for get request" $ do
+    shouldBe getReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test" ]
+          [ QueryArg ("flag", "boolX") Flag ]
+      , _reqMethod     = "GET"
+      , _reqHeaders    = [HeaderArg ("header", "listX of stringX")]
+      , _reqBody       = Nothing
+      , _reqReturnType = "intX"
+      , _reqFuncName      = ["get", "test"]
+      }
 
-    it "collects all info for post request" $ do
-        shouldBe postReq $ defReq
-            { _reqUrl        = Url
-                [ Segment $ Static "test" ]
-                [ QueryArg ("param", "intX") Normal ]
-            , _reqMethod     = "POST"
-            , _reqHeaders    = []
-            , _reqBody       = Just "listX of stringX"
-            , _reqReturnType = "voidX"
-            , _funcName      = ["post", "test"]
-            }
+  it "collects all info for post request" $ do
+    shouldBe postReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test" ]
+          [ QueryArg ("param", "intX") Normal ]
+      , _reqMethod     = "POST"
+      , _reqHeaders    = []
+      , _reqBody       = Just "listX of stringX"
+      , _reqReturnType = "voidX"
+      , _reqFuncName      = ["post", "test"]
+      }
 
-    it "collects all info for put request" $ do
-        shouldBe putReq $ defReq
-            { _reqUrl        = Url
-                [ Segment $ Static "test" ]
-                -- Shoud this be |intX| or |listX of intX| ?
-                [ QueryArg ("params", "listX of intX") List ]
-            , _reqMethod     = "PUT"
-            , _reqHeaders    = []
-            , _reqBody       = Just "stringX"
-            , _reqReturnType = "voidX"
-            , _funcName      = ["put", "test"]
-            }
+  it "collects all info for put request" $ do
+    shouldBe putReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test" ]
+          -- Shoud this be |intX| or |listX of intX| ?
+          [ QueryArg ("params", "listX of intX") List ]
+      , _reqMethod     = "PUT"
+      , _reqHeaders    = []
+      , _reqBody       = Just "stringX"
+      , _reqReturnType = "voidX"
+      , _reqFuncName      = ["put", "test"]
+      }
 
-    it "collects all info for delete request" $ do
-        shouldBe deleteReq $ defReq
-            { _reqUrl        = Url
-                [ Segment $ Static "test"
-                , Segment $ Cap ("id", "intX") ]
-                []
-            , _reqMethod     = "DELETE"
-            , _reqHeaders    = []
-            , _reqBody       = Nothing
-            , _reqReturnType = "voidX"
-            , _funcName      = ["delete", "test", "by", "id"]
-            }
-
+  it "collects all info for delete request" $ do
+    shouldBe deleteReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test"
+          , Segment $ Cap ("id", "intX") ]
+          []
+      , _reqMethod     = "DELETE"
+      , _reqHeaders    = []
+      , _reqBody       = Nothing
+      , _reqReturnType = "voidX"
+      , _reqFuncName      = ["delete", "test", "by", "id"]
+      }

--- a/servant-js/src/Servant/JS/Angular.hs
+++ b/servant-js/src/Servant/JS/Angular.hs
@@ -128,7 +128,7 @@ generateAngularJSWith ngOptions opts req = "\n" <>
 
         fsep = if hasService then ":" else " ="
 
-        fname = namespace <> (functionNameBuilder opts $ req ^. funcName)
+        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/servant-js/src/Servant/JS/Axios.hs
+++ b/servant-js/src/Servant/JS/Axios.hs
@@ -116,7 +116,7 @@ generateAxiosJSWith aopts opts req = "\n" <>
                where
                   hasNoModule = moduleName opts == ""
 
-        fname = namespace <> (functionNameBuilder opts $ req ^. funcName)
+        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
 
         method = T.toLower . decodeUtf8 $ req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/servant-js/src/Servant/JS/Internal.hs
+++ b/servant-js/src/Servant/JS/Internal.hs
@@ -51,12 +51,19 @@ type JavaScriptGenerator = [Req] -> Text
 -- customize the output
 data CommonGeneratorOptions = CommonGeneratorOptions
   {
-    functionNameBuilder :: FunctionName -> Text  -- ^ function generating function names
-  , requestBody :: Text                -- ^ name used when a user want to send the request body (to let you redefine it)
-  , successCallback :: Text            -- ^ name of the callback parameter when the request was successful
-  , errorCallback :: Text              -- ^ name of the callback parameter when the request reported an error
-  , moduleName :: Text                 -- ^ namespace on which we define the foreign function (empty mean local var)
-  , urlPrefix :: Text                  -- ^ a prefix we should add to the Url in the codegen
+    functionNameBuilder :: FunctionName -> Text
+    -- ^ function generating function names
+  , requestBody :: Text
+    -- ^ name used when a user want to send the request body
+    -- (to let you redefine it)
+  , successCallback :: Text
+    -- ^ name of the callback parameter when the request was successful
+  , errorCallback :: Text
+    -- ^ name of the callback parameter when the request reported an error
+  , moduleName :: Text
+    -- ^ namespace on which we define the foreign function (empty mean local var)
+  , urlPrefix :: Text
+    -- ^ a prefix we should add to the Url in the codegen
   }
 
 -- | Default options.

--- a/servant-js/src/Servant/JS/JQuery.hs
+++ b/servant-js/src/Servant/JS/JQuery.hs
@@ -81,7 +81,7 @@ generateJQueryJSWith opts req = "\n" <>
         namespace = if (moduleName opts) == ""
                        then "var "
                        else (moduleName opts) <> "."
-        fname = namespace <> (functionNameBuilder opts $ req ^. funcName)
+        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/servant-js/src/Servant/JS/Vanilla.hs
+++ b/servant-js/src/Servant/JS/Vanilla.hs
@@ -93,7 +93,7 @@ generateVanillaJSWith opts req = "\n" <>
         namespace = if moduleName opts == ""
                        then "var "
                        else (moduleName opts) <> "."
-        fname = namespace <> (functionNameBuilder opts $ req ^. funcName)
+        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'


### PR DESCRIPTION
I felt like i have to do this before addressing a few other issues with servant-foreign

Basically it's:
* non-messy imports
* got rid of most long lines (>80 chars)
* prisms for sum types and newtypes(we use lens anyway, so why not)
* consistent indentation

Also i made some changes to demonstrate my point from https://github.com/haskell-servant/servant/pull/345#issuecomment-182807730

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/haskell-servant/servant/372)
<!-- Reviewable:end -->
