### PR TITLE
Add a field to Delayed for storing a clean up action

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -102,6 +102,7 @@ test-suite spec
       Servant.ArbitraryMonadServerSpec
       Servant.Server.ErrorSpec
       Servant.Server.Internal.ContextSpec
+      Servant.Server.Internal.RoutingApplicationSpec
       Servant.Server.RouterSpec
       Servant.Server.StreamingSpec
       Servant.Server.UsingContextSpec

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -398,7 +398,7 @@ instance HasServer Raw context where
   type ServerT Raw m = Application
 
   route Proxy _ rawApplication = RawRouter $ \ env request respond -> do
-    r <- runDelayed rawApplication env request
+    (r, _) <- runDelayed rawApplication env request
     case r of
       Route app   -> app request (respond . Route)
       Fail a      -> respond $ Fail a

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -10,10 +10,10 @@
 module Servant.Server.Internal.RoutingApplication where
 
 import           Control.Exception                  (bracket)
-import           Control.Monad                      (ap, liftM)
+import           Control.Monad                      (ap, liftM, (>=>))
 import           Control.Monad.Trans                (MonadIO(..))
 import           Control.Monad.Trans.Except         (runExceptT)
-import           Data.IORef                         (newIORef, readIORef, writeIORef)
+import           Data.IORef                         (newIORef, readIORef, writeIORef, IORef, atomicModifyIORef)
 import           Network.Wai                        (Application, Request,
                                                      Response, ResponseReceived)
 import           Prelude                            ()
@@ -106,10 +106,6 @@ data Delayed env c where
              , authD     :: DelayedIO auth
              , bodyD     :: DelayedIO body
              , serverD   :: captures -> auth -> body -> Request -> RouteResult c
-             , cleanupD  :: body -> IO ()
-               -- not in DelayedIO because:
-               -- - most likely should not depend on the request
-               -- - simpler
              } -> Delayed env c
 
 instance Functor (Delayed env) where
@@ -119,12 +115,33 @@ instance Functor (Delayed env) where
       , ..
       } -- Note [Existential Record Update]
 
