### PR TITLE
Temporary fix for Header.

### DIFF
--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -225,7 +225,7 @@ instance (Elem JSON list, HasForeignType lang ftype a, ReflectMethod method)
       method   = reflectMethod (Proxy :: Proxy method)
       methodLC = toLower $ decodeUtf8 method
 
-instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype api)
+instance (KnownSymbol sym, HasForeignType lang ftype (Maybe a), HasForeign lang ftype api)
   => HasForeign lang ftype (Header sym a :> api) where
   type Foreign ftype (Header sym a :> api) = Foreign ftype api
 
@@ -235,7 +235,7 @@ instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype ap
       hname = pack . symbolVal $ (Proxy :: Proxy sym)
       arg   = Arg
         { _argName = PathSegment hname
-        , _argType  = typeFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy a) }
+        , _argType  = typeFor lang (Proxy :: Proxy ftype) (Proxy :: Proxy (Maybe a)) }
       subP  = Proxy :: Proxy api
 
 instance (KnownSymbol sym, HasForeignType lang ftype a, HasForeign lang ftype api)

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -51,6 +51,9 @@ instance OVERLAPPING_ HasForeignType LangX String String where
 instance OVERLAPPABLE_ HasForeignType LangX String a => HasForeignType LangX String [a] where
   typeFor lang ftype _ = "listX of " <> typeFor lang ftype (Proxy :: Proxy a)
 
+instance (HasForeignType LangX String a) => HasForeignType LangX String (Maybe a) where
+  typeFor lang ftype _ = "maybe " <> typeFor lang ftype (Proxy :: Proxy a)
+
 type TestApi
     = "test" :> Header "header" [String] :> QueryFlag "flag" :> Get '[JSON] Int
  :<|> "test" :> QueryParam "param" Int :> ReqBody '[JSON] [String] :> Post '[JSON] NoContent
@@ -75,7 +78,7 @@ listFromAPISpec = describe "listFromAPI" $ do
           [ Segment $ Static "test" ]
           [ QueryArg (Arg "flag" "boolX") Flag ]
       , _reqMethod     = "GET"
-      , _reqHeaders    = [HeaderArg $ Arg "header" "listX of stringX"]
+      , _reqHeaders    = [HeaderArg $ Arg "header" "maybe listX of stringX"]
       , _reqBody       = Nothing
       , _reqReturnType = Just "intX"
       , _reqFuncName   = FunctionName ["get", "test"]


### PR DESCRIPTION
This fix exposes routes containing `Header _ a :> …` as `Maybe a …`. A typical problem is when you want to make request to such routes without using a header (typical when you’re working with the `Authorization` header, for instance).

I’m also making a PR to the `servant-elm` project.