### PR TITLE
Support http-client’s CookieJar in servant-client

### DIFF
--- a/doc/cookbook/basic-auth/BasicAuth.lhs
+++ b/doc/cookbook/basic-auth/BasicAuth.lhs
@@ -164,7 +164,7 @@ main :: IO ()
 main = do
   mgr <- newManager defaultManagerSettings
   bracket (forkIO $ runApp userDB) killThread $ \_ ->
-    runClientM (getSite u) (ClientEnv mgr (BaseUrl Http "localhost" 8080 ""))
+    runClientM (getSite u) (ClientEnv mgr (BaseUrl Http "localhost" 8080 "") Nothing)
       >>= print
 
   where u = BasicAuthData "foo" "bar"

--- a/doc/cookbook/db-postgres-pool/PostgresPool.lhs
+++ b/doc/cookbook/db-postgres-pool/PostgresPool.lhs
@@ -125,7 +125,7 @@ main = do
   initDB connStr
   mgr <- newManager defaultManagerSettings
   bracket (forkIO $ runApp pool) killThread $ \_ -> do
-    ms <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" 8080 "")) $ do
+    ms <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" 8080 "") Nothing) $ do
       postMsg "hello"
       postMsg "world"
       getMsgs

--- a/doc/cookbook/db-sqlite-simple/DBConnection.lhs
+++ b/doc/cookbook/db-sqlite-simple/DBConnection.lhs
@@ -86,7 +86,7 @@ main = do
   initDB dbfile
   mgr <- newManager defaultManagerSettings
   bracket (forkIO $ runApp dbfile) killThread $ \_ -> do
-    ms <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" 8080 "")) $ do
+    ms <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" 8080 "") Nothing) $ do
       postMsg "hello"
       postMsg "world"
       getMsgs

--- a/doc/cookbook/jwt-and-basic-auth/JWTAndBasicAuth.lhs
+++ b/doc/cookbook/jwt-and-basic-auth/JWTAndBasicAuth.lhs
@@ -151,7 +151,7 @@ testClient = do
   let (foo :<|> _) = client (Proxy :: Proxy TestAPIClient)
                      (BasicAuthData "name" "pass")
   res <- runClientM (foo 42)
-    (ClientEnv mgr (BaseUrl Http "localhost" port ""))
+    (ClientEnv mgr (BaseUrl Http "localhost" port "") Nothing)
   hPutStrLn stderr $ case res of
     Left err -> "Error: " ++ show err
     Right r -> "Success: " ++ show r

