### PR TITLE
Servant.API.Modifiers

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -534,7 +534,7 @@ sampleByteStrings ctypes@Proxy Proxy =
 --
 -- Example of an instance:
 --
--- > instance ToParam (QueryParam "capital" Bool) where
+-- > instance ToParam (QueryParam' mods "capital" Bool) where
 -- >   toParam _ =
 -- >     DocQueryParam "capital"
 -- >                   ["true", "false"]
@@ -859,7 +859,7 @@ instance OVERLAPPING_
           p = Proxy :: Proxy a
 
 instance (KnownSymbol sym, HasDocs api)
-      => HasDocs (Header sym a :> api) where
+      => HasDocs (Header' mods sym a :> api) where
   docsFor Proxy (endpoint, action) =
     docsFor subApiP (endpoint, action')
 
@@ -867,14 +867,14 @@ instance (KnownSymbol sym, HasDocs api)
           action' = over headers (|> headername) action
           headername = T.pack $ symbolVal (Proxy :: Proxy sym)
 
-instance (KnownSymbol sym, ToParam (QueryParam sym a), HasDocs api)
-      => HasDocs (QueryParam sym a :> api) where
+instance (KnownSymbol sym, ToParam (QueryParam' mods sym a), HasDocs api)
+      => HasDocs (QueryParam' mods sym a :> api) where
 
   docsFor Proxy (endpoint, action) =
     docsFor subApiP (endpoint, action')
 
     where subApiP = Proxy :: Proxy api
-          paramP = Proxy :: Proxy (QueryParam sym a)
+          paramP = Proxy :: Proxy (QueryParam' mods sym a)
           action' = over params (|> toParam paramP) action
 
 instance (KnownSymbol sym, ToParam (QueryParams sym a), HasDocs api)
@@ -929,7 +929,7 @@ instance (KnownSymbol desc, HasDocs api)
 -- 'AllMimeUnrender' and 'AllMimeRender' actually agree (or to suppose that
 -- both are even defined) for any particular type.
 instance (ToSample a, AllMimeRender (ct ': cts) a, HasDocs api)
-      => HasDocs (ReqBody (ct ': cts) a :> api) where
+      => HasDocs (ReqBody' mods (ct ': cts) a :> api) where
 
   docsFor Proxy (endpoint, action) opts@DocOptions{..} =
     docsFor subApiP (endpoint, action') opts

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -33,7 +33,9 @@ import           Servant.Docs.Internal
 -- This declaration simply checks that all instances are in place.
 _ = docs comprehensiveAPI
 
-instance ToParam (QueryParam "foo" Int) where
+instance ToParam (QueryParam' mods "foo" Int) where
+  toParam = error "unused"
+instance ToParam (QueryParam' mods "bar" Int) where
   toParam = error "unused"
 instance ToParam (QueryParams "foo" Int) where
   toParam = error "unused"

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -36,10 +36,11 @@ library
   exposed-modules:     Servant.Foreign
                      , Servant.Foreign.Internal
                      , Servant.Foreign.Inflections
-  build-depends:       base       == 4.*
-                     , lens       == 4.*
-                     , servant    == 0.12.*
-                     , text       >= 1.2  && < 1.3
+  build-depends:       base        >= 4.7   && <4.11
+                     , base-compat >= 0.9.3 && <0.10
+                     , lens        == 4.*
+                     , servant     == 0.12.*
+                     , text        >= 1.2  && < 1.3
                      , http-types
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -7,9 +7,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+#if __GLASGOW__HASKELL < 709
+{-# OPTIONS_GHC -fcontext-stack=41 #-}
+#endif
 #include "overlapping-compat.h"
 
 module Servant.ForeignSpec where
@@ -99,7 +101,7 @@ listFromAPISpec = describe "listFromAPI" $ do
     shouldBe postReq $ defReq
       { _reqUrl        = Url
           [ Segment $ Static "test" ]
-          [ QueryArg (Arg "param" "intX") Normal ]
+          [ QueryArg (Arg "param" "maybe intX") Normal ]
       , _reqMethod     = "POST"
       , _reqHeaders    = []
       , _reqBody       = Just "listX of stringX"

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -47,7 +47,7 @@ import           Network.Wai.Test           (defaultRequest, request,
                                              simpleHeaders, simpleStatus)
 import           Servant.API                ((:<|>) (..), (:>), AuthProtect,
                                              BasicAuth, BasicAuthData(BasicAuthData),
-                                             Capture, CaptureAll, Delete, Get, Header (..),
+                                             Capture, CaptureAll, Delete, Get, Header,
                                              Headers, HttpVersion,
                                              IsSecure (..), JSON,
                                              NoContent (..), Patch, PlainText,
@@ -461,8 +461,8 @@ reqBodySpec = describe "Servant.API.ReqBody" $ do
 ------------------------------------------------------------------------------
 
 type HeaderApi a = Header "MyHeader" a :> Delete '[JSON] NoContent
-headerApi :: Proxy (HeaderApi a)
-headerApi = Proxy
+headerApi :: Proxy a -> Proxy (HeaderApi a)
+headerApi _ = Proxy
 
 headerSpec :: Spec
 headerSpec = describe "Servant.API.Header" $ do
@@ -479,19 +479,19 @@ headerSpec = describe "Servant.API.Header" $ do
           return NoContent
         expectsString Nothing  = error "Expected a string"
 
-    with (return (serve headerApi expectsInt)) $ do
+    with (return (serve (headerApi (Proxy :: Proxy Int)) expectsInt)) $ do
         let delete' x = THW.request methodDelete x [("MyHeader", "5")]
 
         it "passes the header to the handler (Int)" $
             delete' "/" "" `shouldRespondWith` 200
 
-    with (return (serve headerApi expectsString)) $ do
+    with (return (serve (headerApi (Proxy :: Proxy String)) expectsString)) $ do
         let delete' x = THW.request methodDelete x [("MyHeader", "more from you")]
 
         it "passes the header to the handler (String)" $
             delete' "/" "" `shouldRespondWith` 200
 
-    with (return (serve headerApi expectsInt)) $ do
+    with (return (serve (headerApi (Proxy :: Proxy Int)) expectsInt)) $ do
         let delete' x = THW.request methodDelete x [("MyHeader", "not a number")]
 
         it "checks for parse errors" $

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -49,12 +49,13 @@ library
     Servant.API.HttpVersion
     Servant.API.Internal.Test.ComprehensiveAPI
     Servant.API.IsSecure
+    Servant.API.Modifiers
     Servant.API.QueryParam
     Servant.API.Raw
-    Servant.API.Stream
     Servant.API.RemoteHost
     Servant.API.ReqBody
     Servant.API.ResponseHeaders
+    Servant.API.Stream
     Servant.API.Sub
     Servant.API.TypeLevel
     Servant.API.Vault
@@ -77,6 +78,7 @@ library
     , mmorph                >= 1    && < 1.2
     , tagged                >= 0.7.3 && < 0.9
     , text                  >= 1    && < 1.3
+    , singleton-bool        >= 0.1.2.0 && <0.2
     , string-conversions    >= 0.3  && < 0.5
     , network-uri           >= 2.6  && < 2.7
     , vault                 >= 0.3  && < 0.4

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -7,6 +7,8 @@ module Servant.API (
   -- | Type-level combinator for alternative endpoints: @':<|>'@
   module Servant.API.Empty,
   -- | Type-level combinator for an empty API: @'EmptyAPI'@
+  module Servant.API.Modifiers,
+  -- | Type-level modifiers for 'QueryParam', 'Header' and 'ReqBody'.
 
   -- * Accessing information from the request
   module Servant.API.Capture,
@@ -64,6 +66,10 @@ module Servant.API (
   -- * Utilities
   module Servant.Utils.Links,
   -- | Type-safe internal URIs
+  
+  -- * Re-exports
+  If,
+  SBool (..), SBoolI (..)
   ) where
 
 import           Servant.API.Alternative     ((:<|>) (..))
@@ -77,10 +83,11 @@ import           Servant.API.ContentTypes    (Accept (..), FormUrlEncoded,
 import           Servant.API.Description     (Description, Summary)
 import           Servant.API.Empty           (EmptyAPI (..))
 import           Servant.API.Experimental.Auth (AuthProtect)
-import           Servant.API.Header          (Header (..))
+import           Servant.API.Header          (Header, Header')
 import           Servant.API.HttpVersion     (HttpVersion (..))
 import           Servant.API.IsSecure        (IsSecure (..))
-import           Servant.API.QueryParam      (QueryFlag, QueryParam,
+import           Servant.API.Modifiers       (Required,  Optional, Lenient, Strict)
+import           Servant.API.QueryParam      (QueryFlag, QueryParam, QueryParam',
                                               QueryParams)
 import           Servant.API.Raw             (Raw)
 import           Servant.API.Stream          (Stream, StreamGet, StreamPost,
@@ -93,12 +100,12 @@ import           Servant.API.Stream          (Stream, StreamGet, StreamPost,
                                               NewlineFraming,
                                               NetstringFraming)
 import           Servant.API.RemoteHost      (RemoteHost)
-import           Servant.API.ReqBody         (ReqBody)
+import           Servant.API.ReqBody         (ReqBody, ReqBody')
 import           Servant.API.ResponseHeaders (AddHeader, addHeader, noHeader,
                                               BuildHeadersTo (buildHeadersTo),
                                               GetHeaders (getHeaders),
                                               HList (..), Headers (..),
-                                              getHeadersHList, getResponse)
+                                              getHeadersHList, getResponse, ResponseHeader (..))
 import           Servant.API.Sub             ((:>))
 import           Servant.API.Vault           (Vault)
 import           Servant.API.Verbs           (PostCreated, Delete, DeleteAccepted,
@@ -124,3 +131,6 @@ import           Servant.Utils.Links         (HasLink (..), Link, IsElem, IsElem
                                               URI (..), safeLink)
 import           Web.HttpApiData             (FromHttpApiData (..),
                                               ToHttpApiData (..))
+
+import           Data.Type.Bool              (If)
+import           Data.Singletons.Bool        (SBool (..), SBoolI (..))

--- a/servant/src/Servant/API/Header.hs
+++ b/servant/src/Servant/API/Header.hs
@@ -4,13 +4,15 @@
 {-# LANGUAGE PolyKinds          #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Header (
-  Header(..),
-) where
+    Header, Header',
+    ) where
 
-import           Data.ByteString (ByteString)
 import           Data.Typeable   (Typeable)
 import           GHC.TypeLits    (Symbol)
+import           Servant.API.Modifiers
+
 -- | Extract the given header's value as a value of type @a@.
+-- I.e. header sent by client, parsed by server.
 --
 -- Example:
 --
@@ -18,10 +20,10 @@ import           GHC.TypeLits    (Symbol)
 -- >>>
 -- >>>            -- GET /view-my-referer
 -- >>> type MyApi = "view-my-referer" :> Header "from" Referer :> Get '[JSON] Referer
-data Header (sym :: Symbol) a = Header a
-                              | MissingHeader
-                              | UndecodableHeader ByteString
-    deriving (Typeable, Eq, Show, Functor)
+type Header = Header' '[Optional, Strict]
+
+data Header' (mods :: [*]) (sym :: Symbol) a
+    deriving Typeable
 
 -- $setup
 -- >>> import Servant.API

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -24,13 +24,16 @@ type ComprehensiveAPIWithoutRaw =
   Get '[JSON] Int :<|>
   Capture "foo" Int :> GET :<|>
   Header "foo" Int :> GET :<|>
+  Header' '[Required, Lenient] "bar" Int :> GET :<|>
   HttpVersion :> GET :<|>
   IsSecure :> GET :<|>
   QueryParam "foo" Int :> GET :<|>
+  QueryParam' '[Required, Lenient] "bar" Int :> GET :<|>
   QueryParams "foo" Int :> GET :<|>
   QueryFlag "foo" :> GET :<|>
   RemoteHost :> GET :<|>
   ReqBody '[JSON] Int :> GET :<|>
+  ReqBody' '[Lenient] '[JSON] Int :> GET :<|>
   Get '[JSON] (Headers '[Header "foo" Int] NoContent) :<|>
   "foo" :> GET :<|>
   Vault :> GET :<|>

--- a/servant/src/Servant/API/Modifiers.hs
+++ b/servant/src/Servant/API/Modifiers.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+module Servant.API.Modifiers (
+    -- * Required / optional argument
+    Required, Optional,
+    FoldRequired, FoldRequired',
+    -- * Lenient / strict parsing
+    Lenient, Strict,
+    FoldLenient, FoldLenient',
+    -- * Utilities
+    RequiredArgument,
+    foldRequiredArgument,
+    unfoldRequiredArgument,
+    RequestArgument,
+    unfoldRequestArgument,
+    ) where
+
+import Data.Proxy           (Proxy (..))
+import Data.Singletons.Bool (SBool (..), SBoolI (..))
+import Data.Text            (Text)
+import Data.Type.Bool       (If)
+
+-- | Required argument. Not wrapped.
+data Required
+
+-- | Optional argument. Wrapped in 'Maybe'.
+data Optional
+
+-- | Fold modifier list to decide whether argument is required.
+--
+-- >>> :kind! FoldRequired '[Required, Description "something"]
+-- FoldRequired '[Required, Description "something"] :: Bool
+-- = 'True
+--
+-- >>> :kind! FoldRequired '[Required, Optional]
+-- FoldRequired '[Required, Optional] :: Bool
+-- = 'False
+--
+-- >>> :kind! FoldRequired '[]
+-- FoldRequired '[] :: Bool
+-- = 'False
+--
+type FoldRequired mods = FoldRequired' 'False mods
+
+-- | Implementation of 'FoldRequired'.
+type family FoldRequired' (acc :: Bool) (mods :: [*]) :: Bool where
+    FoldRequired' acc '[]                = acc
+    FoldRequired' acc (Required ': mods) = FoldRequired' 'True mods
+    FoldRequired' acc (Optional ': mods) = FoldRequired' 'False mods
+    FoldRequired' acc (mod      ': mods) = FoldRequired' acc mods
+
+-- | Leniently parsed argument, i.e. parsing never fail. Wrapped in @'Either' 'Text'@.
+data Lenient
+
+-- | Strictly parsed argument. Not wrapped.
+data Strict
+
+-- | Fold modifier list to decide whether argument should be parsed strictly or leniently.
+--
+-- >>> :kind! FoldLenient '[]
+-- FoldLenient '[] :: Bool
+-- = 'False
+--
+type FoldLenient mods = FoldLenient' 'False mods
+
+-- | Implementation of 'FoldLenient'.
+type family FoldLenient' (acc :: Bool) (mods ::  [*]) :: Bool where
+    FoldLenient' acc '[]               = acc
+    FoldLenient' acc (Lenient ': mods) = FoldLenient' 'True mods
+    FoldLenient' acc (Strict  ': mods) = FoldLenient' 'False mods
+    FoldLenient' acc (mod     ': mods) = FoldLenient' acc mods
+
+-- | Helper type alias.
+--
+-- * 'Required' ↦ @a@
+--
+-- * 'Optional' ↦ @'Maybe' a@
+--
+type RequiredArgument mods a = If (FoldRequired mods) a (Maybe a)
+
+-- | Fold a 'RequiredAgument' into a value
+foldRequiredArgument
+    :: forall mods a r. (SBoolI (FoldRequired mods))
+    => Proxy mods
+    -> (a -> r)        -- ^ 'Required'
+    -> (Maybe a -> r)  -- ^ 'Optional'
+    -> RequiredArgument mods a
+    -> r
+foldRequiredArgument _ f g mx =
+    case (sbool :: SBool (FoldRequired mods), mx) of
+        (STrue, x)  -> f x
+        (SFalse, x) -> g x
+
+-- | Unfold a value into a 'RequiredArgument'.
+unfoldRequiredArgument
+    :: forall mods m a. (Monad m, SBoolI (FoldRequired mods), SBoolI (FoldLenient mods))
+    => Proxy mods
+    -> m (RequiredArgument mods a)            -- ^ error when argument is required
+    -> (Text -> m (RequiredArgument mods a))  -- ^ error when argument is strictly parsed
+    -> Maybe (Either Text a)                  -- ^ value
+    -> m (RequiredArgument mods a)
+unfoldRequiredArgument _ errReq errSt mex =
+    case (sbool :: SBool (FoldRequired mods), mex) of
+        (STrue, Nothing)  -> errReq
+        (SFalse, Nothing) -> return Nothing
+        (STrue, Just ex)  -> either errSt return ex
+        (SFalse, Just ex) -> either errSt (return . Just) ex
+
+-- | Helper type alias.
+--
+-- By default argument is 'Optional' and 'Strict'.
+--
+-- * 'Required', 'Strict' ↦ @a@
+--
+-- * 'Required', 'Lenient' ↦ @'Either' 'Text' a@
+--
+-- * 'Optional', 'Strict' ↦ @'Maybe' a@
+--
+-- * 'Optional', 'Lenient' ↦ @'Maybe' ('Either' 'Text' a)@
+--
+type RequestArgument mods a =
+    If (FoldRequired mods)
+       (If (FoldLenient mods) (Either Text a) a)
+       (Maybe (If (FoldLenient mods) (Either Text a) a))
+
+
+
+-- | Unfold a value into a 'RequestArgument'.
+unfoldRequestArgument
+    :: forall mods m a. (Monad m, SBoolI (FoldRequired mods), SBoolI (FoldLenient mods))
+    => Proxy mods
+    -> m (RequestArgument mods a)            -- ^ error when argument is required
+    -> (Text -> m (RequestArgument mods a))  -- ^ error when argument is strictly parsed
+    -> Maybe (Either Text a)                 -- ^ value
+    -> m (RequestArgument mods a)
+unfoldRequestArgument _ errReq errSt mex =
+    case (sbool :: SBool (FoldRequired mods), mex, sbool :: SBool (FoldLenient mods)) of
+        (STrue,  Nothing, _)      -> errReq
+        (SFalse, Nothing, _)      -> return Nothing
+        (STrue,  Just ex, STrue)  -> return ex
+        (STrue,  Just ex, SFalse) -> either errSt return ex
+        (SFalse, Just ex, STrue)  -> return (Just ex)
+        (SFalse, Just ex, SFalse) -> either errSt (return . Just) ex
+
+-- $setup
+-- >>> import Servant.API

--- a/servant/src/Servant/API/QueryParam.hs
+++ b/servant/src/Servant/API/QueryParam.hs
@@ -3,10 +3,12 @@
 {-# LANGUAGE TypeOperators      #-}
 {-# LANGUAGE PolyKinds          #-}
 {-# OPTIONS_HADDOCK not-home    #-}
-module Servant.API.QueryParam (QueryFlag, QueryParam, QueryParams) where
+module Servant.API.QueryParam (QueryFlag, QueryParam, QueryParam', QueryParams) where
 
 import           Data.Typeable (Typeable)
 import           GHC.TypeLits (Symbol)
+import           Servant.API.Modifiers
+
 -- | Lookup the value associated to the @sym@ query string parameter
 -- and try to extract it as a value of type @a@.
 --
@@ -14,7 +16,10 @@ import           GHC.TypeLits (Symbol)
 --
 -- >>> -- /books?author=<author name>
 -- >>> type MyApi = "books" :> QueryParam "author" Text :> Get '[JSON] [Book]
-data QueryParam (sym :: Symbol) (a :: *)
+type QueryParam = QueryParam' '[Optional, Strict]
+
+-- | 'QueryParam' which can be 'Required', 'Lenient', or modified otherwise.
+data QueryParam' (mods :: [*]) (sym :: Symbol) (a :: *)
     deriving Typeable
 
 -- | Lookup the values associated to the @sym@ query string parameter

--- a/servant/src/Servant/API/ReqBody.hs
+++ b/servant/src/Servant/API/ReqBody.hs
@@ -2,16 +2,25 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PolyKinds          #-}
 {-# OPTIONS_HADDOCK not-home    #-}
-module Servant.API.ReqBody where
+module Servant.API.ReqBody (
+    ReqBody, ReqBody',
+    ) where
 
-import           Data.Typeable (Typeable)
+import Data.Typeable (Typeable)
+import Servant.API.Modifiers
+
 -- | Extract the request body as a value of type @a@.
 --
 -- Example:
 --
 -- >>>            -- POST /books
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book
-data ReqBody (contentTypes :: [*]) (a :: *)
+type ReqBody = ReqBody' '[Required, Strict]
+
+-- | 
+--
+-- /Note:/ 'ReqBody'' is always 'Required'.
+data ReqBody' (mods :: [*]) (contentTypes :: [*]) (a :: *)
     deriving (Typeable)
 
 -- $setup


### PR DESCRIPTION
Implements modifiers #856.

### Combinators

- [x] QueryParam
- [x] Header
- [x] ReqBody

`QueryParams`? `Required` -> `NonEmpty a`?

### Implementations

- [x] servant (Links)
- [x] servant-client-core
- [x] servant-server
- [x] servant-docs
- [x] servant-foreign
- [x] Amend ComprehensiveAPI

### QA

-  `Capture` can also be lenient, but I'll leave it for now, but by definition they are always required.

There's some info in the commit messages.

### Resolves

- https://github.com/haskell-servant/servant/issues/862
- When `ReqBody` is amended, will solve https://github.com/haskell-servant/servant/issues/793
- Supersedes https://github.com/haskell-servant/servant/pull/256