### PR TITLE
Bump servant-client-core upperbound in servant-client-ghcjs

### DIFF
--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -43,7 +43,7 @@ library
     , monad-control         >= 1.0.0.4  && < 1.1
     , mtl                   >= 2.1      && < 2.3
     , semigroupoids         >= 4.3      && < 5.3
-    , servant-client-core   == 0.11.*
+    , servant-client-core   >= 0.12     && < 0.13
     , string-conversions    >= 0.3      && < 0.5
     , transformers          >= 0.3      && < 0.6
     , transformers-base     >= 0.4.4    && < 0.5


### PR DESCRIPTION
I haven’t done particularly extensive testing against `0.12` but it definitely does build and in my limited testing it also seems to work just fine.