+-- | A mutable cleanup action
+newtype CleanupRef = CleanupRef (IORef (IO ()))
+
+newCleanupRef :: IO CleanupRef
+newCleanupRef = CleanupRef <$> newIORef (return ())
+
+-- | Add a clean up action to a 'CleanupRef'
+addCleanup' :: IO () -> CleanupRef -> IO ()
+addCleanup' act (CleanupRef ref) = atomicModifyIORef ref (\act' -> (act' >> act, ()))
+
+addCleanup :: IO () -> DelayedIO ()
+addCleanup act = DelayedIO $ \_req cleanupRef ->
+  addCleanup' act cleanupRef >> return (Route ())
+
+-- | Run all the clean up actions registered in
+--   a 'CleanupRef'.
+runCleanup :: CleanupRef -> IO ()
+runCleanup (CleanupRef ref) = do
+  act <- readIORef ref
+  act
+
 -- | Computations used in a 'Delayed' can depend on the
 -- incoming 'Request', may perform 'IO, and result in a
 -- 'RouteResult, meaning they can either suceed, fail
 -- (with the possibility to recover), or fail fatally.
 --
-newtype DelayedIO a = DelayedIO { runDelayedIO :: Request -> IO (RouteResult a) }
+newtype DelayedIO a = DelayedIO { runDelayedIO :: Request -> CleanupRef -> IO (RouteResult a) }
 
 instance Functor DelayedIO where
   fmap = liftM
@@ -134,36 +151,36 @@ instance Applicative DelayedIO where
   (<*>) = ap
 
 instance Monad DelayedIO where
-  return x = DelayedIO (const $ return (Route x))
+  return x = DelayedIO (\_req _cleanup -> return (Route x))
   DelayedIO m >>= f =
-    DelayedIO $ \ req -> do
-      r <- m req
+    DelayedIO $ \ req cl -> do
+      r <- m req cl
       case r of
         Fail      e -> return $ Fail e
         FailFatal e -> return $ FailFatal e
-        Route     a -> runDelayedIO (f a) req
+        Route     a -> runDelayedIO (f a) req cl
 
 instance MonadIO DelayedIO where
-  liftIO m = DelayedIO (const $ Route <$> m)
+  liftIO m = DelayedIO (\_req _cl -> Route <$> m)
 
 -- | A 'Delayed' without any stored checks.
 emptyDelayed :: RouteResult a -> Delayed env a
 emptyDelayed result =
-  Delayed (const r) r r r (\ _ _ _ _ -> result) (const $ return ())
+  Delayed (const r) r r r (\ _ _ _ _ -> result)
   where
     r = return ()
 
 -- | Fail with the option to recover.
 delayedFail :: ServantErr -> DelayedIO a
-delayedFail err = DelayedIO (const $ return $ Fail err)
+delayedFail err = DelayedIO (\_req _cleanup -> return $ Fail err)
 
 -- | Fail fatally, i.e., without any option to recover.
 delayedFailFatal :: ServantErr -> DelayedIO a
-delayedFailFatal err = DelayedIO (const $ return $ FailFatal err)
+delayedFailFatal err = DelayedIO (\_req _cleanup -> return $ FailFatal err)
 
 -- | Gain access to the incoming request.
 withRequest :: (Request -> DelayedIO a) -> DelayedIO a
-withRequest f = DelayedIO (\ req -> runDelayedIO (f req) req)
+withRequest f = DelayedIO (\ req cl -> runDelayedIO (f req) req cl)
 
 -- | Add a capture to the end of the capture block.
 addCapture :: Delayed env (a -> b)
@@ -205,7 +222,6 @@ addBodyCheck Delayed{..} new =
   Delayed
     { bodyD    = (,) <$> bodyD <*> new
     , serverD  = \ c a (z, v) req -> ($ v) <$> serverD c a z req
-    , cleanupD = cleanupD . fst -- not sure that's right
     , ..
     } -- Note [Existential Record Update]
 
@@ -248,19 +264,18 @@ passToServer Delayed{..} x =
 runDelayed :: Delayed env a
            -> env
            -> Request
-           -> IO (RouteResult a, IO ())
-runDelayed Delayed{..} env req = do
-  cleanupRef <- newIORef (return ())
-  routeRes <- runDelayedIO
+           -> CleanupRef
+           -> IO (RouteResult a)
+runDelayed Delayed{..} env req cleanupRef =
+  runDelayedIO
     (do c <- capturesD env
         methodD
         a <- authD
         b <- bodyD
-        liftIO (writeIORef cleanupRef $ cleanupD b)
-        DelayedIO $ \ r -> return (serverD c a b r)
+        DelayedIO $ \ r _cleanup -> return (serverD c a b r)
     )
     req
-  fmap (routeRes,) $ readIORef cleanupRef
+    cleanupRef
 
 -- | Runs a delayed server and the resulting action.
 -- Takes a continuation that lets us send a response.
@@ -272,10 +287,11 @@ runAction :: Delayed env (Handler a)
           -> (RouteResult Response -> IO r)
           -> (a -> RouteResult Response)
           -> IO r
-runAction action env req respond k =
-  bracket (runDelayed action env req)
-          snd
-          (\(res, _) -> go res >>= respond)
+runAction action env req respond k = do
+  cleanupRef <- newCleanupRef
+  bracket (runDelayed action env req cleanupRef)
+          (const $ runCleanup cleanupRef)
+          (go >=> respond)
 
   where
     go (Fail e)      = return $ Fail e

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -256,7 +256,7 @@ runDelayed Delayed{..} env req = do
         a <- authD
         b <- bodyD
         liftIO (writeIORef cleanupRef $ cleanupD b)
-        DelayedIO $ \ req -> return (serverD c a b req)
+        DelayedIO $ \ r -> return (serverD c a b r)
     )
     req
   fmap (routeRes,) $ readIORef cleanupRef

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TupleSections              #-}
 module Servant.Server.Internal.RoutingApplication where
 
-import           Control.Exception                  (bracket)
+import           Control.Exception                  (finally)
 import           Control.Monad                      (ap, liftM, (>=>))
 import           Control.Monad.Trans                (MonadIO(..))
 import           Control.Monad.Trans.Except         (runExceptT)
