### PR TITLE
Add missing changelogs and readme

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -15,11 +15,14 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
 category:            Web
 build-type:          Simple
-extra-source-files:  include/*.h
 cabal-version:       >=1.10
 tested-with:         GHC >= 7.8
 homepage:            http://haskell-servant.github.io/
 Bug-reports:         http://github.com/haskell-servant/servant/issues
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
 source-repository head
   type: git
   location: http://github.com/haskell-servant/servant.git

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -16,9 +16,11 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
 category:            Web
 build-type:          Simple
-extra-source-files:  include/*.h
 cabal-version:       >=1.10
 tested-with:         GHC >= 7.8
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
 source-repository head
   type: git
   location: http://github.com/haskell-servant/servant.git


### PR DESCRIPTION
Add missing changelogs and readme to cabal in `servant`, `servant-client` for hackage to display.