### PR TITLE
Improve authStr in markdown

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -561,6 +561,7 @@ markdown api = unlines $
 
 
         authStr :: [DocAuthentication] -> [String]
+        authStr [] = []
         authStr auths =
           let authIntros = mapped %~ view authIntro $ auths
               clientInfos = mapped %~ view authDataRequired $ auths


### PR DESCRIPTION
This PR removes `#### Authentication` section when `authInfo` in `Action` is empty.

Before:

~~~
$ stack runghc example/greet.hs | head -n 25                                                                                                                  
## On proper introductions.                                                                                                                                   

Hello there.

As documentation is usually written for humans, it's often useful to introduce concepts with a few words.

## This title is below the last

You'll also note that multiple intros are possible.

## POST /greet

#### Authentication



Clients must supply the following data


#### Request:

- Supported content types are:

    - `application/json;charset=utf-8`
    - `application/json`
~~~

After:

~~~
$ stack runghc example/greet.hs | head -n 25 
## On proper introductions.                                                                                                                                   

Hello there.

As documentation is usually written for humans, it's often useful to introduce concepts with a few words.

## This title is below the last

You'll also note that multiple intros are possible.

## POST /greet

#### Request:

- Supported content types are:

    - `application/json;charset=utf-8`
    - `application/json`

- Example (If you use ?capital=true): `application/json;charset=utf-8`

```javascript
"HELLO, HASKELLER"
```
~~~

