### PR TITLE
support http-client-0.5

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -35,24 +35,24 @@ library
     Servant.Common.BasicAuth
     Servant.Common.Req
   build-depends:
-      base >=4.7 && <5
-    , aeson
-    , attoparsec
-    , base64-bytestring
-    , bytestring
-    , exceptions
-    , http-api-data >= 0.1  && < 0.3
-    , http-client <0.5
-    , http-client-tls
-    , http-media
-    , http-types
-    , network-uri >= 2.6
-    , safe
-    , servant == 0.7.*
-    , string-conversions
-    , text
-    , transformers
-    , transformers-compat
+      base                  >= 4.7      && < 4.10
+    , aeson                 >= 0.7      && < 0.12
+    , attoparsec            >= 0.12     && < 0.14
+    , base64-bytestring     >= 1.0.0.1  && < 1.1
+    , bytestring            >= 0.10     && < 0.11
+    , exceptions            >= 0.8      && < 0.9
+    , http-api-data         >= 0.1      && < 0.3
+    , http-client           >= 0.4.18.1 && < 0.5
+    , http-client-tls       >= 0.2.2    && < 0.3
+    , http-media            >= 0.6.2    && < 0.7
+    , http-types            >= 0.8.6    && < 0.10
+    , network-uri           >= 2.6      && < 2.7
+    , safe                  >= 0.3.9    && < 0.4
+    , servant               == 0.7.*
+    , string-conversions    >= 0.3      && < 0.5
+    , text                  >= 1.2      && < 1.3
+    , transformers          >= 0.3      && < 0.6
+    , transformers-compat   >= 0.4      && < 0.6
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -42,8 +42,8 @@ library
     , bytestring            >= 0.10     && < 0.11
     , exceptions            >= 0.8      && < 0.9
     , http-api-data         >= 0.1      && < 0.3
-    , http-client           >= 0.4.18.1 && < 0.5
-    , http-client-tls       >= 0.2.2    && < 0.3
+    , http-client           >= 0.4.18.1 && < 0.6
+    , http-client-tls       >= 0.2.2    && < 0.4
     , http-media            >= 0.6.2    && < 0.7
     , http-types            >= 0.8.6    && < 0.10
     , network-uri           >= 2.6      && < 2.7

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -45,31 +45,31 @@ library
     Servant.Server.Internal.ServantErr
     Servant.Utils.StaticFiles
   build-depends:
-        base               >= 4.7  && < 5
-      , base-compat        >= 0.9
+        base               >= 4.7  && < 4.10
+      , base-compat        >= 0.9  && < 0.10
       , aeson              >= 0.7  && < 0.12
       , attoparsec         >= 0.12 && < 0.14
-      , base64-bytestring  == 1.0.*
+      , base64-bytestring  >= 1.0  && < 1.1
       , bytestring         >= 0.10 && < 0.11
       , containers         >= 0.5  && < 0.6
       , http-api-data      >= 0.1  && < 0.3
       , http-types         >= 0.8  && < 0.10
       , network-uri        >= 2.6  && < 2.7
-      , mtl                >= 2    && < 3
+      , mtl                >= 2    && < 2.3
       , network            >= 2.6  && < 2.7
       , safe               >= 0.3  && < 0.4
       , servant            == 0.7.*
       , split              >= 0.2  && < 0.3
       , string-conversions >= 0.3  && < 0.5
       , system-filepath    >= 0.4  && < 0.5
-      , filepath           >= 1
+      , filepath           >= 1    && < 1.5
       , text               >= 1.2  && < 1.3
       , transformers       >= 0.3  && < 0.6
-      , transformers-compat>= 0.4
+      , transformers-compat>= 0.4  && < 0.6
       , wai                >= 3.0  && < 3.3
       , wai-app-static     >= 3.1  && < 3.2
       , warp               >= 3.0  && < 3.3
-      , word8              == 0.1.*
+      , word8              >= 0.1  && < 0.2
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -49,22 +49,22 @@ library
     Servant.Utils.Links
     Servant.Utils.Enter
   build-depends:
-      base >= 4.7 && < 4.10
-    , base-compat >= 0.9
-    , aeson >= 0.7
-    , attoparsec >= 0.12
-    , bytestring == 0.10.*
-    , bytestring-conversion == 0.3.*
-    , case-insensitive >= 1.2
-    , http-api-data >= 0.1  && < 0.3
-    , http-media >= 0.4 && < 0.7
-    , http-types >= 0.8 && < 0.10
-    , mtl >= 2 && < 3
-    , mmorph >= 1
-    , text >= 1 && < 2
-    , string-conversions >= 0.3 && < 0.5
-    , network-uri >= 2.6
-    , vault >= 0.3 && <0.4
+      base                  >= 4.7  && < 4.10
+    , base-compat           >= 0.9  && < 0.10
+    , aeson                 >= 0.7  && < 0.12
+    , attoparsec            >= 0.12 && < 0.14
+    , bytestring            >= 0.10 && < 0.11
+    , bytestring-conversion >= 0.3  && < 0.4
+    , case-insensitive      >= 1.2  && < 1.3
+    , http-api-data         >= 0.1  && < 0.3
+    , http-media            >= 0.4  && < 0.7
+    , http-types            >= 0.8  && < 0.10
+    , mtl                   >= 2.0  && < 2.3
+    , mmorph                >= 1    && < 1.1
+    , text                  >= 1    && < 1.3
+    , string-conversions    >= 0.3  && < 0.5
+    , network-uri           >= 2.6  && < 2.7
+    , vault                 >= 0.3  && < 0.4
   hs-source-dirs: src
   default-language: Haskell2010
   other-extensions: CPP


### PR DESCRIPTION
This is an alternative PR to #538. I'd like to make a release to hackage that works with `http-client-0.5` soon. Since #538 contains other, more controversial changes I've created this PR in the hope in can be merged and released faster.

@haskell-servant/maintainers