### PR TITLE
Add a type representing an empty API

### DIFF
--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -326,6 +326,16 @@ type ProtectedAPI11
  :<|> BasicAuth "my-realm" User :> UserAPI2 -- this is protected by auth
 ```
 
+### Empty APIs
+
+TODO motivation...
+
+``` haskell ignore
+type UserAPI12
+     = UserAPI
+ :<|> EmptyAPI -- this adds nothing to the API
+```
+
 ### Interoperability with `wai`: `Raw`
 
 Finally, we also include a combinator named `Raw` that provides an escape hatch

--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -321,7 +321,7 @@ data BasicAuth (realm :: Symbol) (userData :: *)
 Which is used like so:
 
 ``` haskell
-type ProtectedAPI12
+type ProtectedAPI11
      = UserAPI                              -- this is public
  :<|> BasicAuth "my-realm" User :> UserAPI2 -- this is protected by auth
 ```
@@ -334,7 +334,7 @@ you want to plug a [wai `Application`](http://hackage.haskell.org/package/wai)
 into your webservice:
 
 ``` haskell
-type UserAPI11 = "users" :> Get '[JSON] [User]
+type UserAPI12 = "users" :> Get '[JSON] [User]
                  -- a /users endpoint
 
             :<|> Raw

--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -334,7 +334,7 @@ you want to plug a [wai `Application`](http://hackage.haskell.org/package/wai)
 into your webservice:
 
 ``` haskell
-type UserAPI12 = "users" :> Get '[JSON] [User]
+type UserAPI13 = "users" :> Get '[JSON] [User]
                  -- a /users endpoint
 
             :<|> Raw

--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -345,7 +345,8 @@ type UserAPI12Alone = UserAPI12 EmptyAPI
 ```
 
 This also works well as a placeholder for unfinished parts of an API while it
-is under development.
+is under development, for when you know that there should be _something_ there
+but you don't yet know what. Think of it as similar to the unit type `()`.
 
 ### Interoperability with `wai`: `Raw`
 

--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -328,13 +328,24 @@ type ProtectedAPI11
 
 ### Empty APIs
 
-TODO motivation...
+Sometimes it is useful to be able to generalise an API over the type of some
+part of it:
 
-``` haskell ignore
-type UserAPI12
-     = UserAPI
- :<|> EmptyAPI -- this adds nothing to the API
+``` haskell
+type UserAPI12 innerAPI
+     = UserAPI             -- this is the fixed bit of the API
+ :<|> "inner" :> innerAPI  -- this lets us put various other APIs under /inner
 ```
+
+If there is a case where you do not have anything extra to serve, you can use
+the `EmptyAPI` combinator to indicate this:
+
+``` haskell
+type UserAPI12Alone = UserAPI12 EmptyAPI
+```
+
+This also works well as a placeholder for unfinished parts of an API while it
+is under development.
 
 ### Interoperability with `wai`: `Raw`
 

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -77,8 +77,6 @@ hello :: Maybe String -- ^ an optional value for "name"
 
 marketing :: ClientInfo -- ^ value for the request body
           -> ClientM Email
-
-emptyClient :: EmptyAPIClient
 ```
 
 Each function makes available as an argument any value that the response may
@@ -91,7 +89,7 @@ the function `client`. It takes one argument:
 api :: Proxy API
 api = Proxy
 
-position :<|> hello :<|> marketing :<|> emptyClient = client api
+position :<|> hello :<|> marketing :<|> EmptyClient = client api
 ```
 
 `client api` returns client functions for our _entire_ API, combined with `:<|>`, which we can pattern match on as above. You could say `client` "calculates" the correct type and number of client functions for the API type it is given (via a `Proxy`), as well as their implementations.

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -62,6 +62,7 @@ Enough chitchat, let's see an example. Consider the following API type from the 
 type API = "position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
       :<|> "hello" :> QueryParam "name" String :> Get '[JSON] HelloMessage
       :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email
+      :<|> EmptyAPI
 ```
 
 What we are going to get with **servant-client** here is three functions, one to query each endpoint:
@@ -76,6 +77,8 @@ hello :: Maybe String -- ^ an optional value for "name"
 
 marketing :: ClientInfo -- ^ value for the request body
           -> ClientM Email
+
+emptyClient :: EmptyAPIClient
 ```
 
 Each function makes available as an argument any value that the response may
@@ -88,7 +91,7 @@ the function `client`. It takes one argument:
 api :: Proxy API
 api = Proxy
 
-position :<|> hello :<|> marketing = client api
+position :<|> hello :<|> marketing :<|> emptyClient = client api
 ```
 
 `client api` returns client functions for our _entire_ API, combined with `:<|>`, which we can pattern match on as above. You could say `client` "calculates" the correct type and number of client functions for the API type it is given (via a `Proxy`), as well as their implementations.

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -93,8 +93,9 @@ position :<|> hello :<|> marketing = client api
 
 `client api` returns client functions for our _entire_ API, combined with `:<|>`, which we can pattern match on as above. You could say `client` "calculates" the correct type and number of client functions for the API type it is given (via a `Proxy`), as well as their implementations.
 
-If there is an `EmptyAPI` within your API, this matches the `EmptyClient`
-constructor:
+If you have an `EmptyAPI` in your API, servant-client will hand you a value of
+type `EmptyClient` in the corresponding slot, where `data EmptyClient =
+EmptyClient`, as a way to indicate that you can't do anything useful with it.
 
 ``` haskell ignore
 type API' = API :<|> EmptyAPI

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -62,7 +62,6 @@ Enough chitchat, let's see an example. Consider the following API type from the 
 type API = "position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
       :<|> "hello" :> QueryParam "name" String :> Get '[JSON] HelloMessage
       :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email
-      :<|> EmptyAPI
 ```
 
 What we are going to get with **servant-client** here is three functions, one to query each endpoint:
@@ -89,10 +88,22 @@ the function `client`. It takes one argument:
 api :: Proxy API
 api = Proxy
 
-position :<|> hello :<|> marketing :<|> EmptyClient = client api
+position :<|> hello :<|> marketing = client api
 ```
 
 `client api` returns client functions for our _entire_ API, combined with `:<|>`, which we can pattern match on as above. You could say `client` "calculates" the correct type and number of client functions for the API type it is given (via a `Proxy`), as well as their implementations.
+
+If there is an `EmptyAPI` within your API, this matches the `EmptyClient`
+constructor:
+
+``` haskell ignore
+type API' = API :<|> EmptyAPI
+
+api' :: Proxy API'
+api' = Proxy
+
+(position' :<|> hello' :<|> marketing') :<|> EmptyClient = client api'
+```
 
 ``` haskell ignore
 -- | URI scheme to use

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -38,10 +38,9 @@ Like client function generation, documentation generation amounts to inspecting 
 This time however, we have to assist **servant**. While it is able to deduce a lot of things about our API, it can't magically come up with descriptions of the various pieces of our APIs that are human-friendly and explain what's going on "at the business-logic level". A good example to study for documentation generation is our webservice with the `/position`, `/hello` and `/marketing` endpoints from earlier:
 
 ``` haskell
-type ExampleAPI = ("position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
+type ExampleAPI = "position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
       :<|> "hello" :> QueryParam "name" String :> Get '[JSON] HelloMessage
-      :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email)
-      :<|> EmptyAPI
+      :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email
 
 exampleAPI :: Proxy ExampleAPI
 exampleAPI = Proxy
@@ -221,7 +220,7 @@ api :: Proxy DocsAPI
 api = Proxy
 
 server :: Server DocsAPI
-server = (Server.server3 :<|> emptyServer) :<|> Tagged serveDocs where
+server = Server.server3 :<|> Tagged serveDocs where
     serveDocs _ respond =
         respond $ responseLBS ok200 [plain] docsBS
     plain = ("Content-Type", "text/plain")

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -221,7 +221,7 @@ api :: Proxy DocsAPI
 api = Proxy
 
 server :: Server DocsAPI
-server = (Server.server3 :<|> emptyAPIServer) :<|> Tagged serveDocs where
+server = (Server.server3 :<|> emptyServer) :<|> Tagged serveDocs where
     serveDocs _ respond =
         respond $ responseLBS ok200 [plain] docsBS
     plain = ("Content-Type", "text/plain")

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -38,9 +38,10 @@ Like client function generation, documentation generation amounts to inspecting 
 This time however, we have to assist **servant**. While it is able to deduce a lot of things about our API, it can't magically come up with descriptions of the various pieces of our APIs that are human-friendly and explain what's going on "at the business-logic level". A good example to study for documentation generation is our webservice with the `/position`, `/hello` and `/marketing` endpoints from earlier:
 
 ``` haskell
-type ExampleAPI = "position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
+type ExampleAPI = ("position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
       :<|> "hello" :> QueryParam "name" String :> Get '[JSON] HelloMessage
-      :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email
+      :<|> "marketing" :> ReqBody '[JSON] ClientInfo :> Post '[JSON] Email)
+      :<|> EmptyAPI
 
 exampleAPI :: Proxy ExampleAPI
 exampleAPI = Proxy
@@ -220,7 +221,7 @@ api :: Proxy DocsAPI
 api = Proxy
 
 server :: Server DocsAPI
-server = Server.server3 :<|> Tagged serveDocs where
+server = (Server.server3 :<|> emptyAPIServer) :<|> Tagged serveDocs where
     serveDocs _ respond =
         respond $ responseLBS ok200 [plain] docsBS
     plain = ("Content-Type", "text/plain")

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -89,6 +89,8 @@ instance ToSample Email where
 ```
 
 Types that are used as request or response bodies have to instantiate the `ToSample` typeclass which lets you specify one or more examples of values. `Capture`s and `QueryParam`s have to instantiate their respective `ToCapture` and `ToParam` classes and provide a name and some information about the concrete meaning of that argument, as illustrated in the code above.
+The `EmptyAPI` combinator needs no special treatment as it generates no
+documentation: an empty API has no endpoints to document.
 
 With all of this, we can derive docs for our API.
 

--- a/doc/tutorial/Javascript.lhs
+++ b/doc/tutorial/Javascript.lhs
@@ -149,6 +149,9 @@ Why two different API types, proxies and servers though? Simply because we
 don't want to generate javascript functions for the `Raw` part of our API type,
 so we need a `Proxy` for our API type `API'` without its `Raw` endpoint.
 
+The `EmptyAPI` combinator needs no special treatment as it generates no
+Javascript functions: an empty API has no endpoints to access.
+
 Very similarly to how one can derive haskell functions, we can derive the
 javascript with just a simple function call to `jsForAPI` from
 `Servant.JS`.

--- a/doc/tutorial/Javascript.lhs
+++ b/doc/tutorial/Javascript.lhs
@@ -134,7 +134,7 @@ api' = Proxy
 server :: Server API
 server = randomPoint
     :<|> searchBook
-    :<|> emptyAPIServer
+    :<|> emptyServer
 
 server' :: Server API'
 server' = server

--- a/doc/tutorial/Javascript.lhs
+++ b/doc/tutorial/Javascript.lhs
@@ -45,7 +45,6 @@ Now let's have the API type(s) and the accompanying datatypes.
 ``` haskell
 type API = "point" :> Get '[JSON] Point
       :<|> "books" :> QueryParam "q" Text :> Get '[JSON] (Search Book)
-      :<|> EmptyAPI
 
 type API' = API :<|> Raw
 
@@ -134,7 +133,6 @@ api' = Proxy
 server :: Server API
 server = randomPoint
     :<|> searchBook
-    :<|> emptyServer
 
 server' :: Server API'
 server' = server

--- a/doc/tutorial/Javascript.lhs
+++ b/doc/tutorial/Javascript.lhs
@@ -45,6 +45,7 @@ Now let's have the API type(s) and the accompanying datatypes.
 ``` haskell
 type API = "point" :> Get '[JSON] Point
       :<|> "books" :> QueryParam "q" Text :> Get '[JSON] (Search Book)
+      :<|> EmptyAPI
 
 type API' = API :<|> Raw
 
@@ -133,6 +134,7 @@ api' = Proxy
 server :: Server API
 server = randomPoint
     :<|> searchBook
+    :<|> emptyAPIServer
 
 server' :: Server API'
 server' = server

--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1026,7 +1026,7 @@ TODO prose
 type CombinedAPI2 = API :<|> EmptyAPI
 
 server11 :: Server CombinedAPI2
-server11 = server3 :<|> emptyAPIServer
+server11 = server3 :<|> emptyServer
 ```
 
 ## Using another monad for your handlers

--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1023,10 +1023,10 @@ serverFor = error "..."
 TODO prose
 
 ``` haskell
-type CombinedAPI2 = CombinedAPI :<|> EmptyAPI
+type CombinedAPI2 = API :<|> EmptyAPI
 
 server11 :: Server CombinedAPI2
-server11 = server10 :<|> emptyAPIServer
+server11 = server3 :<|> emptyAPIServer
 ```
 
 ## Using another monad for your handlers

--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1020,8 +1020,9 @@ serverFor = error "..."
 -- or the mailing list if you get stuck!
 ```
 
-If the API contains the `EmptyAPI` combinator, the corresponding server is
-called `emptyServer`:
+When your API contains the `EmptyAPI` combinator, you'll want to use
+`emptyServer` in the corresponding slot for your server, which will simply fail
+with 404 whenever a request reaches it:
 
 ``` haskell
 type CombinedAPI2 = API :<|> "empty" :> EmptyAPI

--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1020,10 +1020,11 @@ serverFor = error "..."
 -- or the mailing list if you get stuck!
 ```
 
-TODO prose
+If the API contains the `EmptyAPI` combinator, the corresponding server is
+called `emptyServer`:
 
 ``` haskell
-type CombinedAPI2 = API :<|> EmptyAPI
+type CombinedAPI2 = API :<|> "empty" :> EmptyAPI
 
 server11 :: Server CombinedAPI2
 server11 = server3 :<|> emptyServer

--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1020,6 +1020,15 @@ serverFor = error "..."
 -- or the mailing list if you get stuck!
 ```
 
+TODO prose
+
+``` haskell
+type CombinedAPI2 = CombinedAPI :<|> EmptyAPI
+
+server11 :: Server CombinedAPI2
+server11 = server10 :<|> emptyAPIServer
+```
+
 ## Using another monad for your handlers
 
 Remember how `Server` turns combinators for HTTP methods into `Handler`? Well, actually, there's more to that. `Server` is actually a

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -24,7 +24,7 @@ module Servant.Client
   , ClientEnv (ClientEnv)
   , mkAuthenticateReq
   , ServantError(..)
-  , EmptyAPIClient(..)
+  , EmptyClient(..)
   , module Servant.Common.BaseUrl
   ) where
 
@@ -90,9 +90,9 @@ instance (HasClient a, HasClient b) => HasClient (a :<|> b) where
     clientWithRoute (Proxy :: Proxy b) req
 
 -- | Singleton type representing a client for an empty API.
-data EmptyAPIClient = EmptyAPIClient
+data EmptyClient = EmptyClient deriving (Eq, Show, Bounded, Enum)
 
--- | The client for 'EmptyAPI' is simply 'EmptyAPIClient'.
+-- | The client for 'EmptyAPI' is simply 'EmptyClient'.
 --
 -- > type MyAPI = "books" :> Get '[JSON] [Book] -- GET /books
 -- >         :<|> "nothing" :> EmptyAPI
@@ -101,10 +101,10 @@ data EmptyAPIClient = EmptyAPIClient
 -- > myApi = Proxy
 -- >
 -- > getAllBooks :: ClientM [Book]
--- > (getAllBooks :<|> EmptyAPIClient) = client myApi
+-- > (getAllBooks :<|> EmptyClient) = client myApi
 instance HasClient EmptyAPI where
-  type Client EmptyAPI = EmptyAPIClient
-  clientWithRoute Proxy _ = EmptyAPIClient
+  type Client EmptyAPI = EmptyClient
+  clientWithRoute Proxy _ = EmptyClient
 
 -- | If you use a 'Capture' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -24,6 +24,7 @@ module Servant.Client
   , ClientEnv (ClientEnv)
   , mkAuthenticateReq
   , ServantError(..)
+  , EmptyAPIClient(..)
   , module Servant.Common.BaseUrl
   ) where
 
