### PR TITLE
servant-client: update stack-ghcjs.yaml file for testsuite

### DIFF
--- a/servant-client/test/ghcjs/stack-ghcjs.yaml
+++ b/servant-client/test/ghcjs/stack-ghcjs.yaml
@@ -7,15 +7,16 @@ packages:
   - location: ../../../servant-server
     extra-dep: true
 
-resolver: lts-5.11
+resolver: lts-5.12
 
-compiler: ghcjs-0.2.0.20160315_ghc-7.10.2
+compiler: ghcjs-0.2.0.20160414_ghc-7.10.3
 compiler-check: match-exact
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.0.20160315_ghc-7.10.2:
-        url: "https://github.com/nrolland/ghcjs/releases/download/v.0.2.0.20160315/ghcjs-0.2.0.20160315.tar.gz"
+      ghcjs-0.2.0.20160414_ghc-7.10.3:
+        url: https://s3.amazonaws.com/ghcjs/ghcjs-0.2.0.20160414_ghc-7.10.3.tar.gz
+        sha1: 6d6f307503be9e94e0c96ef1308c7cf224d06be3
 
 extra-deps:
   - hspec-expectations-0.7.2


### PR DESCRIPTION
Unfortunately I couldn't reproduce a working `ghcjs` setup with the existing stack file. With this one it works again. But I suspect that `ghcjs` projects with stack files are not really reproducible yet. :(