### PR TITLE
Adding instances for non-JSON content types to `servant-foreign`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ release of `servant` package.
 | servant-cassava     | 0.7      | ?        | ?        |
 | servant-client      | 0.10     | 0.11     | 0.12     |
 | servant-docs        | 0.10     | 0.11     | 0.11.1   |
-| servant-foreign     | 0.10     | 0.10.0.1 | 0.10.2   |
+| servant-foreign     | 0.10     | 0.10.0.1 | 0.11     |
 | servant-js          | 0.9.1    | ?        | ?        |
 | servant-lucid       | 0.7.1    | ?        | ?        |
 | servant-mock        | 0.8.1.1  | ?        | ?        |

--- a/servant-foreign/CHANGELOG.md
+++ b/servant-foreign/CHANGELOG.md
@@ -1,11 +1,13 @@
 [The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-foreign/CHANGELOG.md)
 [Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
 
-0.10.2
-------
+0.11
+----
 
 ### Changes
 
+* Add support for body/return content types in `Req`
+  ([#832](https://github.com/haskell-servant/servant/pull/832))
 * Add instances for `Description` and `Summary` combinators
   ([#767](https://github.com/haskell-servant/servant/pull/767))
 * Derive Data for all types

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -1,5 +1,5 @@
 name:                servant-foreign
-version:             0.10.2
+version:             0.11
 synopsis:            Helpers for generating clients for servant APIs in any programming language
 description:
   Helper types and functions for generating client functions for servant APIs in any programming language
@@ -40,6 +40,7 @@ library
                      , lens       == 4.*
                      , servant    == 0.12.*
                      , text       >= 1.2  && < 1.3
+                     , http-media >= 0.6  && < 0.8
                      , http-types
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -77,6 +78,10 @@ test-suite spec
                    , hspec >= 2.1.8
                    , servant
                    , servant-foreign
+  if !impl(ghc >= 8.0)
+    build-depends:
+                     semigroups >= 0.16 && < 0.19
+
   default-language:  Haskell2010
   default-extensions:  ConstraintKinds
                      , DataKinds
@@ -90,3 +95,4 @@ test-suite spec
                      , UndecidableInstances
                      , OverloadedStrings
                      , PolyKinds
+

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -21,7 +21,9 @@ module Servant.Foreign
   , reqMethod
   , reqHeaders
   , reqBody
+  , reqBodyContentTypes
   , reqReturnType
+  , reqReturnContentTypes
   , reqFuncName
   , path
   , queryStr

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -3,6 +3,7 @@
 
 module Servant.ForeignSpec where
 
+import Data.List.NonEmpty (toList)
 import Data.Monoid ((<>))
 import Data.Proxy
 import Servant.Foreign
@@ -57,6 +58,8 @@ type TestApi
  :<|> "test" :> QueryParams "params" Int :> ReqBody '[JSON] String :> Put '[JSON] NoContent
  :<|> "test" :> Capture "id" Int :> Delete '[JSON] NoContent
  :<|> "test" :> CaptureAll "ids" Int :> Get '[JSON] [Int]
+ :<|> "test" :> "text" :> ReqBody '[PlainText] String :> Get '[PlainText] String
+ :<|> "test" :> "multi" :> ReqBody '[JSON, PlainText] String :> Get '[JSON, PlainText] String
  :<|> "test" :> EmptyAPI
 
 testApi :: [Req String]
@@ -65,9 +68,9 @@ testApi = listFromAPI (Proxy :: Proxy LangX) (Proxy :: Proxy String) (Proxy :: P
 listFromAPISpec :: Spec
 listFromAPISpec = describe "listFromAPI" $ do
   it "generates 5 endpoints for TestApi" $ do
-    length testApi `shouldBe` 5
+    length testApi `shouldBe` 7
 
-  let [getReq, postReq, putReq, deleteReq, captureAllReq] = testApi
+  let [getReq, postReq, putReq, deleteReq, captureAllReq, getTextReq, getMultiReq] = testApi
 
   it "collects all info for get request" $ do
     shouldBe getReq $ defReq
@@ -77,7 +80,9 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "GET"
       , _reqHeaders    = [HeaderArg $ Arg "header" "listX of stringX"]
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "intX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqFuncName   = FunctionName ["get", "test"]
       }
 
@@ -89,7 +94,9 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "POST"
       , _reqHeaders    = []
       , _reqBody       = Just "listX of stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqReturnType = Just "voidX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqFuncName   = FunctionName ["post", "test"]
       }
 
@@ -102,7 +109,9 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "PUT"
       , _reqHeaders    = []
       , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqReturnType = Just "voidX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqFuncName   = FunctionName ["put", "test"]
       }
 
@@ -115,7 +124,9 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "DELETE"
       , _reqHeaders    = []
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "voidX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqFuncName   = FunctionName ["delete", "test", "by", "id"]
       }
 
@@ -128,6 +139,38 @@ listFromAPISpec = describe "listFromAPI" $ do
       , _reqMethod     = "GET"
       , _reqHeaders    = []
       , _reqBody       = Nothing
+      , _reqBodyContentTypes = []
       , _reqReturnType = Just "listX of intX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy JSON)
       , _reqFuncName   = FunctionName ["get", "test", "by", "ids"]
+      }
+
+  it "collects all info for plaintext request" $ do
+    shouldBe getTextReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test"
+          , Segment $ Static "text" ]
+          []
+      , _reqMethod     = "GET"
+      , _reqHeaders    = []
+      , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = toList $ contentTypes (Proxy :: Proxy PlainText)
+      , _reqReturnType = Just "stringX"
+      , _reqReturnContentTypes = toList $ contentTypes (Proxy :: Proxy PlainText)
+      , _reqFuncName   = FunctionName ["get", "test", "text"]
+      }
+
+  it "collects all info for requets with multiple request/return types" $ do
+    shouldBe getMultiReq $ defReq
+      { _reqUrl        = Url
+          [ Segment $ Static "test"
+          , Segment $ Static "multi" ]
+          []
+      , _reqMethod     = "GET"
+      , _reqHeaders    = []
+      , _reqBody       = Just "stringX"
+      , _reqBodyContentTypes = (toList $ contentTypes (Proxy :: Proxy JSON)) ++ [contentType (Proxy :: Proxy PlainText)]
+      , _reqReturnType = Just "stringX"
+      , _reqReturnContentTypes = (toList $ contentTypes (Proxy :: Proxy JSON)) ++ [contentType (Proxy :: Proxy PlainText)]
+      , _reqFuncName   = FunctionName ["get", "test", "multi"]
       }

--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -18,6 +18,8 @@
   ([#767](https://github.com/haskell-servant/servant/pull/767))
 - Lower `:>` and `:<|>` infix precedence to 4 and 3 respectively
   ([#761](https://github.com/haskell-servant/servant/issues/761))
+* *servant-foreign* Add support for body/return content types in `Req`
+  ([#832](https://github.com/haskell-servant/servant/pull/832))
 
 ### Other changes
 


### PR DESCRIPTION
Rebase of #832 