### PR TITLE
Generic client

### DIFF
--- a/servant-client/CHANGELOG.md
+++ b/servant-client/CHANGELOG.md
@@ -7,6 +7,8 @@
 * client asks for any content-type in Accept contentTypes non-empty list
   ([#615](https://github.com/haskell-servant/servant/pull/615))
 
+* Add `ClientLike` class that matches client functions generated using `client` with client data structure.
+
 0.9.1.1
 -------
 

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -43,7 +43,7 @@ library
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , bytestring            >= 0.10     && < 0.11
     , exceptions            >= 0.8      && < 0.9
-    , generics-sop
+    , generics-sop          >= 0.1.0.0  && < 0.3
     , http-api-data         >= 0.3      && < 0.4
     , http-client           >= 0.4.18.1 && < 0.6
     , http-client-tls       >= 0.2.2    && < 0.4

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
     Servant.Client
+    Servant.Client.Generic
     Servant.Client.Experimental.Auth
     Servant.Common.BaseUrl
     Servant.Common.BasicAuth
@@ -42,6 +43,7 @@ library
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , bytestring            >= 0.10     && < 0.11
     , exceptions            >= 0.8      && < 0.9
+    , generics-sop
     , http-api-data         >= 0.3      && < 0.4
     , http-client           >= 0.4.18.1 && < 0.6
     , http-client-tls       >= 0.2.2    && < 0.4

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -98,3 +98,4 @@ test-suite spec
     , transformers-compat
     , wai
     , warp
+    , generics-sop

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -5,12 +5,14 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Servant.Client.Generic
   ( ClientLike(..)
-  , genericMkClient
+  , genericMkClientL
+  , genericMkClientP
   ) where
 
-import Generics.SOP   (Generic, I(..), NP(..), NS(Z), Rep, SOP(..), to)
+import Generics.SOP   (Code, Generic, I(..), NP(..), NS(Z), Rep, SOP(..), to)
 import Servant.API    ((:<|>)(..))
 import Servant.Client (ClientM)
 
@@ -40,20 +42,20 @@ import Servant.Client (ClientM)
 -- > instance (Client API ~ client) => ClientLike client APIClient
 -- >
 -- > data NestedClient = NestedClient
--- >  { getString ::  ClientM String
+-- >  { getString :: ClientM String
 -- >  , postBaz   :: Maybe Char -> ClientM ()
 -- >  } deriving GHC.Generic
 -- >
--- > instance Generic.SOP.Generic
+-- > instance Generic.SOP.Generic NestedClient
 -- > instance (Client NestedAPI ~ client) => ClientLike client NestedClient
 -- >
 -- > mkAPIClient :: APIClient
 -- > mkAPIClient = mkClient (client (Proxy :: Proxy API))
 class ClientLike client custom where
   mkClient :: client -> custom
-  default mkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)
+  default mkClient :: (Generic custom, Code custom ~ '[xs], GClientList client '[], GClientLikeL (ClientList client '[]) xs)
     => client -> custom
-  mkClient = genericMkClient
+  mkClient = genericMkClientL
 
 instance ClientLike client custom
       => ClientLike (a -> client) (a -> custom) where
@@ -62,9 +64,7 @@ instance ClientLike client custom
 instance ClientLike (ClientM a) (ClientM a) where
   mkClient = id
 
--- | This class is used to match client functions to the
--- representation of client structure type as sum of products
--- and basically does all the internal job to build this structure.
+-- GClientLikeP
 class GClientLikeP client xs where
   gMkClientP :: client -> NP I xs
 
@@ -75,8 +75,37 @@ instance (GClientLikeP b (y ': xs), ClientLike a x)
 instance ClientLike a x => GClientLikeP a '[x] where
   gMkClientP a = I (mkClient a) :* Nil
 
+-- GClientLikeL
+class GClientLikeL (xs :: [*]) (ys :: [*]) where
+  gMkClientL :: NP I xs -> NP I ys
+
+instance GClientLikeL '[] '[] where
+  gMkClientL Nil = Nil
+
+instance (ClientLike x y, GClientLikeL xs ys) => GClientLikeL (x ': xs) (y ': ys) where
+  gMkClientL (I x :* xs) = I (mkClient x) :* gMkClientL xs
+
+type family ClientList (client :: *) (acc :: [*]) :: [*] where
+  ClientList (a :<|> b) acc = ClientList a (ClientList b acc)
+  ClientList a acc = a ': acc
+
+class GClientList client (acc :: [*]) where
+  gClientList :: client -> NP I acc -> NP I (ClientList client acc)
+
+instance (GClientList b acc, GClientList a (ClientList b acc))
+  => GClientList (a :<|> b) acc where
+  gClientList (a :<|> b) acc = gClientList a (gClientList b acc)
+
+instance {-# OVERLAPPABLE #-} (ClientList client acc ~ (client ': acc))
+  => GClientList client acc where
+  gClientList c acc = I c :* acc
+
 -- | Generate client structure from client type.
-genericMkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)
+genericMkClientL :: (Generic custom, Code custom ~ '[xs], GClientList client '[], GClientLikeL (ClientList client '[]) xs)
   => client -> custom
-genericMkClient = to . SOP . Z . gMkClientP
+genericMkClientL = to . SOP . Z . gMkClientL . flip gClientList Nil
+
+genericMkClientP :: (Generic custom, Code custom ~ '[xs], GClientLikeP client xs)
+  => client -> custom
+genericMkClientP = to . SOP . Z . gMkClientP
 

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -21,6 +21,7 @@ import Servant.Client (ClientM)
 --
 -- Example:
 --
+-- @
 -- type API
 --     = "foo" :> Capture "x" Int :> Get '[JSON] Int
 --  :<|> "bar" :> QueryParam "a" Char :> QueryParam "b" String :> Post '[JSON] [Int]
@@ -31,8 +32,8 @@ import Servant.Client (ClientM)
 --  :<|> "baz" :> QueryParam "c" Char :> Post '[JSON] ()
 --
 -- data APIClient = APIClient
---   { getFoo         :: Int -> Manager -> BaseUrl -> ClientM Int
---   , postBar        :: Maybe Char -> Maybe String -> Manager -> BaseUrl -> ClientM [Int]
+--   { getFoo         :: Int -> ClientM Int
+--   , postBar        :: Maybe Char -> Maybe String -> ClientM [Int]
 --   , mkNestedClient :: Int -> NestedClient
 --   } deriving GHC.Generic
 --
@@ -40,8 +41,8 @@ import Servant.Client (ClientM)
 -- instance (Client API ~ client) => ClientLike client APIClient
 --
 -- data NestedClient = NestedClient
---  { getString :: Manager -> BaseUrl -> ClientM String
---  , postBaz   :: Maybe Char -> Manager -> BaseUrl -> ClientM ()
+--  { getString ::  ClientM String
+--  , postBaz   :: Maybe Char -> ClientM ()
 --  } deriving GHC.Generic
 --
 -- instance Generic.SOP.Generic
@@ -49,6 +50,7 @@ import Servant.Client (ClientM)
 --
 -- mkAPIClient :: APIClient
 -- mkAPIClient = mkClient (client (Proxy :: Proxy API))
+-- @
 class ClientLike client custom where
   mkClient :: client -> custom
   default mkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Servant.Client.Generic
+  ( ClientLike(..)
+  , genericMkClient
+  ) where
+
+import Generics.SOP   (Generic, I(..), NP(..), NS(Z), Rep, SOP(..), to)
+import Servant.API    ((:<|>)(..))
+import Servant.Client (ClientM)
+
+-- | This class allows us to match client structure with client functions
+-- produced with 'client' without explicit pattern-matching.
+--
+-- The client structure needs a 'Generics.SOP.Generic' instance.
+--
+-- Example:
+--
+-- type API
+--     = "foo" :> Capture "x" Int :> Get '[JSON] Int
+--  :<|> "bar" :> QueryParam "a" Char :> QueryParam "b" String :> Post '[JSON] [Int]
+--  :<|> Captre "nested" Int :> NestedAPI
+--
+-- type NestedAPI
+--     = Get '[JSON] String
+--  :<|> "baz" :> QueryParam "c" Char :> Post '[JSON] ()
+--
+-- data APIClient = APIClient
+--   { getFoo         :: Int -> Manager -> BaseUrl -> ClientM Int
+--   , postBar        :: Maybe Char -> Maybe String -> Manager -> BaseUrl -> ClientM [Int]
+--   , mkNestedClient :: Int -> NestedClient
+--   } deriving GHC.Generic
+--
+-- instance Generic.SOP.Generic APIClient
+-- instance (Client API ~ client) => ClientLike client APIClient
+--
+-- data NestedClient = NestedClient
+--  { getString :: Manager -> BaseUrl -> ClientM String
+--  , postBaz   :: Maybe Char -> Manager -> BaseUrl -> ClientM ()
+--  } deriving GHC.Generic
+--
+-- instance Generic.SOP.Generic
+-- instance (Client NestedAPI ~ client) => ClientLike client NestedAPI
+--
+-- mkAPIClient :: APIClient
+-- mkAPIClient = mkClient (client (Proxy :: Proxy API))
+class ClientLike client custom where
+  mkClient :: client -> custom
+  default mkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)
+    => client -> custom
+  mkClient = genericMkClient
+
+instance ClientLike client custom
+      => ClientLike (a -> client) (a -> custom) where
+  mkClient c = mkClient . c
+
+instance ClientLike (ClientM a) (ClientM a) where
+  mkClient = id
+
+-- | This class is used to match client functions to the
+-- representation of client structure type as sum of products
+-- and basically does all the internal job to build this structure.
+class GClientLikeP client xs where
+  gMkClientP :: client -> NP I xs
+
+instance (GClientLikeP b (y ': xs), ClientLike a x)
+      => GClientLikeP (a :<|> b) (x ': y ': xs) where
+  gMkClientP (a :<|> b) = I (mkClient a) :* gMkClientP b
+
+instance ClientLike a x => GClientLikeP a '[x] where
+  gMkClientP a = I (mkClient a) :* Nil
+
+-- | Generate client structure from client type.
+genericMkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)
+  => client -> custom
+genericMkClient = to . SOP . Z . gMkClientP
+

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -21,36 +21,34 @@ import Servant.Client (ClientM)
 --
 -- Example:
 --
--- @
--- type API
---     = "foo" :> Capture "x" Int :> Get '[JSON] Int
---  :<|> "bar" :> QueryParam "a" Char :> QueryParam "b" String :> Post '[JSON] [Int]
---  :<|> Captre "nested" Int :> NestedAPI
---
--- type NestedAPI
---     = Get '[JSON] String
---  :<|> "baz" :> QueryParam "c" Char :> Post '[JSON] ()
---
--- data APIClient = APIClient
---   { getFoo         :: Int -> ClientM Int
---   , postBar        :: Maybe Char -> Maybe String -> ClientM [Int]
---   , mkNestedClient :: Int -> NestedClient
---   } deriving GHC.Generic
---
--- instance Generic.SOP.Generic APIClient
--- instance (Client API ~ client) => ClientLike client APIClient
---
--- data NestedClient = NestedClient
---  { getString ::  ClientM String
---  , postBaz   :: Maybe Char -> ClientM ()
---  } deriving GHC.Generic
---
--- instance Generic.SOP.Generic
--- instance (Client NestedAPI ~ client) => ClientLike client NestedAPI
---
--- mkAPIClient :: APIClient
--- mkAPIClient = mkClient (client (Proxy :: Proxy API))
--- @
+-- > type API
+-- >     = "foo" :> Capture "x" Int :> Get '[JSON] Int
+-- >  :<|> "bar" :> QueryParam "a" Char :> QueryParam "b" String :> Post '[JSON] [Int]
+-- >  :<|> Capture "nested" Int :> NestedAPI
+-- >
+-- > type NestedAPI
+-- >     = Get '[JSON] String
+-- >  :<|> "baz" :> QueryParam "c" Char :> Post '[JSON] ()
+-- >
+-- > data APIClient = APIClient
+-- >   { getFoo         :: Int -> ClientM Int
+-- >   , postBar        :: Maybe Char -> Maybe String -> ClientM [Int]
+-- >   , mkNestedClient :: Int -> NestedClient
+-- >   } deriving GHC.Generic
+-- >
+-- > instance Generic.SOP.Generic APIClient
+-- > instance (Client API ~ client) => ClientLike client APIClient
+-- >
+-- > data NestedClient = NestedClient
+-- >  { getString ::  ClientM String
+-- >  , postBaz   :: Maybe Char -> ClientM ()
+-- >  } deriving GHC.Generic
+-- >
+-- > instance Generic.SOP.Generic
+-- > instance (Client NestedAPI ~ client) => ClientLike client NestedClient
+-- >
+-- > mkAPIClient :: APIClient
+-- > mkAPIClient = mkClient (client (Proxy :: Proxy API))
 class ClientLike client custom where
   mkClient :: client -> custom
   default mkClient :: (Generic custom, GClientLikeP client xs, SOP I '[xs] ~ Rep custom)

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -6,6 +7,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+#include "overlapping-compat.h"
+
 module Servant.Client.Generic
   ( ClientLike(..)
   , genericMkClientL
@@ -142,7 +146,7 @@ instance (GClientList b acc, GClientList a (ClientList b acc))
   => GClientList (a :<|> b) acc where
   gClientList (a :<|> b) acc = gClientList a (gClientList b acc)
 
-instance {-# OVERLAPPABLE #-} (ClientList client acc ~ (client ': acc))
+instance OVERLAPPABLE_ (ClientList client acc ~ (client ': acc))
   => GClientList client acc where
   gClientList c acc = I c :* acc
 

--- a/servant-client/src/Servant/Client/Generic.hs
+++ b/servant-client/src/Servant/Client/Generic.hs
@@ -114,7 +114,8 @@ instance ClientLike client custom
 instance ClientLike (ClientM a) (ClientM a) where
   mkClient = id
 
--- GClientLikeP
+-- | Match client structure with client functions, regarding left-nested API clients
+-- as separate data structures.
 class GClientLikeP client xs where
   gMkClientP :: client -> NP I xs
 
@@ -125,7 +126,8 @@ instance (GClientLikeP b (y ': xs), ClientLike a x)
 instance ClientLike a x => GClientLikeP a '[x] where
   gMkClientP a = I (mkClient a) :* Nil
 
--- GClientLikeL
+-- | Match client structure with client functions, expanding left-nested API clients
+-- in the same structure.
 class GClientLikeL (xs :: [*]) (ys :: [*]) where
   gMkClientL :: NP I xs -> NP I ys
 

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -264,12 +264,12 @@ genericClientServer :: Application
 genericClientServer = serve (Proxy :: Proxy GenericClientAPI) (
        (\ mx -> case mx of
                   Just x -> return (x*x)
-                  Nothing -> throwE $ ServantErr 400 "missing parameter" "" []
+                  Nothing -> throwError $ ServantErr 400 "missing parameter" "" []
        )
   :<|> nestedServer1
  )
   where
-    nestedServer1 _str = nestedServer2 :<|> (maybe (throwE $ ServantErr 400 "missing parameter" "" []) return)
+    nestedServer1 _str = nestedServer2 :<|> (maybe (throwError $ ServantErr 400 "missing parameter" "" []) return)
     nestedServer2 _int = (\ x y -> return (x + y)) :<|> return ()
 
 {-# NOINLINE manager #-}


### PR DESCRIPTION
This PR is related to #344 and adds the class that matches client functions generated using `client` with data structure (its representation as sum of products).
The structure itself has to be written manually (no TH used here), but we avoid pattern-matching, which is replaced with just one line of code.