### PR TITLE
Use From/ToForm from http-api-data

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -41,7 +41,7 @@ library
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , bytestring            >= 0.10     && < 0.11
     , exceptions            >= 0.8      && < 0.9
-    , http-api-data         >= 0.1      && < 0.3
+    , http-api-data         >= 0.1      && < 0.4
     , http-client           >= 0.4.18.1 && < 0.6
     , http-client-tls       >= 0.2.2    && < 0.4
     , http-media            >= 0.6.2    && < 0.7

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -77,6 +77,7 @@ test-suite spec
     , bytestring
     , deepseq
     , hspec == 2.*
+    , http-api-data
     , http-client
     , http-media
     , http-types

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -41,7 +41,7 @@ library
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , bytestring            >= 0.10     && < 0.11
     , exceptions            >= 0.8      && < 0.9
-    , http-api-data         >= 0.1      && < 0.4
+    , http-api-data         >= 0.3      && < 0.4
     , http-client           >= 0.4.18.1 && < 0.6
     , http-client-tls       >= 0.2.2    && < 0.4
     , http-media            >= 0.6.2    && < 0.7

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -30,28 +30,29 @@ module Servant.ClientSpec where
 import           Control.Applicative        ((<$>))
 #endif
 import           Control.Arrow              (left)
-import           Control.Concurrent         (forkIO, killThread, ThreadId)
+import           Control.Concurrent         (ThreadId, forkIO, killThread)
 import           Control.Exception          (bracket)
-import           Control.Monad.Trans.Except (throwE, runExceptT)
+import           Control.Monad.Trans.Except (runExceptT, throwE)
 import           Data.Aeson
 import qualified Data.ByteString.Lazy       as BS
 import           Data.Char                  (chr, isPrint)
 import           Data.Foldable              (forM_)
 import           Data.Monoid                hiding (getLast)
 import           Data.Proxy
-import qualified Data.Text                  as T
 import           GHC.Generics               (Generic)
 import qualified Network.HTTP.Client        as C
 import           Network.HTTP.Media
 import qualified Network.HTTP.Types         as HTTP
 import           Network.Socket
-import           Network.Wai                (Request, requestHeaders, responseLBS)
+import           Network.Wai                (Request, requestHeaders,
+                                             responseLBS)
 import           Network.Wai.Handler.Warp
 import           System.IO.Unsafe           (unsafePerformIO)
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.HUnit
 import           Test.QuickCheck
+import           Web.FormUrlEncoded         (FromForm, ToForm)
 
 import           Servant.API
 import           Servant.API.Internal.Test.ComprehensiveAPI