@@ -87,6 +88,13 @@ instance (HasClient a, HasClient b) => HasClient (a :<|> b) where
   clientWithRoute Proxy req =
     clientWithRoute (Proxy :: Proxy a) req :<|>
     clientWithRoute (Proxy :: Proxy b) req
+
+-- | TODO docs
+data EmptyAPIClient = EmptyAPIClient
+
+instance HasClient EmptyAPI where
+  type Client EmptyAPI = EmptyAPIClient
+  clientWithRoute Proxy _ = EmptyAPIClient
 
 -- | If you use a 'Capture' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -89,9 +89,19 @@ instance (HasClient a, HasClient b) => HasClient (a :<|> b) where
     clientWithRoute (Proxy :: Proxy a) req :<|>
     clientWithRoute (Proxy :: Proxy b) req
 
--- | TODO docs
+-- | Singleton type representing a client for an empty API.
 data EmptyAPIClient = EmptyAPIClient
 
+-- | The client for 'EmptyAPI' is simply 'EmptyAPIClient'.
+--
+-- > type MyAPI = "books" :> Get '[JSON] [Book] -- GET /books
+-- >         :<|> "nothing" :> EmptyAPI
+-- >
+-- > myApi :: Proxy MyApi
+-- > myApi = Proxy
+-- >
+-- > getAllBooks :: ClientM [Book]
+-- > (getAllBooks :<|> EmptyAPIClient) = client myApi
 instance HasClient EmptyAPI where
   type Client EmptyAPI = EmptyAPIClient
   clientWithRoute Proxy _ = EmptyAPIClient

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -146,7 +146,7 @@ getGet
   :<|> getMultiple
   :<|> getRespHeaders
   :<|> getDeleteContentType
