### PR TITLE
Throw error on query parameter parse failure

### DIFF
--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.10
+------
+
+* Changed `HasServer` instances for `QueryParam` and `QueryParam` to throw 400
+  when parsing fails
+* Added `paramD` block to `Delayed`
+
 0.7.1
 ------
 

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -26,7 +26,8 @@ import           Control.Monad.Trans        (liftIO)
 import qualified Data.ByteString            as B
 import qualified Data.ByteString.Char8      as BC8
 import qualified Data.ByteString.Lazy       as BL
-import           Data.Maybe                 (fromMaybe, mapMaybe)
+import           Data.Either                (partitionEithers)
+import           Data.Maybe                 (fromMaybe)
 import           Data.String                (fromString)
 import           Data.String.Conversions    (cs, (<>))
 import           Data.Typeable
@@ -43,7 +44,7 @@ import           Network.Wai                (Application, Request, Response,
 import           Prelude                    ()
 import           Prelude.Compat
 import           Web.HttpApiData            (FromHttpApiData, parseHeaderMaybe,
-                                             parseQueryParamMaybe,
+                                             parseQueryParam,
                                              parseUrlPieceMaybe,
                                              parseUrlPieces)
 import           Servant.API                 ((:<|>) (..), (:>), BasicAuth, Capture,
@@ -308,14 +309,23 @@ instance (KnownSymbol sym, FromHttpApiData a, HasServer api context)
     Maybe a -> ServerT api m
 
   route Proxy context subserver =
-    let querytext r = parseQueryText $ rawQueryString r
-        param r =
-          case lookup paramname (querytext r) of
-            Nothing       -> Nothing -- param absent from the query string
-            Just Nothing  -> Nothing -- param present with no value -> Nothing
-            Just (Just v) -> parseQueryParamMaybe v -- if present, we try to convert to
-                                        -- the right type
-    in route (Proxy :: Proxy api) context (passToServer subserver param)
+    let querytext req = parseQueryText $ rawQueryString req
+        parseParam req =
+          case lookup paramname (querytext req) of
+            Nothing       -> return Nothing -- param absent from the query string
+            Just Nothing  -> return Nothing -- param present with no value -> Nothing
+            Just (Just v) ->
+              case parseQueryParam v of
+                  -- TODO: This should set an error description (including
+                  -- paramname)
+                  Left _e -> delayedFailFatal err400 -- parsing the request
+                                                     -- paramter failed
+
+                  Right param -> return $ Just param
+        delayed = addParameterCheck subserver . withRequest $ \req ->
+                    parseParam req
+
+    in route (Proxy :: Proxy api) context delayed
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
 
 -- | If you use @'QueryParams' "authors" Text@ in one of the endpoints for your API,
@@ -349,12 +359,20 @@ instance (KnownSymbol sym, FromHttpApiData a, HasServer api context)
         -- named "foo" or "foo[]" and call parseQueryParam on the
         -- corresponding values
         parameters r = filter looksLikeParam (querytext r)
-        values r = mapMaybe (convert . snd) (parameters r)
-    in  route (Proxy :: Proxy api) context (passToServer subserver values)
+        parseParam (paramName, paramTxt) =
+          case parseQueryParam (fromMaybe "" paramTxt) of
+              Left _e -> Left paramName -- On error, remember name of parameter
+              Right paramVal -> Right paramVal
+        parseParams req =
+          case partitionEithers $ parseParam <$> parameters req of
+              ([], params) -> return params -- No errors
+              -- TODO: This should set an error description
+              (_errors, _) -> delayedFailFatal err400
+        delayed = addParameterCheck subserver . withRequest $ \req ->
+                    parseParams req
+    in  route (Proxy :: Proxy api) context delayed
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
           looksLikeParam (name, _) = name == paramname || name == (paramname <> "[]")
-          convert Nothing = Nothing
-          convert (Just v) = parseQueryParamMaybe v
 
 -- | If you use @'QueryFlag' "published"@ in one of the endpoints for your API,
 -- this automatically requires your server-side handler to be a function


### PR DESCRIPTION
`QueryParam` and `QueryParams` pass `Nothing` to the handler when parsing the parameters fails. This is counter-intuitive and IMO makes the parsing functionality almost useless. 

This pull-request changes the HasServer instance to throw error400 when parsing fails. In case where parse failures are to be dealt with gracefully the user can define a new type:

```haskell
data MayFail a = Success a
               | Failed Text Text -- Original Text and error message

instance FromHttpApiData a => FromHttpApiData (MayFail a) where
  parseQueryParam txt =
    Right $ case parseQueryParam txt of
              Left e -> Failed txt e
              Right r -> Success r
```
or similar or just take `Text` parameters directly. 

(Maybe servant should provide this for convenience?)

Related to #256

#### Technical Details:

* I added a new `serverD` block to the `Delayed` type because none of the existing blocks seemed to be appropriate. The block is executed last, even after bodyD because this is the only way to guarantee that 400 has the least priority (bodyD can also return 406 and 415)

#### RFCs:
* When returning errors in the 400 range, the HTTP spec recommends :
> The 4xx class of status code is intended for cases in which the client seems to have erred. Except when responding to a HEAD request, the server SHOULD include an entity containing an explanation of the error situation, and whether it is a temporary or permanent condition. These status codes are applicable to any request method. User agents SHOULD display any included entity to the user.

And of course this would greatly aid debugging of requests, but I left this as a TODO because I wasn't sure what format to put the error messages in and whether to include the parse errors. 

* Parse error propagation for `Header`s could use the same `Delayed` block, but this isn't implemented in this PR (yet?). In this case it might be better to rename it to something different than `paramD`. Suggestions?
