### PR TITLE
Dry build with stack, to test that yaml files are valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 language: c
 
 env:
-  - GHCVER=7.8.4 CABALVER=1.22
-  - GHCVER=7.10.3 CABALVER=1.22
+  - GHCVER=7.8.4 CABALVER=1.22 STACK_YAML=stack-ghc-7.8.4.yaml
+  - GHCVER=7.10.3 CABALVER=1.22 STACK_YAML=stack.yaml
   - GHCVER=8.0.1 CABALVER=1.24
 
 addons:
@@ -20,10 +20,13 @@ addons:
       - libgmp-dev
 
 install:
-  - (mkdir -p $HOME/.local/bin && cd $HOME/.local/bin && wget https://zalora-public.s3.amazonaws.com/tinc && chmod +x tinc)
+  - mkdir -p $HOME/.local/bin
+  - (cd $HOME/.local/bin && wget https://zalora-public.s3.amazonaws.com/tinc && chmod +x tinc)
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
   - ghc --version
   - cabal --version
+  - stack --version
   - travis_retry cabal update
   - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - base-compat-0.9.0
 - engine-io-wai-1.0.2
 - control-monad-omega-0.3.1
-- should-not-typecheck-2.0.1
+- should-not-typecheck-2.1.0
 - markdown-unlit-0.4.0
 - aeson-0.11.0.0
 - fail-4.9.0.0

--- a/travis.sh
+++ b/travis.sh
@@ -2,6 +2,10 @@
 
 set -o errexit
 
+if [ -n "$STACK_YAML" ]; then
+  stack test --dry-run
+fi
+
 for package in $(cat sources.txt) doc/tutorial ; do
   echo testing $package
   pushd $package


### PR DESCRIPTION
- `stack.yaml` seemed to be broken
- GHC-8.0 situation is a bit sad atm, as hvr's launchpad get updates once in a while. (would work with `--skip-ghc-check`, but not /that/ important atm I guess?)