-  :<|> EmptyAPIClient = client api
+  :<|> EmptyClient = client api
 
 server :: Application
 server = serve api (

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -166,8 +166,7 @@ server = serve api (
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)
   :<|> return NoContent
-  :<|> emptyAPIServer
- )
+  :<|> emptyServer)
 
 
 type FailApi =

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -111,6 +111,8 @@ type Api =
             Get '[JSON] (String, Maybe Int, Bool, [(String, [Rational])])
   :<|> "headers" :> Get '[JSON] (Headers TestHeaders Bool)
   :<|> "deleteContentType" :> DeleteNoContent '[JSON] NoContent
+  :<|> "empty" :> EmptyAPI
+
 api :: Proxy Api
 api = Proxy
 
@@ -130,6 +132,7 @@ getMultiple     :: String -> Maybe Int -> Bool -> [(String, [Rational])]
   -> SCR.ClientM (String, Maybe Int, Bool, [(String, [Rational])])
 getRespHeaders  :: SCR.ClientM (Headers TestHeaders Bool)
 getDeleteContentType :: SCR.ClientM NoContent
+
 getGet
   :<|> getDeleteEmpty
   :<|> getCapture
@@ -142,7 +145,8 @@ getGet
   :<|> getRawFailure
   :<|> getMultiple
   :<|> getRespHeaders