@@ -289,9 +289,8 @@ runAction :: Delayed env (Handler a)
           -> IO r
 runAction action env req respond k = do
   cleanupRef <- newCleanupRef
-  bracket (runDelayed action env req cleanupRef)
-          (const $ runCleanup cleanupRef)
-          (go >=> respond)
+  (runDelayed action env req cleanupRef >>= go >>= respond)
+    `finally` runCleanup cleanupRef
 
   where
     go (Fail e)      = return $ Fail e

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -10,10 +10,10 @@
 module Servant.Server.Internal.RoutingApplication where
 
 import           Control.Exception                  (finally)
-import           Control.Monad                      (ap, liftM, (>=>))
+import           Control.Monad                      (ap, liftM)
 import           Control.Monad.Trans                (MonadIO(..))
 import           Control.Monad.Trans.Except         (runExceptT)
-import           Data.IORef                         (newIORef, readIORef, writeIORef, IORef, atomicModifyIORef)
+import           Data.IORef                         (newIORef, readIORef, IORef, atomicModifyIORef)
 import           Network.Wai                        (Application, Request,
                                                      Response, ResponseReceived)
 import           Prelude                            ()

--- a/servant-server/test/Servant/Server/Internal/RoutingApplicationSpec.hs
+++ b/servant-server/test/Servant/Server/Internal/RoutingApplicationSpec.hs
@@ -1,0 +1,51 @@
+module Servant.Server.Internal.RoutingApplicationSpec (spec) where
+
+import Control.Exception hiding (Handler)
+import Control.Monad.IO.Class
+import Servant.Server
+import Servant.Server.Internal.RoutingApplication
+import System.Directory
+import Test.Hspec
+
+ok :: IO (RouteResult ())
+ok = return (Route ())
+
+delayed :: DelayedIO () -> RouteResult (Handler ()) -> Delayed () (Handler ())
+delayed body srv = Delayed
+  { capturesD = \() -> DelayedIO $ \_req _cl -> ok
+  , methodD = DelayedIO $ \_req_ _cl -> ok
+  , authD = DelayedIO $ \_req _cl -> ok
+  , bodyD = do
+      liftIO (writeFile "delayed.test" "hia")
+      addCleanup (removeFile "delayed.test" >> putStrLn "file removed")
+      body
+  , serverD = \() () _body _req -> srv
+  }
+
+simpleRun :: Delayed () (Handler ())
+          -> IO ()
+simpleRun d = fmap (either ignoreE id) . try $
+  runAction d () undefined (\_ -> return ()) (\_ -> FailFatal err500)
+
+  where ignoreE :: SomeException -> ()
+        ignoreE = const ()
+
+spec :: Spec
+spec = do
+  describe "Delayed" $ do
+    it "actually runs clean up actions" $ do
+      _ <- simpleRun $ delayed (return ()) (Route $ return ())
+      fileStillThere <- doesFileExist "delayed.test"
+      fileStillThere `shouldBe` False
+    it "even with exceptions in serverD" $ do
+      _ <- simpleRun $ delayed (return ()) (Route $ throw DivideByZero)
+      fileStillThere <- doesFileExist "delayed.test"
+      fileStillThere `shouldBe` False
+    it "even with routing failure in bodyD" $ do
+      _ <- simpleRun $ delayed (delayedFailFatal err500) (Route $ return ())
+      fileStillThere <- doesFileExist "delayed.test"
+      fileStillThere `shouldBe` False
+    it "even with exceptions in bodyD" $ do
+      _ <- simpleRun $ delayed (liftIO $ throwIO DivideByZero) (Route $ return ())
+      fileStillThere <- doesFileExist "delayed.test"
+      fileStillThere `shouldBe` False


### PR DESCRIPTION
I need something like this in [servant-multipart](https://github.com/haskell-servant/servant-multipart) in order to delete files created in a temporary dir once the handler has run.

This is not the definitive code, but at least we can start a discussion.

For instance, @jkarni pointed out that the clean up might not always run with the code as is because of exceptions.

I decided to make the clean up actions live in `IO` (and not `DelayedIO`) because most of the time, if not always, the code we want to run there lives in `IO` and doesn't really need access to the request, but rather to something created in the body.
