### PR TITLE
Fix servant-js examples

### DIFF
--- a/servant-js/examples/counter.hs
+++ b/servant-js/examples/counter.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeOperators              #-}
 
 import           Control.Concurrent.STM
@@ -92,7 +93,7 @@ main = do
 
   writeJSForAPI testApi (angular defAngularOptions) (www </> "angular" </> "api.js")
 
-  writeJSForAPI testApi axios (www </> "axios" </> "api.js")
+  writeJSForAPI testApi (axios defAxiosOptions) (www </> "axios" </> "api.js")
 
   writeServiceJS (www </> "angular" </> "api.service.js")
 


### PR DESCRIPTION
The Servant.JS Counter example was broken:

- `axios` was not completely applied; it now uses `defAxiosOptions` similarly to the `angular` example
- `OverloadedStrings` was required, but not included