### PR TITLE
Rename type variables 'layout' and 'sublayout' to 'api'

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal/Pretty.hs
+++ b/servant-docs/src/Servant/Docs/Internal/Pretty.hs
@@ -29,12 +29,12 @@ instance ToJSON a => MimeRender PrettyJSON a where
 -- @
 -- 'docs' ('pretty' ('Proxy' :: 'Proxy' MyAPI))
 -- @
-pretty :: Proxy layout -> Proxy (Pretty layout)
+pretty :: Proxy api -> Proxy (Pretty api)
 pretty Proxy = Proxy
 
 -- | Replace all JSON content types with PrettyJSON.
 -- Kind-polymorphic so it can operate on kinds @*@ and @[*]@.
-type family Pretty (layout :: k) :: k where
+type family Pretty (api :: k) :: k where
     Pretty (x :<|> y)     = Pretty x :<|> Pretty y
     Pretty (x :> y)       = Pretty x :> Pretty y
     Pretty (Get cs r)     = Get     (Pretty cs) r

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -184,9 +184,9 @@ data NoTypes
 instance HasForeignType NoTypes () ftype where
   typeFor _ _ _ = ()
 
-class HasForeign lang ftype (layout :: *) where
-  type Foreign ftype layout :: *
-  foreignFor :: Proxy lang -> Proxy ftype -> Proxy layout -> Req ftype -> Foreign ftype layout
+class HasForeign lang ftype (api :: *) where
+  type Foreign ftype api :: *
+  foreignFor :: Proxy lang -> Proxy ftype -> Proxy api -> Req ftype -> Foreign ftype api
 
 instance (HasForeign lang ftype a, HasForeign lang ftype b)
   => HasForeign lang ftype (a :<|> b) where
@@ -196,12 +196,12 @@ instance (HasForeign lang ftype a, HasForeign lang ftype b)
          foreignFor lang ftype (Proxy :: Proxy a) req
     :<|> foreignFor lang ftype (Proxy :: Proxy b) req
 
-instance (KnownSymbol sym, HasForeignType lang ftype t, HasForeign lang ftype sublayout)
-  => HasForeign lang ftype (Capture sym t :> sublayout) where
-  type Foreign ftype (Capture sym a :> sublayout) = Foreign ftype sublayout
+instance (KnownSymbol sym, HasForeignType lang ftype t, HasForeign lang ftype api)
+  => HasForeign lang ftype (Capture sym t :> api) where
+  type Foreign ftype (Capture sym a :> api) = Foreign ftype api
 
   foreignFor lang Proxy Proxy req =
-    foreignFor lang Proxy (Proxy :: Proxy sublayout) $
+    foreignFor lang Proxy (Proxy :: Proxy api) $
       req & reqUrl . path <>~ [Segment (Cap arg)]
           & reqFuncName . _FunctionName %~ (++ ["by", str])
     where
@@ -224,9 +224,9 @@ instance (Elem JSON list, HasForeignType lang ftype a, ReflectMethod method)
       method   = reflectMethod (Proxy :: Proxy method)
       methodLC = toLower $ decodeUtf8 method
 
-instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype sublayout)
-  => HasForeign lang ftype (Header sym a :> sublayout) where
-  type Foreign ftype (Header sym a :> sublayout) = Foreign ftype sublayout
+instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype api)
+  => HasForeign lang ftype (Header sym a :> api) where
+  type Foreign ftype (Header sym a :> api) = Foreign ftype api
 
   foreignFor lang Proxy Proxy req =
     foreignFor lang Proxy subP $ req & reqHeaders <>~ [HeaderArg arg]
@@ -235,14 +235,14 @@ instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype su
       arg   = Arg
         { _argName = PathSegment hname
         , _argType  = typeFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy a) }
-      subP  = Proxy :: Proxy sublayout
+      subP  = Proxy :: Proxy api
 
-instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype sublayout)
-  => HasForeign lang ftype (QueryParam sym a :> sublayout) where
-  type Foreign ftype (QueryParam sym a :> sublayout) = Foreign ftype sublayout
+instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype api)
+  => HasForeign lang ftype (QueryParam sym a :> api) where
+  type Foreign ftype (QueryParam sym a :> api) = Foreign ftype api
 
   foreignFor lang Proxy Proxy req =
-    foreignFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy sublayout) $
+    foreignFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy api) $
       req & reqUrl.queryStr <>~ [QueryArg arg Normal]
     where
       str = pack . symbolVal $ (Proxy :: Proxy sym)
@@ -251,11 +251,11 @@ instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype su
         , _argType = typeFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy a) }
 
 instance
-  (KnownSymbol sym, HasForeignType lang ftype [a], HasForeign lang ftype sublayout)
-  => HasForeign lang ftype (QueryParams sym a :> sublayout) where
-  type Foreign ftype (QueryParams sym a :> sublayout) = Foreign ftype sublayout
+  (KnownSymbol sym, HasForeignType lang ftype [a], HasForeign lang ftype api)
+  => HasForeign lang ftype (QueryParams sym a :> api) where
+  type Foreign ftype (QueryParams sym a :> api) = Foreign ftype api
   foreignFor lang Proxy Proxy req =
-    foreignFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy sublayout) $
+    foreignFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy api) $
       req & reqUrl.queryStr <>~ [QueryArg arg List]
     where
       str = pack . symbolVal $ (Proxy :: Proxy sym)
@@ -264,12 +264,12 @@ instance
         , _argType = typeFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy [a]) }
 
 instance
