### PR TITLE
Add link to old tutorial (0.4)

### DIFF
--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -3,6 +3,11 @@ Tutorial
 
 This is an introductory tutorial to **servant**.
 
+.. note::
+   This tutorial is for the latest version of servant.  The tutorial for
+   servant-0.4 can be viewed
+   `here <https://haskell-servant.github.io/tutorial/>`_.
+
 (Any comments, issues or feedback about the tutorial can be handled
 through
 `servant's issue tracker <http://github.com/haskell-servant/servant/issues>`_.)


### PR DESCRIPTION
I've added a "note" to the tutorial page - it looks like this: https://i.imgur.com/4iNGWWs.png