### PR TITLE
Use classes to access context

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -59,6 +59,7 @@ library
       , exceptions         >= 0.8  && < 0.9
       , http-api-data      >= 0.3  && < 0.4
       , http-types         >= 0.8  && < 0.10
+      , lens
       , network-uri        >= 2.6  && < 2.7
       , monad-control      >= 1.0.0.4 && < 1.1
       , mtl                >= 2    && < 2.3

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -131,11 +131,11 @@ import           Servant.Utils.Enter
 -- > main :: IO ()
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
-serve :: (HasServer api '[]) => Proxy api -> Server api -> Application
-serve p = serveWithContext p EmptyContext
+serve :: (HasServer api ()) => Proxy api -> Server api -> Application
+serve p = serveWithContext p ()
 
 serveWithContext :: (HasServer api context)
-    => Proxy api -> Context context -> Server api -> Application
+    => Proxy api -> context -> Server api -> Application
 serveWithContext p context server =
   toApplication (runRouter (route p context (emptyDelayed (Route server))))
 
@@ -190,12 +190,12 @@ serveWithContext p context server =
 -- that one takes precedence. If both parts fail, the \"better\" error
 -- code will be returned.
 --
-layout :: (HasServer api '[]) => Proxy api -> Text
-layout p = layoutWithContext p EmptyContext
+layout :: (HasServer api ()) => Proxy api -> Text
+layout p = layoutWithContext p ()
 
 -- | Variant of 'layout' that takes an additional 'Context'.
 layoutWithContext :: (HasServer api context)
-    => Proxy api -> Context context -> Text
+    => Proxy api -> context -> Text
 layoutWithContext p context =
   routerLayout (route p context (emptyDelayed (FailFatal err501)))
 

--- a/servant-server/src/Servant/Server/Internal/Context.hs
+++ b/servant-server/src/Servant/Server/Internal/Context.hs
@@ -63,14 +63,17 @@ instance (Eq a, Eq (Context as)) => Eq (Context (a ': as)) where
 -- ...
 class HasContextEntry (context :: [*]) (val :: *) where
     getContextEntry :: Context context -> val
+    setContextEntry :: Context context -> val -> Context context
 
 instance OVERLAPPABLE_
          HasContextEntry xs val => HasContextEntry (notIt ': xs) val where
     getContextEntry (_ :. xs) = getContextEntry xs
+    setContextEntry (x :. xs) y = x :. setContextEntry xs y
 
 instance OVERLAPPING_
          HasContextEntry (val ': xs) val where
     getContextEntry (x :. _) = x
+    setContextEntry (_ :. xs) y = y :. xs
 
 -- * support for named subcontexts
 

--- a/servant-server/test/Servant/Server/RouterSpec.hs
+++ b/servant-server/test/Servant/Server/RouterSpec.hs
@@ -67,14 +67,14 @@ distributivitySpec =
       level `shouldHaveSameStructureAs` levelRef
 
 shouldHaveSameStructureAs ::
-  (HasServer api1 '[], HasServer api2 '[]) => Proxy api1 -> Proxy api2 -> Expectation
+  (HasServer api1 (), HasServer api2 ()) => Proxy api1 -> Proxy api2 -> Expectation
 shouldHaveSameStructureAs p1 p2 =
   unless (sameStructure (makeTrivialRouter p1) (makeTrivialRouter p2)) $
     expectationFailure ("expected:\n" ++ unpack (layout p2) ++ "\nbut got:\n" ++ unpack (layout p1))
 
-makeTrivialRouter :: (HasServer layout '[]) => Proxy layout -> Router ()
+makeTrivialRouter :: (HasServer layout ()) => Proxy layout -> Router ()
 makeTrivialRouter p =
-  route p EmptyContext (emptyDelayed (FailFatal err501))
+  route p () (emptyDelayed (FailFatal err501))
 
 type End = Get '[JSON] NoContent
 

--- a/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
+++ b/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
@@ -23,8 +23,8 @@ import           Servant
 
 data ExtractFromContext
 
-instance (HasContextEntry context String, HasServer subApi context) =>
-  HasServer (ExtractFromContext :> subApi) context where
+instance (HasContextEntry context String, HasServer subApi (Context context)) =>
+  HasServer (ExtractFromContext :> subApi) (Context context) where
 
   type ServerT (ExtractFromContext :> subApi) m =
     String -> ServerT subApi m
@@ -39,8 +39,8 @@ instance (HasContextEntry context String, HasServer subApi context) =>
 
 data InjectIntoContext
 
-instance (HasServer subApi (String ': context)) =>
-  HasServer (InjectIntoContext :> subApi) context where
+instance (HasServer subApi (Context (String ': context))) =>
+  HasServer (InjectIntoContext :> subApi) (Context context) where
 
   type ServerT (InjectIntoContext :> subApi) m =
     ServerT subApi m
@@ -55,8 +55,8 @@ instance (HasServer subApi (String ': context)) =>
 
 data NamedContextWithBirdface (name :: Symbol) (subContext :: [*])
 
-instance (HasContextEntry context (NamedContext name subContext), HasServer subApi subContext) =>
-  HasServer (NamedContextWithBirdface name subContext :> subApi) context where
+instance (HasContextEntry context (NamedContext name subContext), HasServer subApi (Context subContext)) =>
+  HasServer (NamedContextWithBirdface name subContext :> subApi) (Context context) where
 
   type ServerT (NamedContextWithBirdface name subContext :> subApi) m =
     ServerT subApi m


### PR DESCRIPTION
As an example what I mean in #689: We don't need to force which construct is used as `context`. Users should be free to pick their own "extensible-records" library (if they want to use one).