### PR TITLE
Multiple content types

### DIFF
--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -23,6 +23,7 @@ import Network.Wai
 import Servant.API
 import Servant.Docs
 import Servant.Server
+import Web.FormUrlEncoded(FromForm(..), ToForm(..))
 ```
 
 And we'll import some things from one of our earlier modules
@@ -217,6 +218,9 @@ More customisation can be done with the `markdownWith` function, which allows cu
 type ExampleAPI2 = "position" :> Capture "x" Int :> Capture "y" Int :> Get '[JSON] Position
       :<|> "hello" :> QueryParam "name" String :> Get '[JSON] HelloMessage
       :<|> "marketing" :> ReqBody '[JSON, FormUrlEncoded] ClientInfo :> Post '[JSON] Email
+
+instance ToForm ClientInfo
+instance FromForm ClientInfo
 
 exampleAPI2 :: Proxy ExampleAPI2
 exampleAPI2 = Proxy

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -110,12 +110,6 @@ markdown :: API -> String
 That lets us see what our API docs look down in markdown, by looking at `markdown apiDocs`.
 
 ````````` text
-## Welcome
-
-This is our super webservice's API.
-
-Enjoy!
-
 ## GET /hello
 
 #### GET Parameters:
@@ -132,19 +126,20 @@ Enjoy!
 
 - Supported content types are:
 
+    - `application/json;charset=utf-8`
     - `application/json`
 
-- When a value is provided for 'name'
+- When a value is provided for 'name' (`application/json;charset=utf-8`, `application/json`):
 
-  ```javascript
-  {"msg":"Hello, Alp"}
-  ```
+    ```javascript
+{"msg":"Hello, Alp"}
+    ```
 
-- When 'name' is not specified
+- When 'name' is not specified (`application/json;charset=utf-8`, `application/json`):
 
-  ```javascript
-  {"msg":"Hello, anonymous coward"}
-  ```
+    ```javascript
+{"msg":"Hello, anonymous coward"}
+    ```
 
 ## POST /marketing
 
@@ -152,28 +147,30 @@ Enjoy!
 
 - Supported content types are:
 
+    - `application/json;charset=utf-8`
     - `application/json`
 
-- Example: `application/json`
+- Example (`application/json;charset=utf-8`, `application/json`):
 
-  ```javascript
-  {"email":"alp@foo.com","interested_in":["haskell","mathematics"],"age":26,"name":"Alp"}
-  ```
+    ```javascript
+{"clientAge":26,"clientEmail":"alp@foo.com","clientName":"Alp","clientInterestedIn":["haskell","mathematics"]}
+    ```
 
 #### Response:
 
-- Status code 201
+- Status code 200
 - Headers: []
 
 - Supported content types are:
 
+    - `application/json;charset=utf-8`
     - `application/json`
 
-- Response body as below.
+- Example (`application/json;charset=utf-8`, `application/json`):
 
-  ```javascript
-  {"subject":"Hey Alp, we miss you!","body":"Hi Alp,\n\nSince you've recently turned 26, have you checked out our latest haskell, mathematics products? Give us a visit!","to":"alp@foo.com","from":"great@company.com"}
-  ```
+    ```javascript
+{"subject":"Hey Alp, we miss you!","body":"Hi Alp,\n\nSince you've recently turned 26, have you checked out our latest haskell, mathematics products? Give us a visit!","to":"alp@foo.com","from":"great@company.com"}
+    ```
 
 ## GET /position/:x/:y
 
@@ -189,13 +186,14 @@ Enjoy!
 
 - Supported content types are:
 
+    - `application/json;charset=utf-8`
     - `application/json`
 
-- Response body as below.
+- Example (`application/json;charset=utf-8`, `application/json`):
 
-  ```javascript
-  {"x":3,"y":14}
-  ```
+    ```javascript
+{"yCoord":14,"xCoord":3}
+    ````
 
 `````````
 

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -31,6 +31,7 @@ library
                      , servant-docs == 0.11.*
                      , servant-js >= 0.9 && <0.10
                      , warp
+                     , http-api-data
                      , http-media
                      , lucid
                      , time

--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Document the HTTP Method the parameters of an endpoint belong to
   (rather than assuming `GET` for all of them).
 * Content type of sample response body is also displayed.
