### PR TITLE
make ClientM  a Reader

### DIFF
--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -15,11 +15,10 @@ need to have some language extensions and imports:
 
 module Client where
 
-import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Data.Aeson
 import Data.Proxy
 import GHC.Generics
-import Network.HTTP.Client (Manager, newManager, defaultManagerSettings)
+import Network.HTTP.Client (newManager, defaultManagerSettings)
 import Servant.API
 import Servant.Client
 ```

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -71,19 +71,13 @@ What we are going to get with **servant-client** here is 3 functions, one to que
 ``` haskell
 position :: Int -- ^ value for "x"
          -> Int -- ^ value for "y"
-         -> Manager -- ^ the HTTP client to use
-         -> BaseUrl -- ^ the URL at which the API can be found
-         -> ExceptT ServantError IO Position
+         -> ClientM Position
 
 hello :: Maybe String -- ^ an optional value for "name"
-      -> Manager -- ^ the HTTP client to use
-      -> BaseUrl -- ^ the URL at which the API can be found
-      -> ExceptT ServantError IO HelloMessage
+      -> ClientM HelloMessage
 
 marketing :: ClientInfo -- ^ value for the request body
-          -> Manager -- ^ the HTTP client to use
-          -> BaseUrl -- ^ the URL at which the API can be found
-          -> ExceptT ServantError IO Email
+          -> ClientM Email
 ```
 
 Each function makes available as an argument any value that the response may
@@ -120,17 +114,17 @@ data BaseUrl = BaseUrl
 That's it. Let's now write some code that uses our client functions.
 
 ``` haskell
-queries :: Manager -> BaseUrl -> ExceptT ServantError IO (Position, HelloMessage, Email)
-queries manager baseurl = do
-  pos <- position 10 10 manager baseurl
-  message <- hello (Just "servant") manager baseurl
-  em  <- marketing (ClientInfo "Alp" "alp@foo.com" 26 ["haskell", "mathematics"]) manager baseurl
+queries :: ClientM (Position, HelloMessage, Email)
+queries = do
+  pos <- position 10 10 
+  message <- hello (Just "servant") 
+  em  <- marketing (ClientInfo "Alp" "alp@foo.com" 26 ["haskell", "mathematics"])
   return (pos, message, em)
 
 run :: IO ()
 run = do
   manager <- newManager defaultManagerSettings
-  res <- runExceptT (queries manager (BaseUrl Http "localhost" 8081 ""))
+  res <- runClientM queries (ClientEnv manager (BaseUrl Http "localhost" 8081 ""))
   case res of
     Left err -> putStrLn $ "Error: " ++ show err
     Right (pos, message, em) -> do

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -53,7 +53,6 @@ library
     , text                  >= 1.2      && < 1.3
     , transformers          >= 0.3      && < 0.6
     , transformers-compat   >= 0.4      && < 0.6
-    , http-conduit
     , mtl
   hs-source-dirs: src
   default-language: Haskell2010

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -53,6 +53,7 @@ library
     , text                  >= 1.2      && < 1.3
     , transformers          >= 0.3      && < 0.6
     , transformers-compat   >= 0.4      && < 0.6
+    , mtl
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -53,6 +53,7 @@ library
     , text                  >= 1.2      && < 1.3
     , transformers          >= 0.3      && < 0.6
     , transformers-compat   >= 0.4      && < 0.6
+    , http-conduit
     , mtl
   hs-source-dirs: src
   default-language: Haskell2010

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -30,14 +30,13 @@ module Servant.Client
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative        ((<$>))
 #endif
-import           Control.Monad.Reader       (ask)
 import           Data.ByteString.Lazy       (ByteString)
 import           Data.List
 import           Data.Proxy
 import           Data.String.Conversions
 import           Data.Text                  (unpack)
 import           GHC.TypeLits
