### PR TITLE
Remove `ToSample a => ToSample [a]` instance

### DIFF
--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add a markdown header for the Headers an endpoint is sensitive to.
 * Document the HTTP Method the parameters of an endpoint belong to
   (rather than assuming `GET` for all of them).
+* Remove `ToSample a => ToSample [a]` and `ToSample (ZipList a)` instances
+  (https://github.com/haskell-servant/servant/pull/797).
 
 0.11
 ----

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -895,11 +895,9 @@ instance (ToSample a, ToSample b, ToSample c, ToSample d, ToSample e, ToSample f
 
 instance ToSample a => ToSample (Maybe a)
 instance (ToSample a, ToSample b) => ToSample (Either a b)
-instance ToSample a => ToSample [a]
 
 -- ToSample instances for Control.Applicative types
 instance ToSample a => ToSample (Const a b)
-instance ToSample a => ToSample (ZipList a)
 
 -- ToSample instances for Data.Monoid newtypes
 instance ToSample All


### PR DESCRIPTION
`ToSample [a]` was generating an infinite list of samples. This is far from
being useful; if you have two samples for `a` servant-docs generates 79kloc long
samples for `[a]`.

Because it's impossible to come up with a useful `ToSample [a]` that works for
all use cases, we leave that out.