### PR TITLE
Make client runner a type class

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
     Servant.Client
+    Servant.Client.HttpClient
     Servant.Client.Generic
     Servant.Client.Experimental.Auth
     Servant.Common.BaseUrl

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
     Servant.Client
+    Servant.Client.Class
     Servant.Client.HttpClient
     Servant.Client.Generic
     Servant.Client.Experimental.Auth

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -108,7 +108,7 @@ data EmptyClient = EmptyClient deriving (Eq, Show, Bounded, Enum)
 -- > (getAllBooks :<|> EmptyClient) = client myApi
 instance HasClient m EmptyAPI where
   type Client m EmptyAPI = EmptyClient
-  clientWithRoute pm Proxy _ = EmptyClient
+  clientWithRoute _pm Proxy _ = EmptyClient
 
 -- | If you use a 'Capture' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take
@@ -178,7 +178,7 @@ instance OVERLAPPABLE_
   (RunClient m ct ([H.Header], a), MimeUnrender ct a, ReflectMethod method, cts' ~ (ct ': cts)
   ) => HasClient m (Verb method status cts' a) where
   type Client m (Verb method status cts' a) = m a
-  clientWithRoute pm Proxy req = do
+  clientWithRoute _pm Proxy req = do
     (_hdrs, a) :: ([H.Header], a) <- runRequest (Proxy :: Proxy ct) method req
     return a
       where method = reflectMethod (Proxy :: Proxy method)
@@ -188,7 +188,7 @@ instance OVERLAPPING_
   , ReflectMethod method) => HasClient m (Verb method status cts NoContent) where
   type Client m (Verb method status cts NoContent)
     = m NoContent
-  clientWithRoute pm Proxy req = do
+  clientWithRoute _pm Proxy req = do
     _hdrs :: [H.Header] <- runRequest (Proxy :: Proxy NoContent) method req
     return NoContent
       where method = reflectMethod (Proxy :: Proxy method)
@@ -200,7 +200,7 @@ instance OVERLAPPING_
   ) => HasClient m (Verb method status cts' (Headers ls a)) where
   type Client m (Verb method status cts' (Headers ls a))
     = m (Headers ls a)
-  clientWithRoute pm Proxy req = do
+  clientWithRoute _pm Proxy req = do
     let method = reflectMethod (Proxy :: Proxy method)
     (hdrs, resp) <- runRequest (Proxy :: Proxy ct) method req
     return $ Headers { getResponse = resp
@@ -213,7 +213,7 @@ instance OVERLAPPING_
   ) => HasClient m (Verb method status cts (Headers ls NoContent)) where
   type Client m (Verb method status cts (Headers ls NoContent))
     = m (Headers ls NoContent)
-  clientWithRoute pm Proxy req = do
+  clientWithRoute _pm Proxy req = do
     let method = reflectMethod (Proxy :: Proxy method)
     hdrs <- runRequest (Proxy :: Proxy NoContent) method req
     return $ Headers { getResponse = NoContent
@@ -416,7 +416,7 @@ instance (RunClient m NoContent (Int, ByteString, MediaType, [HTTP.Header], Resp
     = H.Method ->  m (Int, ByteString, MediaType, [HTTP.Header], Response ByteString)
 
   clientWithRoute :: Proxy m -> Proxy Raw -> Req -> Client m Raw
-  clientWithRoute pm Proxy req httpMethod = do
+  clientWithRoute _pm Proxy req httpMethod = do
     runRequest (Proxy :: Proxy NoContent) httpMethod req
 
 -- | If you use a 'ReqBody' in one of your endpoints in your API,

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -22,7 +22,7 @@ module Servant.Client
   , client
   , HasClient(..)
   , ClientM
-  , runClientM
+  , runClientM, inClientM, clientM
   , ClientEnv (ClientEnv)
   , mkAuthenticateReq
   , ServantError(..)
@@ -52,7 +52,8 @@ import           Servant.Common.Req
 
 -- * Accessing APIs as a Client
 
--- | 'client' allows you to produce operations to query an API from a client.
+-- | 'client' allows you to produce operations to query an API from a client within
+-- a given monadic context `m`
 --
 -- > type MyApi = "books" :> Get '[JSON] [Book] -- GET /books
 -- >         :<|> "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book -- POST /books
@@ -60,11 +61,25 @@ import           Servant.Common.Req
 -- > myApi :: Proxy MyApi
 -- > myApi = Proxy
 -- >
+-- > clientM :: Proxy ClientM
+-- > clientM = Proxy
+-- >
 -- > getAllBooks :: ClientM [Book]
 -- > postNewBook :: Book -> ClientM Book
--- > (getAllBooks :<|> postNewBook) = client myApi
+-- > (getAllBooks :<|> postNewBook) = client clientM myApi
 client :: HasClient m api => Proxy m -> Proxy api -> Client m api
 client pm p = clientWithRoute pm p defReq
+
+-- | Helper proxy to simplify common case of working in `ClientM` monad
+inClientM :: Proxy ClientM
+inClientM = Proxy
+
+-- | Convenience method to declare clients running in the `ClientM` monad.
+--
+-- Simply pass `inClientM` to `client`....
+clientM :: (HasClient ClientM api) => Proxy api -> Client ClientM api
+clientM = client inClientM
+
 
 -- | This class lets us define how each API combinator
 -- influences the creation of an HTTP request. It's mostly

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -42,6 +42,7 @@ import           Prelude ()
 import           Prelude.Compat
 import           Servant.API
 import           Servant.Client.Experimental.Auth
+import           Servant.Client.HttpClient
 import           Servant.Common.BaseUrl
 import           Servant.Common.BasicAuth
 import           Servant.Common.Req

--- a/servant-client/src/Servant/Client/Class.hs
+++ b/servant-client/src/Servant/Client/Class.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-| Types for possible backends to run client-side `Req` queries -}
+module Servant.Client.Class
+  (RunClient(..))
+where
+
+import Data.Proxy
+import Network.HTTP.Types
+import Servant.API
+import Servant.Common.Req
+
+class (Monad m) => RunClient m ct result where
+  runRequest :: MimeUnrender ct result
+             => Proxy ct
+             -> Method -> Req -> m result

--- a/servant-client/src/Servant/Client/Class.hs
+++ b/servant-client/src/Servant/Client/Class.hs
@@ -6,7 +6,6 @@ where
 
 import Data.Proxy
 import Network.HTTP.Types
-import Servant.API
 import Servant.Common.Req
 
 class (Monad m) => RunClient m ct result where

--- a/servant-client/src/Servant/Client/Class.hs
+++ b/servant-client/src/Servant/Client/Class.hs
@@ -10,6 +10,7 @@ import Servant.API
 import Servant.Common.Req
 
 class (Monad m) => RunClient m ct result where
-  runRequest :: MimeUnrender ct result
-             => Proxy ct
-             -> Method -> Req -> m result
+  runRequest :: Proxy ct
+             -> Method
+             -> Req
+             -> m result

--- a/servant-client/src/Servant/Client/HttpClient.hs
+++ b/servant-client/src/Servant/Client/HttpClient.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+{-| http-client based client  requests executor -}
+module Servant.Client.HttpClient where
+
+
+import Prelude ()
+import Prelude.Compat
+
+import Control.Exception
+import Control.Monad
+import Control.Monad.Catch (MonadThrow, MonadCatch)
+import Data.Foldable (toList)
+import Data.Functor.Alt (Alt (..))
+
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Trans.Except
+
+import GHC.Generics
+import Control.Monad.Base (MonadBase (..))
+import Control.Monad.IO.Class ()
+import Control.Monad.Reader
+import Control.Monad.Trans.Control (MonadBaseControl (..))
+import Data.ByteString.Lazy hiding (pack, filter, map, null, elem, any)
+import Data.String.Conversions (cs)
+import Data.Proxy
+import Network.HTTP.Media
+import Network.HTTP.Types
+import Network.HTTP.Client hiding (Proxy, path)
+import qualified Network.HTTP.Types.Header   as HTTP
+import Servant.API.ContentTypes
+import Servant.Common.BaseUrl
+import Servant.Common.Req
+
+import qualified Network.HTTP.Client as Client
+
+
+data ClientEnv
+  = ClientEnv
+  { manager :: Manager
+  , baseUrl :: BaseUrl
+  }
+
+
+-- | @ClientM@ is the monad in which client functions run. Contains the
+-- 'Manager' and 'BaseUrl' used for requests in the reader environment.
+
+newtype ClientM a = ClientM { runClientM' :: ReaderT ClientEnv (ExceptT ServantError IO) a }
+                    deriving ( Functor, Applicative, Monad, MonadIO, Generic
+                             , MonadReader ClientEnv
+                             , MonadError ServantError
+                             , MonadThrow, MonadCatch
+                             )
+
+instance MonadBase IO ClientM where
+  liftBase = ClientM . liftBase
+
+instance MonadBaseControl IO ClientM where
+  type StM ClientM a = Either ServantError a
+
+  -- liftBaseWith :: (RunInBase ClientM IO -> IO a) -> ClientM a
+  liftBaseWith f = ClientM (liftBaseWith (\g -> f (g . runClientM')))
+
+  -- restoreM :: StM ClientM a -> ClientM a
+  restoreM st = ClientM (restoreM st)
+
+-- | Try clients in order, last error is preserved.
+instance Alt ClientM where
+  a <!> b = a `catchError` \_ -> b
+
+runClientM :: ClientM a -> ClientEnv -> IO (Either ServantError a)
+runClientM cm env = runExceptT $ (flip runReaderT env) $ runClientM' cm
+
+
+performRequest :: Method -> Req
+               -> ClientM ( Int, ByteString, MediaType
+                          , [HTTP.Header], Response ByteString)
+performRequest reqMethod req = do
+  m <- asks manager
+  reqHost <- asks baseUrl
+  partialRequest <- liftIO $ reqToRequest req reqHost
+
+  let request = partialRequest { Client.method = reqMethod }
+
+  eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request m
+  case eResponse of
+    Left err ->
+      throwError . ConnectionError $ SomeException err
+
+    Right response -> do
+      let status = Client.responseStatus response
+          body = Client.responseBody response
+          hdrs = Client.responseHeaders response
+          status_code = statusCode status
+      ct <- case lookup "Content-Type" $ Client.responseHeaders response of
+                 Nothing -> pure $ "application"//"octet-stream"
+                 Just t -> case parseAccept t of
+                   Nothing -> throwError $ InvalidContentTypeHeader (cs t) body
+                   Just t' -> pure t'
+      unless (status_code >= 200 && status_code < 300) $
+        throwError $ FailureResponse (UrlReq reqHost req) status ct body
+      return (status_code, body, ct, hdrs, response)
+
+performRequestCT :: MimeUnrender ct result => Proxy ct -> Method -> Req
+    -> ClientM ([HTTP.Header], result)
+performRequestCT ct reqMethod req = do
+  let acceptCTS = contentTypes ct
+  (_status, respBody, respCT, hdrs, _response) <-
+    performRequest reqMethod (req { reqAccept = toList acceptCTS })
+  unless (any (matches respCT) acceptCTS) $ throwError $ UnsupportedContentType respCT respBody
+  case mimeUnrender ct respBody of
+    Left err -> throwError $ DecodeFailure err respCT respBody
+    Right val -> return (hdrs, val)
+
+performRequestNoBody :: Method -> Req -> ClientM [HTTP.Header]
+performRequestNoBody reqMethod req = do
+  (_status, _body, _ct, hdrs, _response) <- performRequest reqMethod req
+  return hdrs
+
+catchConnectionError :: IO a -> IO (Either ServantError a)
+catchConnectionError action =
+  catch (Right <$> action) $ \e ->
+    pure . Left . ConnectionError $ SomeException (e :: HttpException)

--- a/servant-client/src/Servant/Client/HttpClient.hs
+++ b/servant-client/src/Servant/Client/HttpClient.hs
@@ -63,7 +63,6 @@ data ClientEnv
 
 -- | @ClientM@ is the monad in which client functions run. Contains the
 -- 'Manager' and 'BaseUrl' used for requests in the reader environment.
-
 newtype ClientM a = ClientM { runClientM' :: ReaderT ClientEnv (ExceptT ServantError IO) a }
                     deriving ( Functor, Applicative, Monad, MonadIO, Generic
                              , MonadReader ClientEnv
@@ -77,10 +76,8 @@ instance MonadBase IO ClientM where
 instance MonadBaseControl IO ClientM where
   type StM ClientM a = Either ServantError a
 
-  -- liftBaseWith :: (RunInBase ClientM IO -> IO a) -> ClientM a
   liftBaseWith f = ClientM (liftBaseWith (\g -> f (g . runClientM')))
 
-  -- restoreM :: StM ClientM a -> ClientM a
   restoreM st = ClientM (restoreM st)
 
 -- | Try clients in order, last error is preserved.

--- a/servant-client/src/Servant/Client/HttpClient.hs
+++ b/servant-client/src/Servant/Client/HttpClient.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -36,11 +37,22 @@ import Network.HTTP.Types
 import Network.HTTP.Client hiding (Proxy, path)
 import qualified Network.HTTP.Types.Header   as HTTP
 import Servant.API.ContentTypes
+import Servant.Client.Class
 import Servant.Common.BaseUrl
 import Servant.Common.Req
 
 import qualified Network.HTTP.Client as Client
 
+instance RunClient ClientM NoContent ( Int, ByteString, MediaType
+                                     , [HTTP.Header], Response ByteString) where
+  runRequest _ meth req = performRequest meth req
+
+instance (MimeUnrender ct a) =>
+         RunClient ClientM ct ([HTTP.Header], a) where
+  runRequest p meth req = performRequestCT p meth req
+
+instance RunClient ClientM NoContent [HTTP.Header] where
+  runRequest _ meth req = performRequestNoBody meth req
 
 data ClientEnv
   = ClientEnv

--- a/servant-client/src/Servant/Common/Req.hs
+++ b/servant-client/src/Servant/Common/Req.hs
@@ -13,37 +13,22 @@ import Prelude ()
 import Prelude.Compat
 
 import Control.Exception
-import Control.Monad
-import Control.Monad.Catch (MonadThrow, MonadCatch)
-import Data.Foldable (toList)
-import Data.Functor.Alt (Alt (..))
+import Control.Monad.Catch (MonadThrow)
 import Data.Semigroup ((<>))
 
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Trans.Except
-
-import GHC.Generics
-import Control.Monad.Base (MonadBase (..))
 import Control.Monad.IO.Class ()
-import Control.Monad.Reader
-import Control.Monad.Trans.Control (MonadBaseControl (..))
 import qualified Data.ByteString.Builder as BS
 import Data.ByteString.Lazy hiding (pack, filter, map, null, elem, any)
 import Data.String
 import Data.String.Conversions (cs)
-import Data.Proxy
 import Data.Text (Text)
 import Data.Text.Encoding
 import Data.Typeable
 import Network.HTTP.Media
 import Network.HTTP.Types
 import Network.HTTP.Client hiding (Proxy, path)
-import qualified Network.HTTP.Types.Header   as HTTP
 import Network.URI hiding (path)
-import Servant.API.ContentTypes
 import Servant.Common.BaseUrl
-
-import qualified Network.HTTP.Client as Client
 
 import Web.HttpApiData
 
@@ -196,90 +181,3 @@ parseRequest url = liftM disableStatusCheck (parseUrl url)
 
 displayHttpRequest :: Method -> String
 displayHttpRequest httpmethod = "HTTP " ++ cs httpmethod ++ " request"
-
-data ClientEnv
-  = ClientEnv
-  { manager :: Manager
-  , baseUrl :: BaseUrl
-  }
-
-
--- | @ClientM@ is the monad in which client functions run. Contains the
--- 'Manager' and 'BaseUrl' used for requests in the reader environment.
-
-newtype ClientM a = ClientM { runClientM' :: ReaderT ClientEnv (ExceptT ServantError IO) a }
-                    deriving ( Functor, Applicative, Monad, MonadIO, Generic
-                             , MonadReader ClientEnv
-                             , MonadError ServantError
-                             , MonadThrow, MonadCatch
-                             )
-
-instance MonadBase IO ClientM where
-  liftBase = ClientM . liftBase
-
-instance MonadBaseControl IO ClientM where
-  type StM ClientM a = Either ServantError a
-
-  -- liftBaseWith :: (RunInBase ClientM IO -> IO a) -> ClientM a
-  liftBaseWith f = ClientM (liftBaseWith (\g -> f (g . runClientM')))
-
-  -- restoreM :: StM ClientM a -> ClientM a
-  restoreM st = ClientM (restoreM st)
-
--- | Try clients in order, last error is preserved.
-instance Alt ClientM where
-  a <!> b = a `catchError` \_ -> b
-
-runClientM :: ClientM a -> ClientEnv -> IO (Either ServantError a)
-runClientM cm env = runExceptT $ (flip runReaderT env) $ runClientM' cm
-
-
-performRequest :: Method -> Req
-               -> ClientM ( Int, ByteString, MediaType
-                          , [HTTP.Header], Response ByteString)
-performRequest reqMethod req = do
-  m <- asks manager
-  reqHost <- asks baseUrl
-  partialRequest <- liftIO $ reqToRequest req reqHost
-
-  let request = partialRequest { Client.method = reqMethod }
-
-  eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request m
-  case eResponse of
-    Left err ->
-      throwError . ConnectionError $ SomeException err
-
-    Right response -> do
-      let status = Client.responseStatus response
-          body = Client.responseBody response
-          hdrs = Client.responseHeaders response
-          status_code = statusCode status
-      ct <- case lookup "Content-Type" $ Client.responseHeaders response of
-                 Nothing -> pure $ "application"//"octet-stream"
-                 Just t -> case parseAccept t of
-                   Nothing -> throwError $ InvalidContentTypeHeader (cs t) body
-                   Just t' -> pure t'
-      unless (status_code >= 200 && status_code < 300) $
-        throwError $ FailureResponse (UrlReq reqHost req) status ct body
-      return (status_code, body, ct, hdrs, response)
-
-performRequestCT :: MimeUnrender ct result => Proxy ct -> Method -> Req
-    -> ClientM ([HTTP.Header], result)
-performRequestCT ct reqMethod req = do
-  let acceptCTS = contentTypes ct
-  (_status, respBody, respCT, hdrs, _response) <-
-    performRequest reqMethod (req { reqAccept = toList acceptCTS })
-  unless (any (matches respCT) acceptCTS) $ throwError $ UnsupportedContentType respCT respBody
-  case mimeUnrender ct respBody of
-    Left err -> throwError $ DecodeFailure err respCT respBody
-    Right val -> return (hdrs, val)
-
-performRequestNoBody :: Method -> Req -> ClientM [HTTP.Header]
-performRequestNoBody reqMethod req = do
-  (_status, _body, _ct, hdrs, _response) <- performRequest reqMethod req
-  return hdrs
-
-catchConnectionError :: IO a -> IO (Either ServantError a)
-catchConnectionError action =
-  catch (Right <$> action) $ \e ->
-    pure . Left . ConnectionError $ SomeException (e :: HttpException)

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -58,6 +58,7 @@ import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Client
 import           Servant.Client.Generic
 import qualified Servant.Common.Req         as SCR
+import qualified Servant.Client.HttpClient  as SCR
 import           Servant.Server
 import           Servant.Server.Experimental.Auth
 


### PR DESCRIPTION
This PR is a first attempt at addressing #798 

The idea is to abstract away request execution and expose it as a method `runRequest` in `RunClient` type-class. Specialized instances of this type-class can then be provided to handle various execution contexts:

* Basic execution with `ClientM`
* Specialized execution like `RetryM` context that encapsulates logic for retrying requests depending on a `Policy` 
* Testing without having to launch a server
* ...