-  :<|> getDeleteContentType = client api
+  :<|> getDeleteContentType
+  :<|> EmptyAPIClient = client api
 
 server :: Application
 server = serve api (
@@ -162,6 +166,7 @@ server = serve api (
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)
   :<|> return NoContent
+  :<|> emptyAPIServer
  )
 
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -683,6 +683,10 @@ instance OVERLAPPABLE_
           p2 :: Proxy b
           p2 = Proxy
 
+-- | The generated docs for @'EmptyAPI'@ are empty.
+instance HasDocs EmptyAPI where
+  docsFor Proxy _ _ = emptyAPI
+
 -- | @"books" :> 'Capture' "isbn" Text@ will appear as
 -- @/books/:isbn@ in the docs.
 instance (KnownSymbol sym, ToCapture (Capture sym a), HasDocs api)

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -104,6 +104,9 @@ spec = describe "Servant.Docs" $ do
     it "contains request body samples" $
       md `shouldContain` "17"
 
+    it "does not generate any docs mentioning the 'empty-api' path" $
+      md `shouldNotContain` "empty-api"
+
 
 -- * APIs
 
@@ -128,6 +131,7 @@ instance MimeRender PlainText Int where
 type TestApi1 = Get '[JSON, PlainText] (Headers '[Header "Location" String] Int)
            :<|> ReqBody '[JSON] String :> Post '[JSON] Datatype1
            :<|> Header "X-Test" Int :> Put '[JSON] Int
