### PR TITLE
Mime unrender multiple

### DIFF
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -111,10 +111,10 @@ test-suite spec
       base == 4.*
     , base-compat
     , aeson
+    , aeson-compat >=0.3.3 && <0.4
     , attoparsec
     , bytestring
     , hspec == 2.*
-    , http-media
     , QuickCheck
     , quickcheck-instances
     , servant

--- a/stack-ghc-7.8.4.yaml
+++ b/stack-ghc-7.8.4.yaml
@@ -6,6 +6,7 @@ packages:
 - servant-foreign/
 - servant-server/
 extra-deps:
+- aeson-compat-0.3.6
 - base-compat-0.9.1
 - control-monad-omega-0.3.1
 - cryptonite-0.6


### PR DESCRIPTION
Follow-up to #614, makes possible to resolve problem in #552 without complicating general `servant-client` code: the problem solution will go into client application.

/cc @jkarni @soenkehahn @cdepillabout 

I added an `aeson-compat` dependency, as it makes test pass on ghc-7.8. With old enough `aeson`, vanilla `decode` doesn't accept top-level scalars (i.e. accepts only arrays and objects, which leads to wtf-situations). Alternatively one could bump aeson version for tests.
