### PR TITLE
Export authentication-related types/lenses

### DIFF
--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -43,12 +43,13 @@ module Servant.Docs
   , -- * ADTs to represent an 'API'
     Endpoint, path, method, defEndpoint
   , API, apiIntros, apiEndpoints, emptyAPI
+  , DocAuthentication(..), authIntro, authDataRequired
   , DocCapture(..), capSymbol, capDesc
   , DocQueryParam(..), ParamKind(..), paramName, paramValues, paramDesc, paramKind
   , DocNote(..), noteTitle, noteBody
   , DocIntro(..), introTitle, introBody
   , Response(..), respStatus, respTypes, respBody, defResponse
-  , Action, captures, headers, notes, params, rqtypes, rqbody, response, defAction
+  , Action, authInfo, captures, headers, notes, params, rqtypes, rqbody, response, defAction
   , single
   ) where
 


### PR DESCRIPTION
I'm assuming that they're not meant to be just in `.Internal`.