-  (KnownSymbol sym, HasForeignType lang ftype Bool, HasForeign lang ftype sublayout)
-  => HasForeign lang ftype (QueryFlag sym :> sublayout) where
-  type Foreign ftype (QueryFlag sym :> sublayout) = Foreign ftype sublayout
+  (KnownSymbol sym, HasForeignType lang ftype Bool, HasForeign lang ftype api)
+  => HasForeign lang ftype (QueryFlag sym :> api) where
+  type Foreign ftype (QueryFlag sym :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype (Proxy :: Proxy api) $
       req & reqUrl.queryStr <>~ [QueryArg arg Flag]
     where
       str = pack . symbolVal $ (Proxy :: Proxy sym)
@@ -284,20 +284,20 @@ instance HasForeign lang ftype Raw where
     req & reqFuncName . _FunctionName %~ ((toLower $ decodeUtf8 method) :)
         & reqMethod .~ method
 
-instance (Elem JSON list, HasForeignType lang ftype a, HasForeign lang ftype sublayout)
-      => HasForeign lang ftype (ReqBody list a :> sublayout) where
-  type Foreign ftype (ReqBody list a :> sublayout) = Foreign ftype sublayout
+instance (Elem JSON list, HasForeignType lang ftype a, HasForeign lang ftype api)
+      => HasForeign lang ftype (ReqBody list a :> api) where
+  type Foreign ftype (ReqBody list a :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype (Proxy :: Proxy api) $
       req & reqBody .~ (Just $ typeFor lang ftype (Proxy :: Proxy a))
 
-instance (KnownSymbol path, HasForeign lang ftype sublayout)
-      => HasForeign lang ftype (path :> sublayout) where
-  type Foreign ftype (path :> sublayout) = Foreign ftype sublayout
+instance (KnownSymbol path, HasForeign lang ftype api)
+      => HasForeign lang ftype (path :> api) where
+  type Foreign ftype (path :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype (Proxy :: Proxy api) $
       req & reqUrl . path <>~ [Segment (Static (PathSegment str))]
           & reqFuncName . _FunctionName %~ (++ [str])
     where
@@ -305,39 +305,39 @@ instance (KnownSymbol path, HasForeign lang ftype sublayout)
         Data.Text.map (\c -> if c == '.' then '_' else c)
           . pack . symbolVal $ (Proxy :: Proxy path)
 
-instance HasForeign lang ftype sublayout
-  => HasForeign lang ftype (RemoteHost :> sublayout) where
-  type Foreign ftype (RemoteHost :> sublayout) = Foreign ftype sublayout
+instance HasForeign lang ftype api
+  => HasForeign lang ftype (RemoteHost :> api) where
+  type Foreign ftype (RemoteHost :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) req
+    foreignFor lang ftype (Proxy :: Proxy api) req
 
-instance HasForeign lang ftype sublayout
-  => HasForeign lang ftype (IsSecure :> sublayout) where
-  type Foreign ftype (IsSecure :> sublayout) = Foreign ftype sublayout
-
-  foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) req
-
-instance HasForeign lang ftype sublayout => HasForeign lang ftype (Vault :> sublayout) where
-  type Foreign ftype (Vault :> sublayout) = Foreign ftype sublayout
+instance HasForeign lang ftype api
+  => HasForeign lang ftype (IsSecure :> api) where
+  type Foreign ftype (IsSecure :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) req
+    foreignFor lang ftype (Proxy :: Proxy api) req
 
-instance HasForeign lang ftype sublayout =>
-  HasForeign lang ftype (WithNamedContext name context sublayout) where
-
-  type Foreign ftype (WithNamedContext name context sublayout) = Foreign ftype sublayout
-
-  foreignFor lang ftype Proxy = foreignFor lang ftype (Proxy :: Proxy sublayout)
-
-instance HasForeign lang ftype sublayout
-  => HasForeign lang ftype (HttpVersion :> sublayout) where
-  type Foreign ftype (HttpVersion :> sublayout) = Foreign ftype sublayout
+instance HasForeign lang ftype api => HasForeign lang ftype (Vault :> api) where
+  type Foreign ftype (Vault :> api) = Foreign ftype api
 
   foreignFor lang ftype Proxy req =
-    foreignFor lang ftype (Proxy :: Proxy sublayout) req
+    foreignFor lang ftype (Proxy :: Proxy api) req
+
+instance HasForeign lang ftype api =>
+  HasForeign lang ftype (WithNamedContext name context api) where
+
+  type Foreign ftype (WithNamedContext name context api) = Foreign ftype api
+
+  foreignFor lang ftype Proxy = foreignFor lang ftype (Proxy :: Proxy api)
+
+instance HasForeign lang ftype api
+  => HasForeign lang ftype (HttpVersion :> api) where
+  type Foreign ftype (HttpVersion :> api) = Foreign ftype api
+
+  foreignFor lang ftype Proxy req =
+    foreignFor lang ftype (Proxy :: Proxy api) req
 
 -- | Utility class used by 'listFromAPI' which computes
 --   the data needed to generate a function for each endpoint

--- a/servant-js/src/Servant/JS.hs
+++ b/servant-js/src/Servant/JS.hs
@@ -128,7 +128,7 @@ import           Servant.Foreign (listFromAPI)
 -- | Generate the data necessary to generate javascript code
 --   for all the endpoints of an API, as ':<|>'-separated values
 --   of type 'AjaxReq'.
-javascript :: HasForeign NoTypes () layout => Proxy layout -> Foreign () layout
+javascript :: HasForeign NoTypes () api => Proxy api -> Foreign () api
 javascript p = foreignFor (Proxy :: Proxy NoTypes) (Proxy :: Proxy ()) p defReq
 
 -- | Directly generate all the javascript functions for your API

--- a/servant-js/test/Servant/JSSpec/CustomHeaders.hs
+++ b/servant-js/test/Servant/JSSpec/CustomHeaders.hs
@@ -23,11 +23,11 @@ import           Servant.JS.Internal
 -- using -- Basic, Digest, whatever.
 data Authorization (sym :: Symbol) a
 
-instance (KnownSymbol sym, HasForeign lang () sublayout)
-    => HasForeign lang () (Authorization sym a :> sublayout) where
-    type Foreign () (Authorization sym a :> sublayout) = Foreign () sublayout
+instance (KnownSymbol sym, HasForeign lang () api)
+    => HasForeign lang () (Authorization sym a :> api) where
+    type Foreign () (Authorization sym a :> api) = Foreign () api
 
-    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy api) $
         req & reqHeaders <>~
           [ ReplaceHeaderArg (Arg "Authorization" ())
           $ tokenType (pack . symbolVal $ (Proxy :: Proxy sym)) ]
@@ -37,11 +37,11 @@ instance (KnownSymbol sym, HasForeign lang () sublayout)
 -- | This is a combinator that fetches an X-MyLovelyHorse header.
 data MyLovelyHorse a
 
-instance (HasForeign lang () sublayout)
-    => HasForeign lang () (MyLovelyHorse a :> sublayout) where
-    type Foreign () (MyLovelyHorse a :> sublayout) = Foreign () sublayout
+instance (HasForeign lang () api)
+    => HasForeign lang () (MyLovelyHorse a :> api) where
+    type Foreign () (MyLovelyHorse a :> api) = Foreign () api
 
-    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy api) $
         req & reqHeaders <>~ [ ReplaceHeaderArg (Arg "X-MyLovelyHorse" ()) tpl ]
       where
         tpl = "I am good friends with {X-MyLovelyHorse}"