+           :<|> "empty-api" :> EmptyAPI
 
 data TT = TT1 | TT2 deriving (Show, Eq)
 data UT = UT1 | UT2 deriving (Show, Eq)

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -187,6 +187,13 @@ instance (HasForeign lang ftype a, HasForeign lang ftype b)
          foreignFor lang ftype (Proxy :: Proxy a) req
     :<|> foreignFor lang ftype (Proxy :: Proxy b) req
 
+data EmptyForeignAPI = EmptyForeignAPI
+
+instance HasForeign lang ftype EmptyAPI where
+  type Foreign ftype EmptyAPI = EmptyForeignAPI
+
+  foreignFor Proxy Proxy Proxy _ = EmptyForeignAPI
+
 instance (KnownSymbol sym, HasForeignType lang ftype t, HasForeign lang ftype api)
   => HasForeign lang ftype (Capture sym t :> api) where
   type Foreign ftype (Capture sym t :> api) = Foreign ftype api
@@ -348,6 +355,9 @@ instance HasForeign lang ftype api
 --   and hands it all back in a list.
 class GenerateList ftype reqs where
   generateList :: reqs -> [Req ftype]
+
+instance GenerateList ftype EmptyForeignAPI where
+  generateList _ = []
 
 instance GenerateList ftype (Req ftype) where
   generateList r = [r]

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -63,7 +63,7 @@ testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy String) (Proxy :: P
 
 listFromAPISpec :: Spec
 listFromAPISpec = describe "listFromAPI" $ do
-  it "generates 4 endpoints for TestApi" $ do
+  it "generates 5 endpoints for TestApi" $ do
     length testApi `shouldBe` 5
 
   let [getReq, postReq, putReq, deleteReq, captureAllReq] = testApi

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -57,6 +57,7 @@ type TestApi
  :<|> "test" :> QueryParams "params" Int :> ReqBody '[JSON] String :> Put '[JSON] NoContent
  :<|> "test" :> Capture "id" Int :> Delete '[JSON] NoContent
  :<|> "test" :> CaptureAll "ids" Int :> Get '[JSON] [Int]
+ :<|> "test" :> EmptyAPI
 
 testApi :: [Req String]
 testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy String) (Proxy :: Proxy TestApi)

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -17,6 +17,8 @@ module Servant.Server
   , -- * Handlers for all standard combinators
     HasServer(..)
   , Server
+  , EmptyAPIServer
+  , emptyAPIServer
   , Handler (..)
   , runHandler
 

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -17,7 +17,7 @@ module Servant.Server
   , -- * Handlers for all standard combinators
     HasServer(..)
   , Server
-  , EmptyAPIServer
+  , EmptyServer
   , emptyAPIServer
   , Handler (..)
   , runHandler

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -18,7 +18,7 @@ module Servant.Server
     HasServer(..)
   , Server
   , EmptyServer
