### PR TITLE
Relocate Enter to `servant` package

### DIFF
--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -43,6 +43,7 @@ import           Servant.Client.Experimental.Auth
 import           Servant.Common.BaseUrl
 import           Servant.Common.BasicAuth
 import           Servant.Common.Req
+import           Servant.Utils.Enter
 
 -- * Accessing APIs as a Client
 

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -43,7 +43,6 @@ import           Servant.Client.Experimental.Auth
 import           Servant.Common.BaseUrl
 import           Servant.Common.BasicAuth
 import           Servant.Common.Req
-import           Servant.Utils.Enter
 
 -- * Accessing APIs as a Client
 

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.1
+------
+
+* Remove module `Servant.Server.Internal.Enter` (https://github.com/haskell-servant/servant/pull/478)
+
 0.7
 ---
 

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -40,7 +40,6 @@ library
     Servant.Server.Internal
     Servant.Server.Internal.BasicAuth
     Servant.Server.Internal.Context
-    Servant.Server.Internal.Enter
     Servant.Server.Internal.Router
     Servant.Server.Internal.RoutingApplication
     Servant.Server.Internal.ServantErr
@@ -101,7 +100,6 @@ test-suite spec
   other-modules:
       Servant.Server.ErrorSpec
       Servant.Server.Internal.ContextSpec
-      Servant.Server.Internal.EnterSpec
       Servant.ServerSpec
       Servant.Server.UsingContextSpec
       Servant.Server.UsingContextSpec.TestCombinators

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -56,7 +56,6 @@ library
       , http-types         >= 0.8  && < 0.10
       , network-uri        >= 2.6  && < 2.7
       , mtl                >= 2    && < 3
-      , mmorph             >= 1
       , network            >= 2.6  && < 2.7
       , safe               >= 0.3  && < 0.4
       , servant            == 0.7.*

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -101,7 +101,7 @@ import           Data.Proxy                    (Proxy)
 import           Data.Text                     (Text)
 import           Network.Wai                   (Application)
 import           Servant.Server.Internal
-import           Servant.Server.Internal.Enter
+import           Servant.Utils.Enter
 
 
 -- * Implementing Servers

--- a/servant-server/src/Servant/Server/Internal/Context.hs
+++ b/servant-server/src/Servant/Server/Internal/Context.hs
@@ -18,7 +18,7 @@ import           GHC.TypeLits
 -- | 'Context's are used to pass values to combinators. (They are __not__ meant
 -- to be used to pass parameters to your handlers, i.e. they should not replace
 -- any custom 'Control.Monad.Trans.Reader.ReaderT'-monad-stack that you're using
--- with 'Servant.Server.Internal.Enter.enter'.) If you don't use combinators that
+-- with 'Servant.Utils.Enter'.) If you don't use combinators that
 -- require any context entries, you can just use 'Servant.Server.serve' as always.
 --
 -- If you are using combinators that require a non-empty 'Context' you have to

--- a/servant-server/test/Servant/ArbitraryMonadServerSpec.hs
+++ b/servant-server/test/Servant/ArbitraryMonadServerSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators     #-}
-module Servant.Server.Internal.EnterSpec where
+module Servant.ArbitraryMonadServerSpec where
 
 import qualified Control.Category           as C
 import           Control.Monad.Reader

--- a/servant-server/test/Servant/ArbitraryMonadServerSpec.hs
+++ b/servant-server/test/Servant/ArbitraryMonadServerSpec.hs
@@ -14,7 +14,7 @@ import           Test.Hspec.Wai             (get, matchStatus, post,
                                              shouldRespondWith, with)
 
 spec :: Spec
-spec = describe "module Servant.Server.Enter" $ do
+spec = describe "Arbitrary monad server" $ do
     enterSpec
 
 type ReaderAPI = "int" :> Get '[JSON] Int

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.1
+------
+
+* Add module `Servant.Utils.Enter` (https://github.com/haskell-servant/servant/pull/478)
+
 0.5
 ----
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -47,6 +47,7 @@ library
     Servant.API.Verbs
     Servant.API.WithNamedContext
     Servant.Utils.Links
+    Servant.Utils.Enter
   build-depends:
       base >= 4.7 && < 4.9
     , base-compat >= 0.9
@@ -58,6 +59,8 @@ library
     , http-api-data >= 0.1  && < 0.3
     , http-media >= 0.4 && < 0.7
     , http-types >= 0.8 && < 0.10
+    , mtl >= 2 && < 3
+    , mmorph >= 1
     , text >= 1 && < 2
     , string-conversions >= 0.3 && < 0.5
     , network-uri >= 2.6

--- a/servant/src/Servant/Utils/Enter.hs
+++ b/servant/src/Servant/Utils/Enter.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
-module Servant.Server.Internal.Enter where
+module Servant.Utils.Enter where
 
 import qualified Control.Category            as C
 #if MIN_VERSION_mtl(2,2,1)


### PR DESCRIPTION
@soenkehahn and I were pairing on implementing `staticClient` function which will allow providing `BaseUrl` (or any argument in general) statically. After considering a few approaches we realised that `Enter` is already capable of achieving that (with an additional instance). Hence we decided to move `Enter` to `servant` package so that we could use it in `servant-client` without depending on `servant-server`. 

Please let us know your thoughts.