### PR TITLE
Bump versions and update changelogs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,10 @@ script:
   - cd ${DISTDIR}
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: servant-*/*.cabal servant-client-*/*.cabal servant-client-core-*/*.cabal servant-docs-*/*.cabal servant-foreign-*/*.cabal servant-server-*/*.cabal tutorial-*/*.cabal\n' > cabal.project"
+
+  # Allow-newer and other cabal.project amendments
+  - "echo 'allow-newer: servant-js:servant, servant-js:servant-foreign' >> cabal.project"
+
   - echo -en 'travis_fold:end:unpack\\r'
   - echo Building... && echo -en 'travis_fold:start:build\\r'
   # this builds all libraries and executables (without tests/benchmarks)

--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ list](https://groups.google.com/forum/#!forum/haskell-servant).
 This table lists the versions of some `servant-` libraries at the point of
 release of `servant` package.
 
-|                     | **0.10** | **0.11** |
-| ------------------- | -------- |-----------
-| servant             | 0.10     | 0.11     |
-| servant-blaze       | 0.7.1    | ?        |
-| servant-cassava     | 0.7      | ?        |
-| servant-client      | 0.10     | 0.11     |
-| servant-docs        | 0.10     | 0.11     |
-| servant-foreign     | 0.10     | 0.10.0.1 |
-| servant-js          | 0.9.1    | ?        |
-| servant-lucid       | 0.7.1    | ?        |
-| servant-mock        | 0.8.1.1  | ?        |
-| servant-server      | 0.10     | 0.11     |
-| servant-swagger     | 1.1.2.1  | ?        |
+|                     | **0.10** | **0.11** | **0.12** |
+| ------------------- | -------- |---------------------|
+| servant             | 0.10     | 0.11     | 0.12     |
+| servant-blaze       | 0.7.1    | ?        | ?        |
+| servant-cassava     | 0.7      | ?        | ?        |
+| servant-client      | 0.10     | 0.11     | 0.12     |
+| servant-docs        | 0.10     | 0.11     | 0.11.1   |
+| servant-foreign     | 0.10     | 0.10.0.1 | 0.10.2   |
+| servant-js          | 0.9.1    | ?        | ?        |
+| servant-lucid       | 0.7.1    | ?        | ?        |
+| servant-mock        | 0.8.1.1  | ?        | ?        |
+| servant-server      | 0.10     | 0.11     | 0.12     |
+| servant-swagger     | 1.1.2.1  | ?        | ?        |
 
 ## Contributing
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,5 @@ packages: servant/
   servant-foreign/
   servant-server/
   doc/tutorial/
+
+allow-newer: servant-js:servant, servant-js:servant-foreign

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -33,10 +33,10 @@ library
                      , directory
                      , blaze-markup
                      , containers
-                     , servant == 0.11.*
-                     , servant-server == 0.11.*
-                     , servant-client == 0.11.*
-                     , servant-docs == 0.11.*
+                     , servant == 0.12.*
+                     , servant-server == 0.12.*
+                     , servant-client == 0.12.*
+                     , servant-docs >= 0.11.1 && <0.12
                      , servant-js >= 0.9 && <0.10
                      , warp
                      , http-api-data

--- a/servant-client-core/CHANGELOG.md
+++ b/servant-client-core/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Revision history for servant-client-core
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-client-core/CHANGELOG.md)
+[Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
 
-## 0.12  -- YYYY-mm-dd
+0.12
+----
 
-* First version. Factored out of servant-client all the functionality that was
-independent of the http-client backend.
+- First version. Factored out of `servant-client` all the functionality that was
+  independent of the `http-client` backend.

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -1,5 +1,5 @@
 name:                servant-client-core
-version:             0.11
+version:             0.12
 synopsis:            Core functionality and class for client function generation for servant APIs
 description:
   This library provides backend-agnostic generation of client functions. For
@@ -53,7 +53,7 @@ library
     , mtl                   >= 2.1      && < 2.3
     , network-uri           >= 2.6      && < 2.7
     , safe                  >= 0.3.9    && < 0.4
-    , servant               == 0.11.*
+    , servant               == 0.12.*
     , text                  >= 1.2      && < 1.3
   if !impl(ghc >= 8.0)
     build-depends:

--- a/servant-client/CHANGELOG.md
+++ b/servant-client/CHANGELOG.md
@@ -1,3 +1,12 @@
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-client/CHANGELOG.md)
+[Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
+
+0.12
+----
+
+- Factored out into `servant-client-core` all the functionality that was
+  independent of the `http-client` backend.
+
 0.11
 ----
 

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -1,5 +1,5 @@
 name:                servant-client
-version:             0.11
+version:             0.12
 synopsis: automatical derivation of querying functions for servant webservices
 description:
   This library lets you derive automatically Haskell functions that
@@ -50,7 +50,7 @@ library
     , monad-control         >= 1.0.0.4  && < 1.1
     , mtl                   >= 2.1      && < 2.3
     , semigroupoids         >= 4.3      && < 5.3
-    , servant-client-core   == 0.11.*
+    , servant-client-core   == 0.12.*
     , text                  >= 1.2      && < 1.3
     , transformers          >= 0.3      && < 0.6
     , transformers-base     >= 0.4.4    && < 0.5
@@ -91,7 +91,7 @@ test-suite spec
     , servant
     , servant-client
     , servant-client-core
-    , servant-server == 0.11.*
+    , servant-server == 0.12.*
     , text
     , transformers
     , transformers-compat

--- a/servant-docs/CHANGELOG.md
+++ b/servant-docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-docs/CHANGELOG.md)
+[Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
+
 0.11.1
 ------
 

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -1,5 +1,5 @@
 name:                servant-docs
-version:             0.11
+version:             0.11.1
 synopsis:            generate API docs for your servant webservice
 description:
   Library for generating API docs from a servant API definition.
@@ -46,7 +46,7 @@ library
     , http-media >= 0.6
     , http-types >= 0.7
     , lens
-    , servant == 0.11.*
+    , servant == 0.12.*
     , string-conversions
     , text
     , unordered-containers

--- a/servant-foreign/CHANGELOG.md
+++ b/servant-foreign/CHANGELOG.md
@@ -1,3 +1,14 @@
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-foreign/CHANGELOG.md)
+[Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
+
+0.10.2
+------
+
+### Changes
+
+* Add instances for `Description` and `Summary` combinators
+  ([#767](https://github.com/haskell-servant/servant/pull/767))
+
 0.10.1
 ------
 

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -1,5 +1,5 @@
 name:                servant-foreign
-version:             0.10.1
+version:             0.10.2
 synopsis:            Helpers for generating clients for servant APIs in any programming language
 description:
   Helper types and functions for generating client functions for servant APIs in any programming language
@@ -38,7 +38,7 @@ library
                      , Servant.Foreign.Inflections
   build-depends:       base       == 4.*
                      , lens       == 4.*
-                     , servant    == 0.11.*
+                     , servant    == 0.12.*
                      , text       >= 1.2  && < 1.3
                      , http-types
   hs-source-dirs:      src

--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -1,4 +1,7 @@
-Next
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-server/CHANGELOG.md)
+[Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
+
+0.12
 ----
 
 ### Breaking changes

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -1,5 +1,5 @@
 name:                servant-server
-version:             0.11
+version:             0.12
 synopsis:            A family of combinators for defining webservices APIs and serving them
 description:
   A family of combinators for defining webservices APIs and serving them
@@ -70,7 +70,7 @@ library
       , mtl                >= 2    && < 2.3
       , network            >= 2.6  && < 2.7
       , safe               >= 0.3  && < 0.4
-      , servant            == 0.11.*
+      , servant            == 0.12.*
       , split              >= 0.2  && < 0.3
       , string-conversions >= 0.3  && < 0.5
       , system-filepath    >= 0.4  && < 0.5

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -1,8 +1,39 @@
-Unreleased changes
+[The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
+
+0.12
 ---
 
+### Significant changes
+
+- *servant-client* *servant-client-core*
+  Factored out of `servant-client` all the functionality that was
+  independent of the `http-client` backend.
+  ([#803](https://github.com/haskell-servant/servant/pull/803)
+   [#821](https://github.com/haskell-servant/servant/issues/821))
+- *servant-server* Added `hoistServer` member to the `HasServer` class, which is `HasServer`
+  specific `enter`.
+  ([#804](https://github.com/haskell-servant/servant/pull/804)
+   [#824](https://github.com/haskell-servant/servant/pull/824))
+- Add `Description` and `Summary` combinators
+  ([#767](https://github.com/haskell-servant/servant/pull/767))
 - Lower `:>` and `:<|>` infix precedence to 4 and 3 respectively
   ([#761](https://github.com/haskell-servant/servant/issues/761))
+
+### Other changes
+
+- Allow newest dependencies
+ ([#772](https://github.com/haskell-servant/servant/pull/772)
+  [#842](https://github.com/haskell-servant/servant/pull/842))
+- Documentation improvements and typo fixes
+ ([#757](https://github.com/haskell-servant/servant/pull/757)
+  [#771](https://github.com/haskell-servant/servant/pull/771)
+  [#775](https://github.com/haskell-servant/servant/pull/775)
+  [#790](https://github.com/haskell-servant/servant/pull/790)
+  [#791](https://github.com/haskell-servant/servant/pull/791)
+  [#806](https://github.com/haskell-servant/servant/pull/806))
+- Development process improvements
+  ([#764](https://github.com/haskell-servant/servant/pull/764)
+   [#839](https://github.com/haskell-servant/servant/pull/839))
 
 0.11
 ----

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -1,5 +1,5 @@
 name:                servant
-version:             0.11
+version:             0.12
 synopsis:            A family of combinators for defining webservices APIs
 description:
   A family of combinators for defining webservices APIs and serving them


### PR DESCRIPTION
The changelog for `servant` contains changes across core packages,
as we release them as a suite.

Also added links to the GitHub master as we might update entries
for old versions, as changelogs are written by humans.