--- a/doc/cookbook/using-custom-monad/UsingCustomMonad.lhs
+++ b/doc/cookbook/using-custom-monad/UsingCustomMonad.lhs
@@ -11,7 +11,7 @@ We start with a pretty standard set of imports and definition of the model:
 {-# LANGUAGE TypeOperators #-}
 
 import           Control.Concurrent          (forkIO, killThread)
-import           Control.Concurrent.STM.TVar (TVar, newTVar, readTVar, 
+import           Control.Concurrent.STM.TVar (TVar, newTVar, readTVar,
                                               writeTVar)
 import           Control.Exception           (bracket)
 import           Control.Monad.IO.Class      (liftIO)
@@ -95,7 +95,7 @@ main = do
   bracket (forkIO runApp) killThread $ \_ -> do
     let getBooksClient :<|> addBookClient = client api
     let printBooks = getBooksClient >>= liftIO . print
-    _ <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" port "")) $ do
+    _ <- flip runClientM (ClientEnv mgr (BaseUrl Http "localhost" port "") Nothing) $ do
       _ <- printBooks
       _ <- addBookClient $ Book "Harry Potter and the Order of the Phoenix"
       _ <- printBooks

--- a/doc/tutorial/Client.lhs
+++ b/doc/tutorial/Client.lhs
@@ -136,7 +136,7 @@ queries = do
 run :: IO ()
 run = do
   manager' <- newManager defaultManagerSettings
-  res <- runClientM queries (ClientEnv manager' (BaseUrl Http "localhost" 8081 ""))
+  res <- runClientM queries (ClientEnv manager' (BaseUrl Http "localhost" 8081 "") Nothing)
   case res of
     Left err -> putStrLn $ "Error: " ++ show err
     Right (pos, message, em) -> do

--- a/servant-client-ghcjs/README.md
+++ b/servant-client-ghcjs/README.md
@@ -170,6 +170,6 @@ main :: IO ()
 main = do
     mgr <- newManager defaultManagerSettings
     let clientBaseUrl = BaseUrl Http "www.example.com" 80 ""
-    ePos <- runClientM (position apiClient 10 20) $ ClientEnv mgr clientBaseUrl
+    ePos <- runClientM (position apiClient 10 20) $ ClientEnv mgr clientBaseUrl Nothing
     print ePos
 ```

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -51,7 +51,9 @@ library
     , mtl                   >= 2.1      && < 2.3
     , semigroupoids         >= 4.3      && < 5.3
     , servant-client-core   == 0.12.*
+    , stm                   >= 2.1      && < 2.5
     , text                  >= 1.2      && < 1.3
+    , time                  >= 1.7      && < 1.9
     , transformers          >= 0.3      && < 0.6
     , transformers-base     >= 0.4.4    && < 0.5
     , transformers-compat   >= 0.4      && < 0.6

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -302,7 +302,7 @@ manager' :: C.Manager
 manager' = unsafePerformIO $ C.newManager C.defaultManagerSettings
 
 runClient :: ClientM a -> BaseUrl -> IO (Either ServantError a)
-runClient x baseUrl' = runClientM x (ClientEnv manager' baseUrl')
+runClient x baseUrl' = runClientM x (ClientEnv manager' baseUrl' Nothing)
 
 sucessSpec :: Spec
 sucessSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do

--- a/servant-client/test/Servant/StreamSpec.hs
+++ b/servant-client/test/Servant/StreamSpec.hs
@@ -92,7 +92,7 @@ manager' :: C.Manager
 manager' = unsafePerformIO $ C.newManager C.defaultManagerSettings
 
 runClient :: ClientM a -> BaseUrl -> IO (Either ServantError a)
-runClient x baseUrl' = runClientM x (ClientEnv manager' baseUrl')
+runClient x baseUrl' = runClientM x (ClientEnv manager' baseUrl' Nothing)
 
 runResultStream :: ResultStream a -> IO (Maybe (Either String a), Maybe (Either String a), Maybe (Either String a), Maybe (Either String a))
 runResultStream (ResultStream k) = k $ \act -> (,,,) <$> act <*> act <*> act <*> act

--- a/sources.txt
+++ b/sources.txt
@@ -1,5 +1,6 @@
 servant
 servant-server
 servant-client
+servant-client-core
 servant-docs
 servant-foreign


### PR DESCRIPTION
Could we consider this simple addition? Or something similar? :pray:

(This diff is just a draft to, hopefully, start a discussion.)

It’s incredibly useful when testing “cookied” endpoints (e.g. from https://github.com/zohl/servant-auth-cookie), when we don’t care about cookie values and want to just let them happen correctly behind the scenes (like a browser would do). /cc @zohl 

Perhaps, from Servant’s POV, it would be ideal if `Client.Manager` allowed this (and kept its own `Client.CookieJar`), but… ¯\\\_(ツ)\_/¯

----

Right now, as a workaround (in place of this PR), in our test code, we’re using this hack, which is not at all pretty (reduced imports and lifts because of ClassyPrelude):

```hs
module Backend.Unsafe.Tests.CookiedClientM where

import           Control.Monad.Except
import           Data.Proxy
import qualified Network.HTTP.Client                as Client
import           Network.HTTP.Types                 (statusCode)
import           Servant.Client.Core
import           Servant.Client.Internal.HttpClient

data CookiedClientEnv = CookiedClientEnv
  { clientEnv :: ClientEnv
  , cookieJar :: TVar Client.CookieJar
  }

newtype CookiedClientM a = CookiedClientM
  { runCookiedClientM' :: ReaderT CookiedClientEnv (ExceptT ServantError IO) a
  } deriving ( Functor
             , Applicative
             , Monad
             , MonadIO
             , Generic
             , MonadReader CookiedClientEnv
             , MonadError ServantError
             , MonadThrow
             , MonadCatch
             )

instance RunClient CookiedClientM where
  runRequest = performCookiedRequest
  throwServantError = throwError
  catchServantError = catchError

performCookiedRequest :: Request -> CookiedClientM Response
performCookiedRequest req = do
  m <- asks (manager . clientEnv)
  burl <- asks (baseUrl . clientEnv)
  cookieJar' <- asks cookieJar
  now <- liftIO getCurrentTime
  request <-
    atomically $ do
      oldCookieJar <- readTVar cookieJar'
      let (newRequest, newCookieJar) =
            Client.insertCookiesIntoRequest
              (requestToClientRequest burl req)
              oldCookieJar
              now
      writeTVar cookieJar' newCookieJar
      pure newRequest
  eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request m
  case eResponse of
    Left err -> throwError err
    Right response -> do
      now' <- liftIO getCurrentTime
      atomically $
        modifyTVar'
          cookieJar'
          (fst . Client.updateCookieJar response request now')
      let status = Client.responseStatus response
          status_code = statusCode status
          ourResponse = clientResponseToReponse response
      unless (status_code >= 200 && status_code < 300) $
        throwError $ FailureResponse ourResponse
      return ourResponse

instance ClientLike (CookiedClientM a) (CookiedClientM a) where
  mkClient = id

cookiedClient ::
     HasClient CookiedClientM api => Proxy api -> Client CookiedClientM api
cookiedClient api = api `clientIn` (Proxy :: Proxy CookiedClientM)

runCookiedClientM ::
     CookiedClientM a -> CookiedClientEnv -> IO (Either ServantError a)
runCookiedClientM cm env =
  runExceptT . flip runReaderT env $ runCookiedClientM' cm
```