### PR TITLE
servant-client: generalize the function to set the request body

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -1,5 +1,5 @@
 name:                servant-client
-version:             0.9.1.1
+version:             0.9.2.0
 synopsis: automatical derivation of querying functions for servant webservices
 description:
   This library lets you derive automatically Haskell functions that

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -406,7 +406,7 @@ instance (MimeRender ct a, HasClient api)
   clientWithRoute Proxy req body =
     clientWithRoute (Proxy :: Proxy api)
                     (let ctProxy = Proxy :: Proxy ct
-                     in setRQBody (mimeRender ctProxy body)
+                     in setReqBodyLBS (mimeRender ctProxy body)
                                   -- We use first contentType from the Accept list
                                   (contentType ctProxy)
                                   req


### PR DESCRIPTION
NOTE: This is most probably not ready to be merged yet. It's primarily to aid the discussion in #656.

Rather than hard-coding the `RequestBodyLBS` constructor and be
limited to lazy bytestrings, the new function `setReqBody` just
takes any value of type `RequestBody`.

This has the advantage the we can use streaming request bodies
such as for example constructed by the `streamFile` function in
http-client.