### PR TITLE
Re-export `throwError` from module `Servant`

### DIFF
--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+HEAD
+----
+
+* Export `throwError` from module `Servant`
+
 0.5
 ----
 

--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 HEAD
 ----
 
-* Export `throwError` from module `Servant`
+* Use `throwError` instead of `throwE` in documentation
 
 0.5
 ----

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+HEAD
+----
+
+* Export `throwError` from module `Servant`
+
 0.6
 ---
 

--- a/servant-server/src/Servant.hs
+++ b/servant-server/src/Servant.hs
@@ -10,8 +10,10 @@ module Servant (
   module Servant.Utils.StaticFiles,
   -- | Useful re-exports
   Proxy(..),
+  throwError
   ) where
 
+import           Control.Monad.Error.Class (throwError)
 import           Data.Proxy
 import           Servant.API
 import           Servant.Server

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -1,8 +1,3 @@
-HEAD
-----
-
-* Export `throwError` from module `Servant`
-
 0.5
 ----
 

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -1,3 +1,8 @@
+HEAD
+----
+
+* Export `throwError` from module `Servant`
+
 0.5
 ----
 


### PR DESCRIPTION
Fixes #442