### PR TITLE
Send Accept header in servant-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ sudo: false
 git:
   submodules: false  # whether to recursively clone submodules
 
+branches:
+  only:
+    - master
+    - release-0.12
+
 cache:
   directories:
     - $HOME/.cabal/packages

--- a/servant-client/CHANGELOG.md
+++ b/servant-client/CHANGELOG.md
@@ -1,6 +1,12 @@
 [The latest version of this document is on GitHub.](https://github.com/haskell-servant/servant/blob/master/servant-client/CHANGELOG.md)
 [Changelog for `servant` package contains significant entries for all core packages.](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md)
 
+0.12.0.1
+--------
+
+- Send `Accept` header.
+  ([#858](https://github.com/haskell-servant/servant/issues/858))
+
 0.12
 ----
 

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -1,5 +1,5 @@
 name:                servant-client
-version:             0.12
+version:             0.12.0.1
 synopsis: automatical derivation of querying functions for servant webservices
 description:
   This library lets you derive automatically Haskell functions that


### PR DESCRIPTION
Fixes #858 . The bug was introduced in servant-client-core refactor
(servant-client-0.12).

See https://github.com/haskell-servant/servant/blob/8973cf56f1feea8830212c05ca2c2682e398499e/servant-client/src/Servant/Common/Req.hs#L151-L179
for the unbroken variant in servant-client-0.11