### PR TITLE
Make servant-mock bounds match the other packages.

### DIFF
--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -27,8 +27,8 @@ library
     base >=4.7 && <5,
     bytestring >= 0.10 && <0.11,
     http-types >= 0.8 && <0.10,
-    servant >= 0.4,
-    servant-server >= 0.4,
+    servant == 0.7.*,
+    servant-server == 0.7.*,
     transformers >= 0.3 && <0.5,
     QuickCheck >= 2.7 && <2.9,
     wai >= 3.0 && <3.3


### PR DESCRIPTION
    This is causing build failures for some.