### PR TITLE
Authorization combinator test

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -517,6 +517,10 @@ class ToCapture c where
 class ToAuthInfo a where
       toAuthInfo :: Proxy a -> DocAuthentication
 
+instance ToAuthInfo (BasicAuth "foo-realm" ()) where
+  toAuthInfo _ = DocAuthentication "herp" "derp"
+
+
 -- | Generate documentation in Markdown format for
 --   the given 'API'.
 markdown :: API -> String

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -22,6 +22,7 @@ type ComprehensiveAPI =
   QueryParam "foo" Int :> GET :<|>
   QueryParams "foo" Int :> GET :<|>
   QueryFlag "foo" :> GET :<|>
+  "private" :> BasicAuth "foo-realm" () :> GET :<|>
 -- Raw :<|>
   RemoteHost :> GET :<|>
   ReqBody '[JSON] Int :> GET :<|>


### PR DESCRIPTION
I've started looking at  #465 as it had the `newcomer-friendly` tag, but I've either missed something simple or this is much more complicated that it sounds.

- I've extended `ComprehensiveAPI` and get complaints about missing `ToAuthInfo` and `HasContextEntry` instances.
- I think I've roughly grokked the `ToAuthInfo` instance, but unsure where it should go (`Servant/Docs/Internal` where I've got it seems obviously wrong)
- The `HasContextEntry` instance I'm completely lost.

Would appreciate some pointers, I was inspired by [this](https://www.reddit.com/r/haskell/comments/4m5p8k/what_haskell_projects_can_expert_beginners/d3sudo9) but if this is misguided I'm happy to close.