### PR TITLE
Adding instances for non-JSON content types to `servant-foreign`

### DIFF
--- a/servant-foreign/CHANGELOG.md
+++ b/servant-foreign/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.10.2
+------
+
+### Changes
+
+* Add support for body/return content types in `Req`
+  ([#832](https://github.com/haskell-servant/servant/pull/832/files)).
+
 0.10.1
 ------
 

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -31,6 +31,7 @@ library
                      , Servant.Foreign.Internal
                      , Servant.Foreign.Inflections
   build-depends:       base       == 4.*
+                     , http-media == 0.7.*
                      , lens       == 4.*
                      , servant    == 0.11.*
                      , text       >= 1.2  && < 1.3

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -31,10 +31,10 @@ library
                      , Servant.Foreign.Internal
                      , Servant.Foreign.Inflections
   build-depends:       base       == 4.*
-                     , http-media == 0.7.*
                      , lens       == 4.*
                      , servant    == 0.11.*
                      , text       >= 1.2  && < 1.3
+                     , http-media
                      , http-types
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -34,7 +34,7 @@ library
                      , lens       == 4.*
                      , servant    == 0.11.*
                      , text       >= 1.2  && < 1.3
-                     , http-media
+                     , http-media >= 0.6  && < 0.8
                      , http-types
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -70,6 +70,10 @@ test-suite spec
                    , hspec >= 2.1.8
                    , servant
                    , servant-foreign
+  if !impl(ghc >= 8.0)
+    build-depends:
+                     semigroups >= 0.16 && < 0.19
+
   default-language:  Haskell2010
   default-extensions:  ConstraintKinds
                      , DataKinds
@@ -83,3 +87,4 @@ test-suite spec
                      , UndecidableInstances
                      , OverloadedStrings
                      , PolyKinds
+

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -21,7 +21,9 @@ module Servant.Foreign
   , reqMethod
   , reqHeaders
   , reqBody
+  , reqBodyContentTypes
   , reqReturnType
+  , reqReturnContentTypes
   , reqFuncName
   , path
   , queryStr

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -58,7 +58,8 @@ type TestApi
  :<|> "test" :> QueryParams "params" Int :> ReqBody '[JSON] String :> Put '[JSON] NoContent
  :<|> "test" :> Capture "id" Int :> Delete '[JSON] NoContent
  :<|> "test" :> CaptureAll "ids" Int :> Get '[JSON] [Int]
- :<|> "test" :> "text" :> Get '[PlainText] String
+ :<|> "test" :> "text" :> ReqBody '[PlainText] String :> Get '[PlainText] String
+ :<|> "test" :> "multi" :> ReqBody '[JSON, PlainText] String :> Get '[JSON, PlainText] String
  :<|> "test" :> EmptyAPI
 
 testApi :: [Req String]
@@ -67,9 +68,9 @@ testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy String) (Proxy :: P
 listFromAPISpec :: Spec
 listFromAPISpec = describe "listFromAPI" $ do
   it "generates 5 endpoints for TestApi" $ do
-    length testApi `shouldBe` 6
+    length testApi `shouldBe` 7
 
-  let [getReq, postReq, putReq, deleteReq, captureAllReq, getTextReq] = testApi
+  let [getReq, postReq, putReq, deleteReq, captureAllReq, getTextReq, getMultiReq] = testApi
 
   it "collects all info for get request" $ do
     shouldBe getReq $ defReq
@@ -79,9 +80,10 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "GET"
       , _reqHeaders    = [HeaderArg $ Arg "header" "listX of stringX"]
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "intX"
-      , _reqFuncName   = FunctionName ["get", "test"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
+      , _reqFuncName   = FunctionName ["get", "test"]
       }
 
   it "collects all info for post request" $ do
@@ -92,9 +94,10 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "POST"
       , _reqHeaders    = []
       , _reqBody       = Just "listX of stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqReturnType = Just "voidX"
-      , _reqFuncName   = FunctionName ["post", "test"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
+      , _reqFuncName   = FunctionName ["post", "test"]
       }
 
   it "collects all info for put request" $ do
@@ -106,9 +109,10 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "PUT"
       , _reqHeaders    = []
       , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqReturnType = Just "voidX"
-      , _reqFuncName   = FunctionName ["put", "test"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
+      , _reqFuncName   = FunctionName ["put", "test"]
       }
 
   it "collects all info for delete request" $ do
@@ -120,9 +124,10 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "DELETE"
       , _reqHeaders    = []
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "voidX"
-      , _reqFuncName   = FunctionName ["delete", "test", "by", "id"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
+      , _reqFuncName   = FunctionName ["delete", "test", "by", "id"]
       }
 
   it "collects all info for capture all request" $ do
@@ -134,9 +139,10 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "GET"
       , _reqHeaders    = []
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "listX of intX"
-      , _reqFuncName   = FunctionName ["get", "test", "by", "ids"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
+      , _reqFuncName   = FunctionName ["get", "test", "by", "ids"]
       }
 
   it "collects all info for plaintext request" $ do
@@ -147,9 +153,25 @@ listFromAPISpec = describe "listFromAPI" $ do
           []
       , _reqMethod     = "GET"
       , _reqHeaders    = []
-      , _reqBody       = Nothing
+      , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy PlainText)
       , _reqReturnType = Just "stringX"
-      , _reqFuncName   = FunctionName ["get", "test", "text"]
       , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy PlainText)
+      , _reqFuncName   = FunctionName ["get", "test", "text"]
+      }
+
+  it "collects all info for requets with multiple request/return types" $ do
+    shouldBe getMultiReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test"
+          , Segment $ Static "multi" ]
+          []
+      , _reqMethod     = "GET"
+      , _reqHeaders    = []
+      , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = (toList $ contentTypes (Proxy :: Proxy JSON)) ++ [contentType (Proxy :: Proxy PlainText)]
+      , _reqReturnType = Just "stringX"
+      , _reqReturnContentTypes = (toList $ contentTypes (Proxy :: Proxy JSON)) ++ [contentType (Proxy :: Proxy PlainText)]
+      , _reqFuncName   = FunctionName ["get", "test", "multi"]
       }
 


### PR DESCRIPTION
I am trying to fix #509 (and probably #551). I have only done the work for `Verb` thus far, but I wanted some feedback before I proceed with `ReqBody`. 

In this first approach, I have just modified `Req` to include a list of `MediaType` that comes from the Accept class. From the perspective of someone wanting to use `servant-foreign`, I'm not sure if this is the correct approach. It might be better to create a type similar to `HeaderArg` or create a typeclass separate from `Accept` specifically for this purpose.  Thoughts?