### PR TITLE
Use newer release of Pygments

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ Jinja2==2.8
 livereload==2.4.1
 MarkupSafe==0.23
 pathtools==0.1.2
-Pygments==2.1.1
+Pygments==2.2.0
 pytz==2015.7
 PyYAML==3.11
 recommonmark==0.4.0


### PR DESCRIPTION
 * Includes [Haskell types fix by @teh](https://bitbucket.org/birkenfeld/pygments-main/pull-requests/685/two-haskell-fixes/diff)
 * Local docs build then exhibit proper Haskell highlighting including type literals etc:
 ![local combinator docs](https://cloud.githubusercontent.com/assets/3322808/23824256/eef03a46-066a-11e7-8974-dedb7674d47e.png)

 Fixes #359