### PR TITLE
Make servant-foreign build on GHC 8.2

### DIFF
--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -189,7 +189,7 @@ instance (HasForeign lang ftype a, HasForeign lang ftype b)
 
 instance (KnownSymbol sym, HasForeignType lang ftype t, HasForeign lang ftype api)
   => HasForeign lang ftype (Capture sym t :> api) where
-  type Foreign ftype (Capture sym a :> api) = Foreign ftype api
+  type Foreign ftype (Capture sym t :> api) = Foreign ftype api
 
   foreignFor lang Proxy Proxy req =
     foreignFor lang Proxy (Proxy :: Proxy api) $


### PR DESCRIPTION
`servant-foreign` currently fails to build with GHC 8.2. This is because the validity checking for associated type family instances [tightened up](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.2?version=19#Associatedtypefamilyinstancesarepickier) a bit, and now require using the same type variables in the associated family instance as in the instead head itself.

Luckily, this amounts to a single-character change.