-  , emptyAPIServer
+  , emptyServer
   , Handler (..)
   , runHandler
 

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -221,8 +221,8 @@ layoutWithContext p context =
 --
 -- >>> import Control.Monad.Reader
 -- >>> import qualified Control.Category as C
--- >>> type ReaderAPI = "ep1" :> Get '[JSON] Int :<|> "ep2" :> Get '[JSON] String :<|> Raw
--- >>> let readerServer = return 1797 :<|> ask :<|> Tagged (error "raw server") :: ServerT ReaderAPI (Reader String)
+-- >>> type ReaderAPI = "ep1" :> Get '[JSON] Int :<|> "ep2" :> Get '[JSON] String :<|> Raw :<|> EmptyAPI
+-- >>> let readerServer = return 1797 :<|> ask :<|> Tagged (error "raw server") :<|> emptyServer :: ServerT ReaderAPI (Reader String)
 -- >>> let nt = generalizeNat C.. (runReaderTNat "hi") :: Reader String :~> Handler
 -- >>> let mainServer = enter nt readerServer :: Server ReaderAPI
 --

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -537,7 +537,7 @@ instance HasServer api context => HasServer (HttpVersion :> api) context where
 data EmptyServer = EmptyServer deriving (Typeable, Eq, Show, Bounded, Enum)
 
 -- | Server for `EmptyAPI`
-emptyServer :: Server EmptyAPI
+emptyServer :: ServerT EmptyAPI m
 emptyServer = Tagged EmptyServer
 
 -- | The server for an `EmptyAPI` is `emptyAPIServer`.

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -532,11 +532,19 @@ instance HasServer api context => HasServer (HttpVersion :> api) context where
   route Proxy context subserver =
     route (Proxy :: Proxy api) context (passToServer subserver httpVersion)
 
+-- | Singleton type representing a server that serves an empty API
 data EmptyAPIServer = EmptyAPIServer
 
+-- | Server for `EmptyAPI`
 emptyAPIServer :: Server EmptyAPI
 emptyAPIServer = Tagged EmptyAPIServer
 
+-- | The server for an `EmptyAPI` is `emptyAPIServer`.
+--
+-- > type MyApi = "nothing" :> EmptyApi
+-- >
+-- > server :: Server MyApi
+-- > server = emptyAPIServer
 instance HasServer EmptyAPI context where
   type ServerT EmptyAPI m = Tagged m EmptyAPIServer
 

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -32,7 +32,7 @@ import           Data.Maybe                 (fromMaybe, mapMaybe)
 import           Data.Either                (partitionEithers)
 import           Data.String                (fromString)
 import           Data.String.Conversions    (cs, (<>))
