### PR TITLE
Fix doctests failure when testpack or checkers are installed

### DIFF
--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Servant.API.ContentTypesSpec where
@@ -28,7 +29,7 @@ import           GHC.Generics
 import           Network.URL               (exportParams, importParams)
 import           Test.Hspec
 import           Test.QuickCheck
-import           Test.QuickCheck.Instances ()
+import "quickcheck-instances" Test.QuickCheck.Instances ()
 
 import           Servant.API.ContentTypes
 


### PR DESCRIPTION
Test fails as:
  Test suite doctests: RUNNING...

  test/Servant/API/ContentTypesSpec.hs:31:18:
    Ambiguous module name `Test.QuickCheck.Instances':
      it was found in multiple packages:
      checkers-0.4.4@check_A5bAKHstANbBRqwFoOaIKx testpack-2.1.3.0@testp_BjTqfpWNTOG5Lwlc3iqqG9 quickcheck-instances-0.3.12@quick_3Tkh09kYN8p78zxMKFPcZI
  Test suite doctests: FAIL

Fixed by importing 'Test.QuickCheck.Instances' from "quickcheck-instances".

Signed-off-by: Sergei Trofimovich <siarheit@google.com>