### PR TITLE
Update stack.yaml to LTS 6.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,11 +11,4 @@ packages:
 - servant-server/
 - doc/tutorial
 extra-deps:
-- base-compat-0.9.0
-- engine-io-wai-1.0.2
-- control-monad-omega-0.3.1
-- should-not-typecheck-2.0.1
-- markdown-unlit-0.4.0
-- aeson-0.11.0.0
-- fail-4.9.0.0
-resolver: nightly-2016-03-17
+resolver: lts-6.0


### PR DESCRIPTION
All the missing extra-deps are now on Stackage, and the ones that were 
forced to a later version have also been updated, so the LTS should suffice.