-import           Data.Tagged                (Tagged, untag)
+import           Data.Tagged                (Tagged(..), untag)
 import qualified Data.Text                  as T
 import           Data.Typeable
 import           GHC.TypeLits               (KnownNat, KnownSymbol, natVal,
@@ -52,7 +52,7 @@ import           Web.HttpApiData            (FromHttpApiData, parseHeader,
                                              parseUrlPieceMaybe,
                                              parseUrlPieces)
 import           Servant.API                 ((:<|>) (..), (:>), BasicAuth, Capture,
-                                              CaptureAll, Verb,
+                                              CaptureAll, Verb, EmptyAPI,
                                               ReflectMethod(reflectMethod),
                                               IsSecure(..), Header, QueryFlag,
                                               QueryParam, QueryParams, Raw,
@@ -531,6 +531,16 @@ instance HasServer api context => HasServer (HttpVersion :> api) context where
 
   route Proxy context subserver =
     route (Proxy :: Proxy api) context (passToServer subserver httpVersion)
+
+data EmptyAPIServer = EmptyAPIServer
+
+emptyAPIServer :: Server EmptyAPI
+emptyAPIServer = Tagged EmptyAPIServer
+
+instance HasServer EmptyAPI context where
+  type ServerT EmptyAPI m = Tagged m EmptyAPIServer
+
+  route Proxy _ _ = StaticRouter mempty mempty
 
 -- | Basic Authentication
 instance ( KnownSymbol realm

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -532,12 +532,12 @@ instance HasServer api context => HasServer (HttpVersion :> api) context where
   route Proxy context subserver =
     route (Proxy :: Proxy api) context (passToServer subserver httpVersion)
 
--- | Singleton type representing a server that serves an empty API
-data EmptyAPIServer = EmptyAPIServer
+-- | Singleton type representing a server that serves an empty API.
+data EmptyServer = EmptyServer deriving (Typeable, Eq, Show, Bounded, Enum)
 
 -- | Server for `EmptyAPI`
 emptyAPIServer :: Server EmptyAPI
-emptyAPIServer = Tagged EmptyAPIServer
+emptyAPIServer = Tagged EmptyServer
 
 -- | The server for an `EmptyAPI` is `emptyAPIServer`.
 --
@@ -546,7 +546,7 @@ emptyAPIServer = Tagged EmptyAPIServer
 -- > server :: Server MyApi
 -- > server = emptyAPIServer
 instance HasServer EmptyAPI context where
-  type ServerT EmptyAPI m = Tagged m EmptyAPIServer
+  type ServerT EmptyAPI m = Tagged m EmptyServer
 
   route Proxy _ _ = StaticRouter mempty mempty
 

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -536,8 +536,8 @@ instance HasServer api context => HasServer (HttpVersion :> api) context where
 data EmptyServer = EmptyServer deriving (Typeable, Eq, Show, Bounded, Enum)
 
 -- | Server for `EmptyAPI`
-emptyAPIServer :: Server EmptyAPI
-emptyAPIServer = Tagged EmptyServer
+emptyServer :: Server EmptyAPI
+emptyServer = Tagged EmptyServer
 
 -- | The server for an `EmptyAPI` is `emptyAPIServer`.
 --

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -42,14 +42,14 @@ import           Servant.API                ((:<|>) (..), (:>), AuthProtect,
                                              Headers, HttpVersion,
                                              IsSecure (..), JSON,
                                              NoContent (..), Patch, PlainText,
-                                             Post, Put,
+                                             Post, Put, EmptyAPI,
                                              QueryFlag, QueryParam, QueryParams,
                                              Raw, RemoteHost, ReqBody,
                                              StdMethod (..), Verb, addHeader)
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Server             (Server, Handler, Tagged (..), err401, err403,
                                              err404, serve, serveWithContext,
-                                             Context((:.), EmptyContext))
+                                             Context((:.), EmptyContext), emptyAPIServer)
 import           Test.Hspec                 (Spec, context, describe, it,
                                              shouldBe, shouldContain)
 import qualified Test.Hspec.Wai             as THW
@@ -609,6 +609,7 @@ type MiscCombinatorsAPI
   =    "version" :> HttpVersion :> Get '[JSON] String
   :<|> "secure"  :> IsSecure :> Get '[JSON] String
   :<|> "host"    :> RemoteHost :> Get '[JSON] String
+  :<|> "empty"   :> EmptyAPI
 
 miscApi :: Proxy MiscCombinatorsAPI
 miscApi = Proxy
@@ -617,6 +618,7 @@ miscServ :: Server MiscCombinatorsAPI
 miscServ = versionHandler
       :<|> secureHandler
       :<|> hostHandler
+      :<|> emptyAPIServer
 
   where versionHandler = return . show
         secureHandler Secure = return "secure"
@@ -634,6 +636,9 @@ miscCombinatorSpec = with (return $ serve miscApi miscServ) $
 
     it "Checks that hspec-wai issues request from 0.0.0.0" $
       go "/host" "\"0.0.0.0:0\""
+
+    it "Doesn't serve anything from the empty API" $
+      Test.Hspec.Wai.get "empty" `shouldRespondWith` 404
 
   where go path res = Test.Hspec.Wai.get path `shouldRespondWith` res
 

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -49,7 +49,7 @@ import           Servant.API                ((:<|>) (..), (:>), AuthProtect,
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Server             (Server, Handler, Tagged (..), err401, err403,
                                              err404, serve, serveWithContext,
-                                             Context((:.), EmptyContext), emptyAPIServer)
+                                             Context((:.), EmptyContext), emptyServer)
 import           Test.Hspec                 (Spec, context, describe, it,
                                              shouldBe, shouldContain)
 import qualified Test.Hspec.Wai             as THW
@@ -618,7 +618,7 @@ miscServ :: Server MiscCombinatorsAPI
 miscServ = versionHandler
       :<|> secureHandler
       :<|> hostHandler
-      :<|> emptyAPIServer
+      :<|> emptyServer
 
   where versionHandler = return . show
         secureHandler Secure = return "secure"

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -36,6 +36,7 @@ library
     Servant.API.BasicAuth
     Servant.API.Capture
     Servant.API.ContentTypes
+    Servant.API.Empty
     Servant.API.Experimental.Auth
     Servant.API.Header
     Servant.API.HttpVersion

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -5,6 +5,8 @@ module Servant.API (
   -- | Type-level combinator for expressing subrouting: @':>'@
   module Servant.API.Alternative,
   -- | Type-level combinator for alternative endpoints: @':<|>'@
+  module Servant.API.Empty,
+  -- | Type-level combinator for an empty API: @'EmptyAPI'@
 
   -- * Accessing information from the request
   module Servant.API.Capture,
@@ -66,6 +68,7 @@ import           Servant.API.ContentTypes    (Accept (..), FormUrlEncoded,
                                               MimeRender (..), NoContent (NoContent),
                                               MimeUnrender (..), OctetStream,
                                               PlainText)
+import           Servant.API.Empty           (EmptyAPI (..))
 import           Servant.API.Experimental.Auth (AuthProtect)
 import           Servant.API.Header          (Header (..))
 import           Servant.API.HttpVersion     (HttpVersion (..))

--- a/servant/src/Servant/API/Empty.hs
+++ b/servant/src/Servant/API/Empty.hs
@@ -6,5 +6,7 @@ import           Data.Typeable    (Typeable)
 import           Prelude ()
 import           Prelude.Compat
 
--- | An empty API: one which serves nothing.
+-- | An empty API: one which serves nothing. Morally speaking, this should be
+-- the unit of ':<|>'. Implementors of interpretations of API types should
+-- treat 'EmptyAPI' as close to the unit as possible.
 data EmptyAPI = EmptyAPI deriving (Typeable, Eq, Show, Bounded)

--- a/servant/src/Servant/API/Empty.hs
+++ b/servant/src/Servant/API/Empty.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# OPTIONS_HADDOCK not-home    #-}
+module Servant.API.Empty(EmptyAPI(..)) where
+
+import           Data.Typeable    (Typeable)
+import           Prelude ()
+import           Prelude.Compat
+
+-- | An empty API: one which serves nothing.
+data EmptyAPI = EmptyAPI deriving (Typeable, Eq, Show, Bounded)

--- a/servant/src/Servant/API/Empty.hs
+++ b/servant/src/Servant/API/Empty.hs
@@ -9,4 +9,4 @@ import           Prelude.Compat
 -- | An empty API: one which serves nothing. Morally speaking, this should be
 -- the unit of ':<|>'. Implementors of interpretations of API types should
 -- treat 'EmptyAPI' as close to the unit as possible.
-data EmptyAPI = EmptyAPI deriving (Typeable, Eq, Show, Bounded)
+data EmptyAPI = EmptyAPI deriving (Typeable, Eq, Show, Bounded, Enum)

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -37,7 +37,8 @@ type ComprehensiveAPIWithoutRaw =
   Verb 'POST 204 '[JSON] NoContent :<|>
   Verb 'POST 204 '[JSON] Int :<|>
   WithNamedContext "foo" '[] GET :<|>
-  CaptureAll "foo" Int :> GET
+  CaptureAll "foo" Int :> GET :<|>
+  EmptyAPI
 
 comprehensiveAPIWithoutRaw :: Proxy ComprehensiveAPIWithoutRaw
 comprehensiveAPIWithoutRaw = Proxy

--- a/servant/test/Servant/Utils/LinksSpec.hs
+++ b/servant/test/Servant/Utils/LinksSpec.hs
@@ -25,6 +25,7 @@ type TestApi =
   :<|> "post" :> ReqBody '[JSON] 'True :> Post '[JSON] NoContent
   :<|> "delete" :> Header "ponies" String :> Delete '[JSON] NoContent
   :<|> "raw" :> Raw
+  :<|> NoEndpoint
 
 
 apiLink :: (IsElem endpoint TestApi, HasLink endpoint)
@@ -98,6 +99,11 @@ spec = describe "Servant.Utils.Links" $ do
 -- ...Could not deduce...
 -- ...
 --
+-- >>> apiLink (Proxy :: Proxy NoEndpoint)
+-- ...
+-- ...No instance for...
+-- ...
+--
 -- sanity check
 -- >>> toUrlPiece $ apiLink (Proxy :: Proxy AllGood)
 -- "get"
@@ -107,3 +113,4 @@ type WrongContentType = "get" :> Get '[OctetStream] NoContent
 type WrongMethod = "get" :> Post '[JSON] NoContent
 type NotALink = "hello" :> ReqBody '[JSON] 'True :> Get '[JSON] Bool
 type AllGood = "get" :> Get '[JSON] NoContent
+type NoEndpoint = "empty" :> EmptyAPI


### PR DESCRIPTION
This is for where you want to compose an API out of bits that come from various sources. For example, we have a Servant API, `CommonAPI`, and a function that has a type rather like this:

    defaultMain :: HasServer specialAPI => Proxy specialAPI -> Server specialAPI -> ... -> IO a

the purpose of which is to serve `CommonAPI :<|> specialAPI`, plus a bunch of other common setup/teardown code. Most of the time there's interesting stuff in `specialAPI`, but in one or two cases there's nothing much to put there.

Morally speaking, this would be a unit for the `:<|>` operator (up to isomorphism).

This issue follows a [discussion on the mailing list](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/haskell-servant/J76EcFgr8m8/Rahw0sriBAAJ) concluding with @alpmestan saying:

> OK I think I'm convinced enough to give my +1 for a suitable PR that implements this all properly. Thank you guys for taking the time to make the case. Bonus points if the PR augments the tutorial with a section about this that documents the workflow of using this for "not implemented yet" situations.