### PR TITLE
change a dependency and delete EmptyConfig

### DIFF
--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -29,7 +29,7 @@ import Prelude.Compat
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
-import Data.Aeson
+import Data.Aeson.Compat
 import Data.Aeson.Types
 import Data.Attoparsec.ByteString
 import Data.ByteString (ByteString)
@@ -139,7 +139,7 @@ userAPI = Proxy
 -- which you can think of as an "abstract" web application,
 -- not yet a webserver.
 app1 :: Application
-app1 = serve userAPI EmptyConfig server1
+app1 = serve userAPI server1
 ```
 
 The `userAPI` bit is, alas, boilerplate (we need it to guide type inference).

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -24,7 +24,8 @@ library
   build-depends:       base == 4.*
                      , base-compat
                      , text
-                     , aeson >= 0.11
+                     , aeson
+                     , aeson-compat 
                      , blaze-html
                      , directory
                      , blaze-markup


### PR DESCRIPTION
I change aeson to aeson-compat because Stack has still 0.9 in the repo.
With this change the tutorial will run without problems.

Second change I made is because I saw a error message. See my remarks on the bug report. 
According to fizruk on irc , servant puts automatical EmptyConfig so we do not have to add this ourself.

With these changes the first example part compiles and runs well on my box 