### PR TITLE
Fixed typo: s/real/realm/

### DIFF
--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -319,8 +319,8 @@ Which is used like so:
 
 ``` haskell
 type ProtectedAPI12
-     = UserAPI                             -- this is public
- :<|> BasicAuth "my-real" User :> UserAPI2 -- this is protected by auth
+     = UserAPI                              -- this is public
+ :<|> BasicAuth "my-realm" User :> UserAPI2 -- this is protected by auth
 ```
 
 ### Interoperability with `wai`: `Raw`


### PR DESCRIPTION
Actually, I'm just trying to learn servant and I'm reading the doc for the first time. But this just looks like a typo to me.