+* Can now control how many content-types for each example are shown
+  with `markdownWith` and `RenderingOptions`.
 
 0.11
 ----

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -49,7 +49,7 @@ library
     , control-monad-omega == 0.3.*
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups          >=0.16.2.2 && <0.19
+      semigroups          >=0.17 && <0.19
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -24,6 +24,9 @@
 module Servant.Docs
   ( -- * 'HasDocs' class and key functions
     HasDocs(..), docs, pretty, markdown
+    -- ** Customising generated documentation
+  , markdownWith, ApiOptions(..), defApiOptions
+  , requestExamples, responseExamples, ShowContentTypes(..)
     -- * Generating docs with extra information
   , docsWith, docsWithIntros, docsWithOptions
   , ExtraInfo(..), extraInfo

--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -25,7 +25,7 @@ module Servant.Docs
   ( -- * 'HasDocs' class and key functions
     HasDocs(..), docs, pretty, markdown
     -- ** Customising generated documentation
-  , markdownWith, ApiOptions(..), defApiOptions
+  , markdownWith, RenderingOptions(..), defRenderingOptions
   , requestExamples, responseExamples, ShowContentTypes(..)
     -- * Generating docs with extra information
   , docsWith, docsWithIntros, docsWithOptions

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -298,17 +298,29 @@ defAction =
 single :: Endpoint -> Action -> API
 single e a = API mempty (HM.singleton e a)
 
--- | How many examples should be shown?
-data ShowContentTypes = AllContentTypes | FirstContentType
+-- | How many content-types for each example should be shown?
+--
+--   @since 0.11.1
+data ShowContentTypes = AllContentTypes  -- ^ For each example, show each content type.
+                      | FirstContentType -- ^ For each example, show only one content type.
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 -- | Customise how an 'API' is converted into documentation.
+--
+--   @since 0.11.1
 data RenderingOptions = RenderingOptions
   { _requestExamples  :: !ShowContentTypes
+    -- ^ How many content types to display for request body examples?
   , _responseExamples :: !ShowContentTypes
+    -- ^ How many content types to display for response body examples?
   } deriving (Show)
 
 -- | Default API generation options.
+--
+--   All content types are shown for both 'requestExamples' and
+--   'responseExamples'.
+--
+--   @since 0.11.1
 defRenderingOptions :: RenderingOptions
 defRenderingOptions = RenderingOptions
   { _requestExamples  = AllContentTypes
@@ -542,9 +554,32 @@ class ToAuthInfo a where
 
 -- | Generate documentation in Markdown format for
 --   the given 'API'.
+--
+--   This is equivalent to @'markdownWith' 'defRenderingOptions'@.
 markdown :: API -> String
 markdown = markdownWith defRenderingOptions
 
+-- | Generate documentation in Markdown format for
+--   the given 'API' using the specified options.
+--
+--   These options allow you to customise aspects such as:
+--
+--   * Choose how many content-types for each request body example are
+--     shown with 'requestExamples'.
+--
+--   * Choose how many content-types for each response body example
+--     are shown with 'responseExamples'.
+--
+--   For example, to only show the first content-type of each example:
+--
+--   @
+--   markdownWith ('defRenderingOptions'
+--                   & 'requestExamples'  '.~' 'FirstContentType'
+--                   & 'responseExamples' '.~' 'FirstContentType' )
+--                myAPI
+--   @
+--
+--   @since 0.11.1
 markdownWith :: RenderingOptions -> API -> String
 markdownWith RenderingOptions{..}  api = unlines $
        introsStr (api ^. apiIntros)

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -632,15 +632,18 @@ markdown api = unlines $
         rqbodyStr types s =
             ["#### Request:", ""]
             <> formatTypes types
-            <> concatMap formatBody s
+            <> formatBodies s
 
         formatTypes [] = []
         formatTypes ts = ["- Supported content types are:", ""]
             <> map (\t -> "    - `" <> show t <> "`") ts
             <> [""]
 
+        formatBodies :: [(Text, M.MediaType, ByteString)] -> [String]
+        formatBodies = concatMap formatBody
+
         formatBody (t, m, b) =
-          "- Example (" <> cs t <> "): `" <> cs (show m) <> "`" :
+          "- " <> cs t <> " (`" <> cs (show m) <> "`):" :
           contentStr m b
 
         markdownForType mime_type =
@@ -676,7 +679,7 @@ markdown api = unlines $
                   []        -> ["- No response body\n"]
                   [("", t, r)] -> "- Response body as below." : contentStr t r
                   xs        ->
-                    concatMap (\(ctx, t, r) -> ("- " <> T.unpack ctx <> " (`" <> cs (show t) <> "`)") : contentStr t r) xs
+                    formatBodies xs
 
 -- * Instances
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -724,9 +724,6 @@ markdownWith ApiOptions{..}  api = unlines $
                   xs        ->
                     formatBodies _responseExamples xs
 
-uncurry3 :: (a -> b -> c -> d) -> (a,b,c) -> d
-uncurry3 f (a,b,c) = f a b c
-
 -- * Instances
 
 -- | The generated docs for @a ':<|>' b@ just appends the docs

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -303,14 +303,14 @@ data ShowContentTypes = AllContentTypes | FirstContentType
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 -- | Customise how an 'API' is converted into documentation.
-data ApiOptions = ApiOptions
+data RenderingOptions = RenderingOptions
   { _requestExamples  :: !ShowContentTypes
   , _responseExamples :: !ShowContentTypes
   } deriving (Show)
 
 -- | Default API generation options.
-defApiOptions :: ApiOptions
-defApiOptions = ApiOptions
+defRenderingOptions :: RenderingOptions
+defRenderingOptions = RenderingOptions
   { _requestExamples  = AllContentTypes
   , _responseExamples = AllContentTypes
   }
@@ -326,7 +326,7 @@ makeLenses ''DocIntro
 makeLenses ''DocNote
 makeLenses ''Response
 makeLenses ''Action
-makeLenses ''ApiOptions
+makeLenses ''RenderingOptions
 
 -- | Generate the docs for a given API that implements 'HasDocs'. This is the
 -- default way to create documentation.
@@ -543,10 +543,10 @@ class ToAuthInfo a where
 -- | Generate documentation in Markdown format for
 --   the given 'API'.
 markdown :: API -> String
-markdown = markdownWith defApiOptions
+markdown = markdownWith defRenderingOptions
 
-markdownWith :: ApiOptions -> API -> String
-markdownWith ApiOptions{..}  api = unlines $
+markdownWith :: RenderingOptions -> API -> String
+markdownWith RenderingOptions{..}  api = unlines $
        introsStr (api ^. apiIntros)
     ++ (concatMap (uncurry printEndpoint) . sort . HM.toList $ api ^. apiEndpoints)
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -653,11 +653,12 @@ markdown api = unlines $
                 ("text", "css") -> "css"
                 (_, _) -> ""
 
+
         contentStr mime_type body =
           "" :
-          "```" <> markdownForType mime_type :
+          "    ```" <> markdownForType mime_type :
           cs body :
-          "```" :
+          "    ```" :
           "" :
           []
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -647,6 +647,7 @@ markdown api = unlines $
             case (M.mainType mime_type, M.subType mime_type) of
                 ("text", "html") -> "html"
                 ("application", "xml") -> "xml"
+                ("text", "xml") -> "xml"
                 ("application", "json") -> "javascript"
                 ("application", "javascript") -> "javascript"
                 ("text", "css") -> "css"

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -719,10 +719,14 @@ markdownWith RenderingOptions{..}  api = unlines $
 
         formatBody :: (Text, NonEmpty M.MediaType, ByteString) -> [String]
         formatBody (t, ms, b) =
-          "- " <> cs t <> " (" <> mediaList ms <> "):" :
+          "- " <> title <> " (" <> mediaList ms <> "):" :
           contentStr (NE.head ms) b
           where
             mediaList = fold . NE.intersperse ", " . fmap (\m -> "`" ++ show m ++ "`")
+
+            title
+              | T.null t  = "Example"
+              | otherwise = cs t
 
         markdownForType mime_type =
             case (M.mainType mime_type, M.subType mime_type) of

--- a/stack-ghc-7.8.4.yaml
+++ b/stack-ghc-7.8.4.yaml
@@ -23,6 +23,7 @@ extra-deps:
 - http-client-0.4.30
 - natural-transformation-0.4
 - primitive-0.6.1.0
+- semigroups-0.17
 - servant-js-0.9.3
 - should-not-typecheck-2.1.0
 - time-locale-compat-0.1.1.1

--- a/stack-ghc-7.8.4.yaml
+++ b/stack-ghc-7.8.4.yaml
@@ -28,5 +28,6 @@ extra-deps:
 - should-not-typecheck-2.1.0
 - time-locale-compat-0.1.1.1
 - uri-bytestring-0.2.2.0
+- void-0.7.1
 - wai-app-static-3.1.5
 resolver: lts-2.22


### PR DESCRIPTION
If an instance of `Accept` has multiple `contentTypes`, then previously each one was listed individually, even though the contents were identical.

This attempts to fix that, but isn't perfect: it groups identical rendered output together (which actually may be sufficient from a documentation point of view in indicating that there is no conceptual difference in how the values are represented).

Furthermore, to prevent generated documentation from becoming long, it is possible to specify whether all or just one mime-type of each example is shown.