@@ -49,11 +49,11 @@ instance (HasForeign lang () sublayout)
 -- | This is a combinator that fetches an X-WhatsForDinner header.
 data WhatsForDinner a
 
-instance (HasForeign lang () sublayout)
-    => HasForeign lang () (WhatsForDinner a :> sublayout) where
-    type Foreign () (WhatsForDinner a :> sublayout) = Foreign () sublayout
+instance (HasForeign lang () api)
+    => HasForeign lang () (WhatsForDinner a :> api) where
+    type Foreign () (WhatsForDinner a :> api) = Foreign () api
 
-    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy sublayout) $
+    foreignFor lang ftype Proxy req = foreignFor lang ftype (Proxy :: Proxy api) $
         req & reqHeaders <>~ [ ReplaceHeaderArg (Arg "X-WhatsForDinner" ()) tpl ]
       where
         tpl = "I would like {X-WhatsForDinner} with a cherry on top."

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -130,11 +130,11 @@ import           Servant.Utils.Enter
 -- > main :: IO ()
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
-serve :: (HasServer layout '[]) => Proxy layout -> Server layout -> Application
+serve :: (HasServer api '[]) => Proxy api -> Server api -> Application
 serve p = serveWithContext p EmptyContext
 
-serveWithContext :: (HasServer layout context)
-    => Proxy layout -> Context context -> Server layout -> Application
+serveWithContext :: (HasServer api context)
+    => Proxy api -> Context context -> Server api -> Application
 serveWithContext p context server =
   toApplication (runRouter (route p context (emptyDelayed (Route server))))
 
@@ -189,12 +189,12 @@ serveWithContext p context server =
 -- that one takes precedence. If both parts fail, the \"better\" error
 -- code will be returned.
 --
-layout :: (HasServer layout '[]) => Proxy layout -> Text
+layout :: (HasServer api '[]) => Proxy api -> Text
 layout p = layoutWithContext p EmptyContext
 
 -- | Variant of 'layout' that takes an additional 'Context'.
-layoutWithContext :: (HasServer layout context)
-    => Proxy layout -> Context context -> Text
+layoutWithContext :: (HasServer api context)
+    => Proxy api -> Context context -> Text
 layoutWithContext p context =
   routerLayout (route p context (emptyDelayed (FailFatal err501)))
 


### PR DESCRIPTION
I think `api` much more clearly expresses, what this really is.