@@ -82,19 +83,8 @@ data Person = Person {
 instance ToJSON Person
 instance FromJSON Person
 
-instance ToFormUrlEncoded Person where
-    toFormUrlEncoded Person{..} =
-        [("name", T.pack name), ("age", T.pack (show age))]
-
-lookupEither :: (Show a, Eq a) => a -> [(a,b)] -> Either String b
-lookupEither x xs = do
-    maybe (Left $ "could not find key " <> show x) return $ lookup x xs
-
-instance FromFormUrlEncoded Person where
-    fromFormUrlEncoded xs = do
-        n <- lookupEither "name" xs
-        a <- lookupEither "age" xs
-        return $ Person (T.unpack n) (read $ T.unpack a)
+instance ToForm Person where
+instance FromForm Person where
 
 alice :: Person
 alice = Person "Alice" 42

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -52,7 +52,7 @@ library
       , base64-bytestring  >= 1.0  && < 1.1
       , bytestring         >= 0.10 && < 0.11
       , containers         >= 0.5  && < 0.6
-      , http-api-data      >= 0.1  && < 0.3
+      , http-api-data      >= 0.1  && < 0.4
       , http-types         >= 0.8  && < 0.10
       , network-uri        >= 2.6  && < 2.7
       , mtl                >= 2    && < 2.3

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -43,10 +43,17 @@ import           Network.Wai                (Application, Request, Response,
 import           Prelude                    ()
 import           Prelude.Compat
 import           Web.HttpApiData            (FromHttpApiData)
+#if MIN_VERSION_http_api_data(0,3,0)
+import           Web.Internal.HttpApiData   (parseHeaderMaybe,
+                                             parseQueryParamMaybe,
+                                             parseUrlPieceMaybe,
+                                             parseUrlPieces)
+#else
 import           Web.HttpApiData.Internal   (parseHeaderMaybe,
                                              parseQueryParamMaybe,
                                              parseUrlPieceMaybe,
                                              parseUrlPieces)
+#endif
 
 import           Servant.API                 ((:<|>) (..), (:>), BasicAuth, Capture,
                                               CaptureAll, Verb,

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -22,50 +22,40 @@ module Servant.Server.Internal
   , module Servant.Server.Internal.ServantErr
   ) where
 
-import           Control.Monad.Trans        (liftIO)
-import qualified Data.ByteString            as B
-import qualified Data.ByteString.Char8      as BC8
-import qualified Data.ByteString.Lazy       as BL
-import           Data.Maybe                 (fromMaybe, mapMaybe)
-import           Data.String                (fromString)
-import           Data.String.Conversions    (cs, (<>))
+import           Control.Monad.Trans         (liftIO)
+import qualified Data.ByteString             as B
+import qualified Data.ByteString.Char8       as BC8
+import qualified Data.ByteString.Lazy        as BL
+import           Data.Maybe                  (fromMaybe, mapMaybe)
+import           Data.String                 (fromString)
+import           Data.String.Conversions     (cs, (<>))
 import           Data.Typeable
-import           GHC.TypeLits               (KnownNat, KnownSymbol, natVal,
-                                             symbolVal)
-import           Network.HTTP.Types         hiding (Header, ResponseHeaders)
-import           Network.Socket             (SockAddr)
-import           Network.Wai                (Application, Request, Response,
-                                             httpVersion, isSecure,
-                                             lazyRequestBody,
-                                             rawQueryString, remoteHost,
-                                             requestHeaders, requestMethod,
-                                             responseLBS, vault)
-import           Prelude                    ()
+import           GHC.TypeLits                (KnownNat, KnownSymbol, natVal,
+                                              symbolVal)
+import           Network.HTTP.Types          hiding (Header, ResponseHeaders)
+import           Network.Socket              (SockAddr)
+import           Network.Wai                 (Application, Request, Response,
+                                              httpVersion, isSecure,
+                                              lazyRequestBody, rawQueryString,
+                                              remoteHost, requestHeaders,
+                                              requestMethod, responseLBS, vault)
+import           Prelude                     ()
 import           Prelude.Compat
-import           Web.HttpApiData            (FromHttpApiData)
-#if MIN_VERSION_http_api_data(0,3,0)
-import           Web.Internal.HttpApiData   (parseHeaderMaybe,
-                                             parseQueryParamMaybe,
-                                             parseUrlPieceMaybe,
-                                             parseUrlPieces)
-#else
-import           Web.HttpApiData.Internal   (parseHeaderMaybe,
-                                             parseQueryParamMaybe,
-                                             parseUrlPieceMaybe,
-                                             parseUrlPieces)
-#endif
+import           Web.HttpApiData             (FromHttpApiData, parseHeaderMaybe,
+                                              parseQueryParamMaybe,
+                                              parseUrlPieceMaybe,
+                                              parseUrlPieces)
 
-import           Servant.API                 ((:<|>) (..), (:>), BasicAuth, Capture,
-                                              CaptureAll, Verb,
-                                              ReflectMethod(reflectMethod),
-                                              IsSecure(..), Header, QueryFlag,
+import           Servant.API                 ((:<|>) (..), (:>), BasicAuth,
+                                              Capture, CaptureAll, Header,
+                                              IsSecure (..), QueryFlag,
                                               QueryParam, QueryParams, Raw,
-                                              RemoteHost, ReqBody, Vault,
+                                              ReflectMethod (reflectMethod),
+                                              RemoteHost, ReqBody, Vault, Verb,
                                               WithNamedContext)
 import           Servant.API.ContentTypes    (AcceptHeader (..),
                                               AllCTRender (..),
-                                              AllCTUnrender (..),
-                                              AllMime,
+                                              AllCTUnrender (..), AllMime,
                                               canHandleAcceptH)
 import           Servant.API.ResponseHeaders (GetHeaders, Headers, getHeaders,
                                               getResponse)

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -2,6 +2,7 @@ next
 ----
 
 * Add `CaptureAll` combinator. Captures all of the remaining segments in a URL.
+* BACKWARD INCOMPATIBLE: Moved `From/ToFormUrlEncoded` classes, which were renamed to `From/ToForm` to `http-api-data`
 
 0.8
 ---

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -56,7 +56,7 @@ library
     , bytestring            >= 0.10 && < 0.11
     , bytestring-conversion >= 0.3  && < 0.4
     , case-insensitive      >= 1.2  && < 1.3
-    , http-api-data         >= 0.1  && < 0.3
+    , http-api-data         >= 0.1  && < 0.4
     , http-media            >= 0.4  && < 0.7
     , http-types            >= 0.8  && < 0.10
     , mtl                   >= 2.0  && < 2.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -56,7 +56,7 @@ library
     , bytestring            >= 0.10 && < 0.11
     , bytestring-conversion >= 0.3  && < 0.4
     , case-insensitive      >= 1.2  && < 1.3
-    , http-api-data         >= 0.1  && < 0.4
+    , http-api-data         >= 0.3  && < 0.4
     , http-media            >= 0.4  && < 0.7
     , http-types            >= 0.8  && < 0.10
     , mtl                   >= 2.0  && < 2.3

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -62,10 +62,10 @@ import           Servant.API.Alternative     ((:<|>) (..))
 import           Servant.API.BasicAuth       (BasicAuth,BasicAuthData(..))
 import           Servant.API.Capture         (Capture, CaptureAll)
 import           Servant.API.ContentTypes    (Accept (..), FormUrlEncoded,
-                                              FromFormUrlEncoded (..), JSON,
+                                              JSON,
                                               MimeRender (..), NoContent (NoContent),
                                               MimeUnrender (..), OctetStream,
-                                              PlainText, ToFormUrlEncoded (..))
+                                              PlainText)
 import           Servant.API.Experimental.Auth (AuthProtect)
 import           Servant.API.Header          (Header (..))
 import           Servant.API.HttpVersion     (HttpVersion (..))

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -11,7 +11,6 @@ module Servant.API.ContentTypesSpec where
 import           Prelude ()
 import           Prelude.Compat
 
-import           Control.Arrow
 import           Data.Aeson
 import           Data.ByteString.Char8     (ByteString, append, pack)
 import qualified Data.ByteString.Lazy      as BSL
@@ -25,7 +24,6 @@ import           Data.String.Conversions   (cs)
 import qualified Data.Text                 as TextS
 import qualified Data.Text.Lazy            as TextL
 import           GHC.Generics
-import           Network.URL               (exportParams, importParams)
 import           Test.Hspec
 import           Test.QuickCheck
 import "quickcheck-instances" Test.QuickCheck.Instances ()
@@ -67,21 +65,6 @@ spec = describe "Servant.API.ContentTypes" $ do
 
         it "has mimeUnrender reverse mimeRender for valid top-level json " $ do
             property $ \x -> mimeUnrender p (mimeRender p x) == Right (x::SomeData)
-
-    describe "The FormUrlEncoded Content-Type type" $ do
-        let p = Proxy :: Proxy FormUrlEncoded
-
-        it "has mimeUnrender reverse mimeRender" $ do
-            property $ \x -> mempty `notElem` x
-                ==> mimeUnrender p (mimeRender p x) == Right (x::[(TextS.Text,TextS.Text)])
-
-        it "has mimeUnrender reverse exportParams (Network.URL)" $ do
-            property $ \x -> mempty `notElem` x
-                ==> (mimeUnrender p . cs . exportParams . map (cs *** cs) $ x) == Right (x::[(TextS.Text,TextS.Text)])
-
-        it "has importParams (Network.URL) reverse mimeRender" $ do
-            property $ \x -> mempty `notElem` x
-                ==> (fmap (map (cs *** cs)) . importParams . cs . mimeRender p $ x) == Just (x::[(TextS.Text,TextS.Text)])
 
     describe "The PlainText Content-Type type" $ do
         let p = Proxy :: Proxy PlainText

--- a/stack-ghc-7.8.4.yaml
+++ b/stack-ghc-7.8.4.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - hspec-core-2.2.3
 - hspec-discover-2.2.3
 - hspec-expectations-0.7.2
-- http-api-data-0.2.2
+- http-api-data-0.3
 - primitive-0.6.1.0
 - servant-0.7.1
 - servant-client-0.7.1
@@ -24,5 +24,6 @@ extra-deps:
 - servant-server-0.7.1
 - should-not-typecheck-2.1.0
 - time-locale-compat-0.1.1.1
+- uri-bytestring-0.2.2.0
 - wai-app-static-3.1.5
 resolver: lts-2.22

--- a/stack-ghc-8.0.1.yaml
+++ b/stack-ghc-8.0.1.yaml
@@ -7,5 +7,7 @@ packages:
 - servant-js/
 - servant-mock/
 - servant-server/
-extra-deps: []
+extra-deps:
+- http-api-data-0.3
+- uri-bytestring-0.2.2.0
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,4 +9,5 @@ packages:
 - servant-server/
 - doc/tutorial
 extra-deps:
+- http-api-data-0.3
 resolver: lts-6.0


### PR DESCRIPTION
And remove our version. The `http-api-data` version is a big improvement, and that is anyhow the place for it.

Closes #348.
Supersedes #580.