-import           Network.HTTP.Client        (Manager, Response)
+import           Network.HTTP.Client        (Response)
 import           Network.HTTP.Media
 import qualified Network.HTTP.Types         as H
 import qualified Network.HTTP.Types.Header  as HTTP

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -156,7 +156,7 @@ instance OVERLAPPABLE_
   ) => HasClient (Verb method status cts' a) where
   type Client (Verb method status cts' a) = Manager -> BaseUrl -> ClientM a
   clientWithRoute Proxy req manager baseurl =
-    snd <$> performRequestCT (Proxy :: Proxy ct) method req manager baseurl
+    snd <$> performRequestCT (Proxy :: Proxy ct) method req 
       where method = reflectMethod (Proxy :: Proxy method)
 
 instance OVERLAPPING_
@@ -164,7 +164,7 @@ instance OVERLAPPING_
   type Client (Verb method status cts NoContent)
     = Manager -> BaseUrl -> ClientM NoContent
   clientWithRoute Proxy req manager baseurl =
-    performRequestNoBody method req manager baseurl >> return NoContent
+    performRequestNoBody method req >> return NoContent
       where method = reflectMethod (Proxy :: Proxy method)
 
 instance OVERLAPPING_
@@ -175,7 +175,7 @@ instance OVERLAPPING_
     = Manager -> BaseUrl -> ClientM (Headers ls a)
   clientWithRoute Proxy req manager baseurl = do
     let method = reflectMethod (Proxy :: Proxy method)
-    (hdrs, resp) <- performRequestCT (Proxy :: Proxy ct) method req manager baseurl
+    (hdrs, resp) <- performRequestCT (Proxy :: Proxy ct) method req 
     return $ Headers { getResponse = resp
                      , getHeadersHList = buildHeadersTo hdrs
                      }
@@ -187,7 +187,7 @@ instance OVERLAPPING_
     = Manager -> BaseUrl -> ClientM (Headers ls NoContent)
   clientWithRoute Proxy req manager baseurl = do
     let method = reflectMethod (Proxy :: Proxy method)
-    hdrs <- performRequestNoBody method req manager baseurl
+    hdrs <- performRequestNoBody method req 
     return $ Headers { getResponse = NoContent
                      , getHeadersHList = buildHeadersTo hdrs
                      }
@@ -372,7 +372,7 @@ instance (KnownSymbol sym, HasClient api)
 -- back the full `Response`.
 instance HasClient Raw where
   type Client Raw
-    = H.Method -> Manager -> BaseUrl -> ClientM (Int, ByteString, MediaType, [HTTP.Header], Response ByteString)
+    = H.Method ->  ClientM (Int, ByteString, MediaType, [HTTP.Header], Response ByteString)
 
   clientWithRoute :: Proxy Raw -> Req -> Client Raw
   clientWithRoute Proxy req httpMethod = do

--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -22,9 +22,9 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.Except
 
 #if MIN_VERSION_http_client(0,4,19)
-import Network.HTTP.Client ( HasHttpManager )
+import Network.HTTP.Client hiding (Proxy, path)
 #else
-import Network.HTTP.Client.Conduit ( HasHttpManager(getHttpManager) )
+import Network.HTTP.Client.Conduit hiding (Proxy, path)
 #endif
 
 
@@ -38,7 +38,6 @@ import Data.Proxy
 import Data.Text (Text)
 import Data.Text.Encoding
 import Data.Typeable
-import Network.HTTP.Client hiding (Proxy, path)
 import Network.HTTP.Media
 import Network.HTTP.Types
 import qualified Network.HTTP.Types.Header   as HTTP

--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -21,6 +21,13 @@ import Control.Monad.Error.Class (MonadError(..))
 #endif
 import Control.Monad.Trans.Except
 
+#if MIN_VERSION_http_client(0,4,19)
+import Network.HTTP.Client ( HasHttpManager )
+#else
+import Network.HTTP.Client.Conduit ( HasHttpManager(getHttpManager) )
+#endif
+
+
 import GHC.Generics
 import Control.Monad.IO.Class ()
 import Control.Monad.Reader

--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -21,12 +21,6 @@ import Control.Monad.Error.Class (MonadError(..))
 #endif
 import Control.Monad.Trans.Except
 
-#if MIN_VERSION_http_client(0,4,19)
-import Network.HTTP.Client hiding (Proxy, path)
-#else
-import Network.HTTP.Client.Conduit hiding (Proxy, path)
-#endif
-
 
 import GHC.Generics
 import Control.Monad.IO.Class ()
@@ -40,6 +34,7 @@ import Data.Text.Encoding
 import Data.Typeable
 import Network.HTTP.Media
 import Network.HTTP.Types
+import Network.HTTP.Client hiding (Proxy, path)
 import qualified Network.HTTP.Types.Header   as HTTP
 import Network.URI hiding (path)
 import Servant.API.ContentTypes
@@ -173,8 +168,6 @@ data ClientEnv
   , baseUrl :: BaseUrl
   }
 
-instance HasHttpManager ClientEnv where
-    getHttpManager = manager
 
 -- | @ClientM@ is the monad in which client functions run. Contains the
 -- 'Manager' and 'BaseUrl' used for requests in the reader environment.

--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -175,13 +175,13 @@ performRequest :: Method -> Req
                -> ClientM ( Int, ByteString, MediaType
                           , [HTTP.Header], Response ByteString)
 performRequest reqMethod req = do
-  manager <- asks manager
+  m <- asks manager
   reqHost <- asks baseUrl
   partialRequest <- liftIO $ reqToRequest req reqHost
 
   let request = partialRequest { Client.method = reqMethod }
 
-  eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request manager
+  eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request m
   case eResponse of
     Left err ->
       throwError . ConnectionError $ SomeException err


### PR DESCRIPTION
As discussed in https://github.com/haskell-servant/servant/issues/563

This would change the definition of clientM from
```haskell
type ClientM = ExceptT ServantError IO
```

to
```haskell
newtype ClientM a = ClientM { runClientM' :: ReaderT ClientEnv (ExceptT ServantError IO) a }
```

where ClientEnv is just a record of `Manager` and `BaseUrl`

I added `mtl` as a dependency,  but I am not sure about the version boundaries.