### PR TITLE
Kinder type checking

### DIFF
--- a/servant/src/Servant/API/Capture.hs
+++ b/servant/src/Servant/API/Capture.hs
@@ -12,7 +12,7 @@ import           GHC.TypeLits  (Symbol)
 --
 -- >>>            -- GET /books/:isbn
 -- >>> type MyApi = "books" :> Capture "isbn" Text :> Get '[JSON] Book
-data Capture (sym :: Symbol) a
+data Capture (sym :: Symbol) (a :: *)
     deriving (Typeable)
 
 
@@ -23,7 +23,7 @@ data Capture (sym :: Symbol) a
 --
 -- >>>            -- GET /src/*
 -- >>> type MyAPI = "src" :> CaptureAll "segments" Text :> Get '[JSON] SourceFile
-data CaptureAll (sym :: Symbol) a
+data CaptureAll (sym :: Symbol) (a :: *)
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/QueryParam.hs
+++ b/servant/src/Servant/API/QueryParam.hs
@@ -14,7 +14,7 @@ import           GHC.TypeLits (Symbol)
 --
 -- >>> -- /books?author=<author name>
 -- >>> type MyApi = "books" :> QueryParam "author" Text :> Get '[JSON] [Book]
-data QueryParam (sym :: Symbol) a
+data QueryParam (sym :: Symbol) (a :: *)
     deriving Typeable
 
 -- | Lookup the values associated to the @sym@ query string parameter
@@ -28,7 +28,7 @@ data QueryParam (sym :: Symbol) a
 --
 -- >>> -- /books?authors[]=<author1>&authors[]=<author2>&...
 -- >>> type MyApi = "books" :> QueryParams "authors" Text :> Get '[JSON] [Book]
-data QueryParams (sym :: Symbol) a
+data QueryParams (sym :: Symbol) (a :: *)
     deriving Typeable
 
 -- | Lookup a potentially value-less query string parameter

--- a/servant/src/Servant/API/ReqBody.hs
+++ b/servant/src/Servant/API/ReqBody.hs
@@ -11,7 +11,7 @@ import           Data.Typeable (Typeable)
 --
 -- >>>            -- POST /books
 -- >>> type MyApi = "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book
-data ReqBody (contentTypes :: [*]) a
+data ReqBody (contentTypes :: [*]) (a :: *)
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -23,7 +23,7 @@ import           Control.Arrow               (first)
 import           Network.HTTP.Types.Method   (StdMethod (..))
 
 -- | A Stream endpoint for a given method emits a stream of encoded values at a given Content-Type, delimited by a framing strategy. Steam endpoints always return response code 200 on success. Type synonyms are provided for standard methods.
-data Stream (method :: k1) (framing :: *) (contentType :: *) a
+data Stream (method :: k1) (framing :: *) (contentType :: *) (a :: *)
   deriving (Typeable, Generic)
 
 type StreamGet  = Stream 'GET

--- a/servant/src/Servant/API/Sub.hs
+++ b/servant/src/Servant/API/Sub.hs
@@ -14,7 +14,7 @@ import           Data.Typeable (Typeable)
 -- >>> -- GET /hello/world
 -- >>> -- returning a JSON encoded World value
 -- >>> type MyApi = "hello" :> "world" :> Get '[JSON] World
-data (path :: k) :> a
+data (path :: k) :> (a :: *)
     deriving (Typeable)
 infixr 4 :>
 

--- a/servant/src/Servant/API/Verbs.hs
+++ b/servant/src/Servant/API/Verbs.hs
@@ -23,7 +23,7 @@ import           Network.HTTP.Types.Method (Method, StdMethod (..),
 -- provided, but you are free to define your own:
 --
 -- >>> type Post204 contentTypes a = Verb 'POST 204 contentTypes a
-data Verb (method :: k1) (statusCode :: Nat) (contentTypes :: [*]) a
+data Verb (method :: k1) (statusCode :: Nat) (contentTypes :: [*]) (a :: *)
   deriving (Typeable, Generic)
 
 -- * 200 responses

--- a/servant/test/Servant/Utils/LinksSpec.hs
+++ b/servant/test/Servant/Utils/LinksSpec.hs
@@ -24,7 +24,7 @@ type TestApi =
   -- All of the verbs
   :<|> "get" :> Get '[JSON] NoContent
   :<|> "put" :> Put '[JSON] NoContent
-  :<|> "post" :> ReqBody '[JSON] 'True :> Post '[JSON] NoContent
+  :<|> "post" :> ReqBody '[JSON] Bool :> Post '[JSON] NoContent
   :<|> "delete" :> Header "ponies" String :> Delete '[JSON] NoContent
   :<|> "raw" :> Raw
   :<|> NoEndpoint
@@ -124,6 +124,6 @@ type WrongPath = "getTypo" :> Get '[JSON] NoContent
 type WrongReturnType = "get" :> Get '[JSON] Bool
 type WrongContentType = "get" :> Get '[OctetStream] NoContent
 type WrongMethod = "get" :> Post '[JSON] NoContent
-type NotALink = "hello" :> ReqBody '[JSON] 'True :> Get '[JSON] Bool
+type NotALink = "hello" :> ReqBody '[JSON] Bool :> Get '[JSON] Bool
 type AllGood = "get" :> Get '[JSON] NoContent
 type NoEndpoint = "empty" :> EmptyAPI


### PR DESCRIPTION

The resulting errors are ludicrously better with `( :: *)` signatures:

Breaking the greet example by doing

```
  :<|> "greet" :> Capture "greetid" Text :> Delete '[JSON]
```

instead of

```
  :<|> "greet" :> Capture "greetid" Text :> Delete '[JSON] NoContent
```

Before yielded

```
    /home/mgsloan/oss/haskell/servant/servant-docs/example/greet.hs:94:5: error:
        • Could not deduce: Servant.API.TypeLevel.Or
                              (Servant.API.TypeLevel.IsIn
                                 ("greet" :> (Capture "greetid" Text :> Delete '[JSON] NoContent))
                                 ("hello"
                                  :> (Capture "name" Text
                                      :> (QueryParam "capital" Bool :> Get '[JSON, PlainText] Greet))))
                              (Servant.API.TypeLevel.Or
                                 (Servant.API.TypeLevel.IsIn
                                    (Capture "greetid" Text :> Delete '[JSON] NoContent)
                                    (ReqBody '[JSON] Greet
                                     :> Post '[JSON] (Headers '[Header "X-Example" Int] Greet)))
                                 (Servant.API.TypeLevel.IsIn
                                    (Capture "greetid" Text :> Delete '[JSON] NoContent)
                                    (Capture "greetid" Text :> Maybe)))
            arising from a use of ‘extraInfo’
        • In the expression:
            extraInfo
              (Proxy ::
                 Proxy ("greet"
                        :> (Capture "greetid" Text :> Delete '[JSON] NoContent)))
          In the expression:
            extraInfo
              (Proxy ::
                 Proxy ("greet"
                        :> (Capture "greetid" Text :> Delete '[JSON] NoContent)))
              $ defAction & headers <>~ ["unicorns"]
                  & notes
                      <>~
                        [DocNote "Title" ["This is some text"],
                         DocNote "Second secton" ["And some more"]]
          In an equation for ‘extra’:
              extra
                = extraInfo
                    (Proxy ::
                       Proxy ("greet"
                              :> (Capture "greetid" Text :> Delete '[JSON] NoContent)))
                    $ defAction & headers <>~ ["unicorns"]
                        & notes
                            <>~
                              [DocNote "Title" ["This is some text"],
                               DocNote "Second secton" ["And some more"]]
       |
    94 |     extraInfo (Proxy :: Proxy ("greet" :> Capture "greetid" Text :> Delete '[JSON] NoContent)) $
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    
    /home/mgsloan/oss/haskell/servant/servant-docs/example/greet.hs:108:13: error:
        • No instance for (HasDocs Maybe) arising from a use of ‘docsWith’
        • In the expression:
            docsWith defaultDocOptions [intro1, intro2] extra testApi
          In an equation for ‘docsGreet’:
              docsGreet
                = docsWith defaultDocOptions [intro1, intro2] extra testApi
        |
    108 | docsGreet = docsWith defaultDocOptions [intro1, intro2] extra testApi
        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

And now yields

```
    /home/mgsloan/oss/haskell/servant/servant-docs/example/greet.hs:84:45: error:
        • Expecting one more argument to ‘Delete '[JSON]’
          Expected a type, but ‘Delete '[JSON]’ has kind ‘* -> *’
        • In the second argument of ‘:>’, namely ‘Delete '[JSON]’
          In the second argument of ‘:>’, namely
            ‘Capture "greetid" Text :> Delete '[JSON]’
          In the second argument of ‘:<|>’, namely
            ‘"greet" :> (Capture "greetid" Text :> Delete '[JSON])’
       |
    84 |   :<|> "greet" :> Capture "greetid" Text :> Delete '[JSON]
       |                                             ^^^^^^^^^^^^^^
```