### PR TITLE
cabal: decrease upper bound for base to disallow ghc-8

### DIFF
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -46,7 +46,7 @@ library
     Servant.API.WithNamedContext
     Servant.Utils.Links
   build-depends:
-      base >=4.7 && <5
+      base >= 4.7 && < 4.9
     , base-compat >= 0.9
     , aeson >= 0.7
     , attoparsec >= 0.12


### PR DESCRIPTION
Since `servant` currently doesn't compile with `ghc-8`.

Changing this in `servant` should be enough, since every package in here depends on it.

CC: @phadej