### PR TITLE
Add upper bounds http-client <0.5

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -42,7 +42,7 @@ library
     , bytestring
     , exceptions
     , http-api-data >= 0.1  && < 0.3
-    , http-client
+    , http-client <0.5
     , http-client-tls
     , http-media
     , http-types


### PR DESCRIPTION
I'd like to add bounds for all other dependencies as well.

<img width="680" alt="screen shot 2016-07-05 at 12 24 56" src="https://cloud.githubusercontent.com/assets/51087/16580161/ddde33bc-42ab-11e6-9576-2116cede1a11.png">

 SItuations like are good example why you should have them. ping @hvr