### PR TITLE
Replace use of ToByteString with HttpApiData for GetHeaders

### DIFF
--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -36,7 +36,6 @@ library
     , aeson
     , aeson-pretty
     , bytestring
-    , bytestring-conversion
     , case-insensitive
     , hashable
     , http-media >= 0.6
@@ -61,7 +60,6 @@ executable greet-docs
   build-depends:
       base
     , aeson
-    , bytestring-conversion
     , lens
     , servant
     , servant-docs

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -25,7 +25,6 @@ import           Control.Arrow              (second)
 import           Control.Lens               (makeLenses, mapped, over, traversed, view, (%~),
                                              (&), (.~), (<>~), (^.), (|>))
 import qualified Control.Monad.Omega        as Omega
-import           Data.ByteString.Conversion (ToByteString, toByteString)
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Char8      as BSC
 import qualified Data.CaseInsensitive       as CI
@@ -461,12 +460,12 @@ class AllHeaderSamples ls where
 instance AllHeaderSamples '[] where
     allHeaderToSample _  = []
 
-instance (ToByteString l, AllHeaderSamples ls, ToSample l, KnownSymbol h)
+instance (ToHttpApiData l, AllHeaderSamples ls, ToSample l, KnownSymbol h)
     => AllHeaderSamples (Header h l ': ls) where
     allHeaderToSample _ = mkHeader (toSample (Proxy :: Proxy l)) :
                           allHeaderToSample (Proxy :: Proxy ls)
       where headerName = CI.mk . cs $ symbolVal (Proxy :: Proxy h)
-            mkHeader (Just x) = (headerName, cs $ toByteString x)
+            mkHeader (Just x) = (headerName, cs $ toHeader x)
             mkHeader Nothing  = (headerName, "<no header sample provided>")
 
 -- | Synthesise a sample value of a type, encoded in the specified media types.

--- a/servant-mock/servant-mock.cabal
+++ b/servant-mock/servant-mock.cabal
@@ -69,5 +69,4 @@ test-suite spec
     servant-server,
     servant-mock,
     aeson,
-    bytestring-conversion,
     wai

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -40,8 +40,8 @@ data TestHeader
 
 instance ToHttpApiData TestHeader where
   toHeader = toHeader . show
-  toUrlPiece _ = error "ToHttpApiData.toUrlPiece not implemented for TestHeader"
-  toQueryParam _ = error "ToHttpApiData.toQueryParam not implemented for TestHeader"
+  toUrlPiece = toUrlPiece . show
+  toQueryParam = toQueryParam . show
 
 
 instance Arbitrary TestHeader where

--- a/servant-mock/test/Servant/MockSpec.hs
+++ b/servant-mock/test/Servant/MockSpec.hs
@@ -8,9 +8,7 @@
 module Servant.MockSpec where
 
 import           Data.Aeson as Aeson
-import           Data.ByteString.Conversion.To
 import           Data.Proxy
-import           Data.String
 import           GHC.Generics
 import           Network.Wai
 import           Servant.API
@@ -40,8 +38,11 @@ data TestHeader
   | ArbitraryHeader
   deriving (Show)
 
-instance ToByteString TestHeader where
-  builder = fromString . show
+instance ToHttpApiData TestHeader where
+  toHeader = toHeader . show
+  toUrlPiece _ = error "ToHttpApiData.toUrlPiece not implemented for TestHeader"
+  toQueryParam _ = error "ToHttpApiData.toQueryParam not implemented for TestHeader"
+
 
 instance Arbitrary TestHeader where
   arbitrary = return ArbitraryHeader

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -114,7 +114,6 @@ test-suite spec
     , aeson
     , base64-bytestring
     , bytestring
-    , bytestring-conversion
     , directory
     , exceptions
     , hspec == 2.*

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -17,7 +17,6 @@ import           Control.Monad              (forM_, when, unless)
 import           Control.Monad.Trans.Except (throwE)
 import           Data.Aeson                 (FromJSON, ToJSON, decode', encode)
 import qualified Data.ByteString.Base64     as Base64
-import           Data.ByteString.Conversion ()
 import           Data.Char                  (toUpper)
 import           Data.Monoid
 import           Data.Proxy                 (Proxy (Proxy))

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -2,7 +2,7 @@ next
 ----
 
 * Add `CaptureAll` combinator. Captures all of the remaining segments in a URL.
-* replace use of `ToByteString` with `HttpApiData` for `GetHeaders`
+* BACKWARDS INCOMPATIBLE replace use of `ToFromByteString` with `To/FromHttpApiData` for `GetHeaders/BuildHeadersTo`
 
 0.8
 ---

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -2,6 +2,7 @@ next
 ----
 
 * Add `CaptureAll` combinator. Captures all of the remaining segments in a URL.
+* replace use of `ToByteString` with `HttpApiData` for `GetHeaders`
 
 0.8
 ---

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -1,5 +1,5 @@
 name:                servant
-version:             0.8.1
+version:             0.8
 synopsis:            A family of combinators for defining webservices APIs
 description:
   A family of combinators for defining webservices APIs and serving them

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -54,7 +54,6 @@ library
     , aeson                 >= 0.7  && < 1.1
     , attoparsec            >= 0.12 && < 0.14
     , bytestring            >= 0.10 && < 0.11
-    , bytestring-conversion >= 0.3  && < 0.4
     , case-insensitive      >= 1.2  && < 1.3
     , http-api-data         >= 0.1  && < 0.3
     , http-media            >= 0.4  && < 0.7

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -1,5 +1,5 @@
 name:                servant
-version:             0.8
+version:             0.8.1
 synopsis:            A family of combinators for defining webservices APIs
 description:
   A family of combinators for defining webservices APIs and serving them

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -31,8 +31,8 @@ module Servant.API.ResponseHeaders
     ) where
 
 import           Data.ByteString.Char8       as BS (pack, unlines, init)
-import           Web.HttpApiData             (ToHttpApiData, toHeader
-                                             ,FromHttpApiData, parseHeader)
+import           Web.HttpApiData             (ToHttpApiData, toHeader,
+                                             FromHttpApiData, parseHeader)
 import qualified Data.CaseInsensitive        as CI
 import           Data.Proxy
 import           GHC.TypeLits                (KnownSymbol, symbolVal)

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -31,8 +31,8 @@ module Servant.API.ResponseHeaders
     ) where
 
 import           Data.ByteString.Char8       as BS (pack, unlines, init)
-import           Web.HttpApiData             (ToHttpApiData,toHeader
-                                             ,FromHttpApiData,parseHeader)
+import           Web.HttpApiData             (ToHttpApiData, toHeader
+                                             ,FromHttpApiData, parseHeader)
 import qualified Data.CaseInsensitive        as CI
 import           Data.Proxy
 import           GHC.TypeLits                (KnownSymbol, symbolVal)


### PR DESCRIPTION
Fixes servant/#581

* Version bump because this changes the API for GetHeaders