### PR TITLE
Compatibility with GHC 8.0

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -62,7 +62,7 @@ library
       , system-filepath    >= 0.4  && < 0.5
       , filepath           >= 1
       , text               >= 1.2  && < 1.3
-      , transformers       >= 0.3  && < 0.5
+      , transformers       >= 0.3  && < 0.6
       , transformers-compat>= 0.4
       , wai                >= 3.0  && < 3.3
       , wai-app-static     >= 3.0  && < 3.2

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -170,7 +170,7 @@ class (AllMime list) => AllCTRender (list :: [*]) a where
     handleAcceptH :: Proxy list -> AcceptHeader -> a -> Maybe (ByteString, ByteString)
 
 instance OVERLAPPABLE_
-         (AllMimeRender (ct ': cts) a) => AllCTRender (ct ': cts) a where
+         (Accept ct, AllMime cts, AllMimeRender (ct ': cts) a) => AllCTRender (ct ': cts) a where
     handleAcceptH _ (AcceptHeader accept) val = M.mapAcceptMedia lkup accept
       where pctyps = Proxy :: Proxy (ct ': cts)
             amrs = allMimeRender pctyps val


### PR DESCRIPTION
This builds with the current state of the `ghc-8.0` branch.

I'm not entirely certain about the `ContentTypes` change. Someone more familiar with this code should have a closer look before merging.