### PR TITLE
Bump lower bounds

### DIFF
--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -22,47 +22,60 @@ extra-source-files:
   static/ui.js
 
 library
+  default-language:    Haskell2010
+  ghc-options:         -Wall -pgmL markdown-unlit
   exposed-modules:     ApiType
                      , Authentication
                      , Client
                      , Docs
                      , Javascript
                      , Server
-  build-depends:       base == 4.*
-                     , base-compat
-                     , text
-                     , aeson
-                     , aeson-compat
-                     , blaze-html
-                     , directory
-                     , blaze-markup
-                     , containers
-                     , servant == 0.12.*
-                     , servant-server == 0.12.*
-                     , servant-client == 0.12.*
-                     , servant-docs >= 0.11.1 && <0.12
-                     , servant-js >= 0.9 && <0.10
-                     , warp
-                     , http-api-data
-                     , http-media
-                     , lucid
-                     , time
-                     , string-conversions
-                     , bytestring
-                     , attoparsec
-                     , mtl >=2.1 && <2.3
-                     , mtl-compat
-                     , random
-                     , js-jquery
-                     , wai
-                     , http-types
-                     , transformers
-                     , markdown-unlit >= 0.4
-                     , http-client
-                     , cookie
-  default-language:    Haskell2010
-  ghc-options:         -Wall -pgmL markdown-unlit
-  build-tool-depends: markdown-unlit:markdown-unlit
+
+  -- Packages `servant` depends on.
+  -- We don't need to specify bounds here as this package is never released.
+  build-depends:
+      base >= 4.7 && <4.11
+    , aeson
+    , aeson-compat
+    , attoparsec
+    , base-compat
+    , bytestring
+    , containers
+    , directory
+    , http-api-data
+    , http-client
+    , http-media
+    , http-types
+    , mtl
+    , string-conversions
+    , text
+    , transformers
+    , wai
+    , warp
+
+  -- Servant dependencies
+  build-depends:
+       servant
+     , servant-server
+     , servant-client
+     , servant-docs
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      blaze-html   >= 0.9.0.1 && < 0.10
+    , blaze-markup >= 0.8.0.0 && < 0.9
+    , cookie       >= 0.4.3   && < 0.5
+    , js-jquery    >= 3.2.1   && < 3.3
+    , lucid        >= 2.9.9   && < 2.10
+    , mtl-compat   >= 0.2.1   && < 0.3
+    , random       >= 1.1     && < 1.2
+    , servant-js   >= 0.9     && < 0.10
+    , time         >= 1.4.2   && < 1.9
+
+  -- For legacy tools, we need to specify build-depends too
+  build-depends: markdown-unlit >= 0.4.1 && <0.5
+  build-tool-depends: markdown-unlit:markdown-unlit >= 0.4.1 && <0.5
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -73,7 +86,7 @@ test-suite spec
   other-modules: JavascriptSpec
   build-tool-depends:
     hspec-discover:hspec-discover
-  build-depends: base == 4.*
+  build-depends: base
                , tutorial
                , hspec
                , hspec-wai

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -39,25 +39,39 @@ library
       Servant.Client.Core.Internal.HasClient
       Servant.Client.Core.Internal.Request
       Servant.Client.Core.Internal.RunClient
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
       base                  >= 4.7      && < 4.11
-    , base-compat           >= 0.9.1    && < 0.10
-    , base64-bytestring     >= 1.0.0.1  && < 1.1
-    , bytestring            >= 0.10     && < 0.11
-    , containers            >= 0.5      && < 0.6
-    , exceptions            >= 0.8      && < 0.9
-    , generics-sop          >= 0.1.0.0  && < 0.4
-    , http-api-data         >= 0.3.6    && < 0.4
-    , http-media            >= 0.6.2    && < 0.8
-    , http-types            >= 0.8.6    && < 0.12
+    , bytestring            >= 0.10.4.0 && < 0.11
+    , containers            >= 0.5.5.1  && < 0.6
     , mtl                   >= 2.1      && < 2.3
-    , network-uri           >= 2.6      && < 2.7
-    , safe                  >= 0.3.9    && < 0.4
-    , servant               == 0.12.*
-    , text                  >= 1.2      && < 1.3
+    , text                  >= 1.2.3.0  && < 1.3
+
   if !impl(ghc >= 8.0)
     build-depends:
-        semigroups          >=0.16.2.2 && <0.19
+        semigroups          >=0.18.3 && <0.19
+
+  -- Servant dependencies
+  build-depends:
+        servant            == 0.12.*
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      base-compat           >= 0.9.3    && < 0.10
+    , base64-bytestring     >= 1.0.0.1  && < 1.1
+    , exceptions            >= 0.8.3    && < 0.9
+    , generics-sop          >= 0.3.1.0  && < 0.4
+    , http-api-data         >= 0.3.7.1  && < 0.4
+    , http-media            >= 0.7.1.1  && < 0.8
+    , http-types            >= 0.9.1    && < 0.12
+    , network-uri           >= 2.6.1.0  && < 2.7
+    , safe                  >= 0.3.15   && < 0.4
+
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -69,14 +83,20 @@ test-suite spec
   default-language:    Haskell2010
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:
+      Servant.Client.Core.Internal.BaseUrlSpec
+
+  -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
       base
     , base-compat
-    , deepseq
     , servant-client-core
-    , hspec == 2.*
-    , QuickCheck >= 2.7 && < 2.11
+
+  -- Additonal dependencies
+  build-depends:
+      deepseq    >= 1.3.0.2 && <1.5
+    , hspec      >= 2.4.4   && <2.5
+    , QuickCheck >= 2.10.1  && < 2.12
+
   build-tool-depends:
-    hspec-discover:hspec-discover
-  other-modules:
-      Servant.Client.Core.Internal.BaseUrlSpec
+    hspec-discover:hspec-discover >= 2.4.4 && <2.5

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -35,26 +35,39 @@ library
   exposed-modules:
     Servant.Client
     Servant.Client.Internal.HttpClient
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
       base                  >= 4.7      && < 4.11
-    , base-compat           >= 0.9.1    && < 0.10
-    , bytestring            >= 0.10     && < 0.11
-    , aeson                 >= 0.7      && < 1.3
-    , attoparsec            >= 0.12     && < 0.14
-    , containers            >= 0.5      && < 0.6
-    , http-client           >= 0.4.30   && < 0.6
-    , http-client-tls       >= 0.2.2    && < 0.4
-    , http-media            >= 0.6.2    && < 0.8
-    , http-types            >= 0.8.6    && < 0.12
-    , exceptions            >= 0.8      && < 0.9
-    , monad-control         >= 1.0.0.4  && < 1.1
+    , bytestring            >= 0.10.4.0 && < 0.11
+    , containers            >= 0.5.5.1  && < 0.6
     , mtl                   >= 2.1      && < 2.3
-    , semigroupoids         >= 4.3      && < 5.3
-    , servant-client-core   == 0.12.*
-    , text                  >= 1.2      && < 1.3
-    , transformers          >= 0.3      && < 0.6
+    , text                  >= 1.2.3.0  && < 1.3
+    , transformers          >= 0.3.0.0  && < 0.6
+
+  -- Servant dependencies
+  build-depends:
+      servant-client-core   == 0.12.*
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      aeson                 >= 1.2.3.0  && < 1.3
+    , base-compat           >= 0.9.3    && < 0.10
+    , attoparsec            >= 0.13.2.0 && < 0.14
+    , http-client           >= 0.5.7.1  && < 0.6
+    , http-client-tls       >= 0.3.5.1  && < 0.4
+    , http-media            >= 0.7.1.1  && < 0.8
+    , http-types            >= 0.9.1    && < 0.12
+    , exceptions            >= 0.8.3    && < 0.9
+    , monad-control         >= 1.0.0.4  && < 1.1
+    , semigroupoids         >= 5.2.1    && < 5.3
     , transformers-base     >= 0.4.4    && < 0.5
-    , transformers-compat   >= 0.4      && < 0.6
+    , transformers-compat   >= 0.5.1    && < 0.6
+
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall
@@ -68,34 +81,40 @@ test-suite spec
   default-language: Haskell2010
   hs-source-dirs: test
   main-is: Spec.hs
-  build-tool-depends:
-    hspec-discover:hspec-discover
   other-modules:
       Servant.ClientSpec
       Servant.StreamSpec
+
+  -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base == 4.*
+      base
     , aeson
     , base-compat
     , bytestring
     , containers
-    , deepseq
-    , hspec == 2.*
     , http-api-data
     , http-client
     , http-media
     , http-types
-    , HUnit
     , mtl
-    , network >= 2.6
-    , QuickCheck >= 2.7
-    , servant
     , servant-client
     , servant-client-core
-    , servant-server == 0.12.*
     , text
     , transformers
     , transformers-compat
     , wai
     , warp
-    , generics-sop
+
+  -- Additonal dependencies
+  build-depends:
+      deepseq        >= 1.3.0.2 && < 1.5
+    , generics-sop   >= 0.3.1.0 && < 0.4
+    , hspec          >= 2.4.4   && < 2.5
+    , HUnit          >= 1.6     && < 1.7
+    , network        >= 2.6.3.2 && < 2.7
+    , QuickCheck     >= 2.10.1  && < 2.12
+    , servant        == 0.12.*
+    , servant-server == 0.12.*
+
+  build-tool-depends:
+    hspec-discover:hspec-discover >= 2.4.4 && < 2.5

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -35,25 +35,39 @@ library
       Servant.Docs
     , Servant.Docs.Internal
     , Servant.Docs.Internal.Pretty
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base >=4.7 && <5
-    , base-compat >= 0.9.1 && <0.10
-    , aeson
-    , aeson-pretty
-    , bytestring >= 0.10.4.0 && <0.11
-    , case-insensitive
-    , hashable
-    , http-media >= 0.6
-    , http-types >= 0.7
-    , lens
-    , servant == 0.12.*
-    , string-conversions
-    , text
-    , unordered-containers >=0.2.5.0
-    , control-monad-omega >= 0.3.1 && <0.4
+      base       >= 4.7      && < 4.11
+    , bytestring >= 0.10.4.0 && < 0.11
+    , text       >= 1.2.3.0  && < 1.3
+
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups          >=0.17 && <0.19
+      semigroups          >=0.18.3 && <0.19
+
+  -- Servant dependencies
+  build-depends:
+      servant            == 0.12.*
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      aeson                >= 1.2.3.0  && < 1.3
+    , aeson-pretty         >= 0.8.5    && < 0.9
+    , base-compat          >= 0.9.3    && < 0.10
+    , case-insensitive     >= 1.2.0.10 && < 1.3
+    , control-monad-omega  >= 0.3.1    && < 0.4
+    , hashable             >= 1.2.6.1  && < 1.3
+    , http-media           >= 0.7.1.1  && < 0.8
+    , http-types           >= 0.9.1    && < 0.12
+    , lens                 >= 4.15.4   && < 4.16
+    , string-conversions   >= 0.4.0.1  && < 0.5
+    , unordered-containers >= 0.2.8.0  && < 0.3
+
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall
@@ -76,19 +90,25 @@ executable greet-docs
   default-language: Haskell2010
 
 test-suite spec
+  default-language: Haskell2010
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules: Servant.DocsSpec
-  build-tool-depends:
-    hspec-discover:hspec-discover
   hs-source-dirs: test
   ghc-options: -Wall
+
+  -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
       base
     , aeson
-    , hspec
     , lens
     , servant
     , servant-docs
     , string-conversions
-  default-language: Haskell2010
+
+  -- Additonal dependencies
+  build-depends:
+      hspec                >= 2.4.4    && < 2.5
+
+  build-tool-depends:
+    hspec-discover:hspec-discover >=2.4.4 && <2.5

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -36,12 +36,26 @@ library
   exposed-modules:     Servant.Foreign
                      , Servant.Foreign.Internal
                      , Servant.Foreign.Inflections
-  build-depends:       base        >= 4.7   && <4.11
-                     , base-compat >= 0.9.3 && <0.10
-                     , lens        == 4.*
-                     , servant     == 0.12.*
-                     , text        >= 1.2  && < 1.3
-                     , http-types
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
+  build-depends:
+      base        >= 4.7     && <4.11
+    , text        >= 1.2.3.0 && < 1.3
+
+  -- Servant dependencies
+  build-depends:
+      servant            == 0.12.*
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      base-compat >= 0.9.3  && <0.10
+    , lens        >= 4.15.4 && <4.16
+    , http-types  >= 0.9.1  && < 0.12
+
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -56,10 +70,17 @@ test-suite spec
   include-dirs:      include
   main-is:           Spec.hs
   other-modules:     Servant.ForeignSpec
+
+  -- Dependencies inherited from the library. No need to specify bounds.
+  build-depends:
+      base
+    , servant
+    , servant-foreign
+
+  -- Additonal dependencies
+  build-depends:
+    hspec >= 2.4.4 && <2.5
+
   build-tool-depends:
-    hspec-discover:hspec-discover
-  build-depends:     base
-                   , hspec >= 2.1.8
-                   , servant
-                   , servant-foreign
+    hspec-discover:hspec-discover >=2.4.4 && <2.5
   default-language:  Haskell2010

--- a/servant-foreign/test/Servant/ForeignSpec.hs
+++ b/servant-foreign/test/Servant/ForeignSpec.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-#if __GLASGOW__HASKELL < 709
+#if __GLASGOW_HASKELL__ < 709
 {-# OPTIONS_GHC -fcontext-stack=41 #-}
 #endif
 #include "overlapping-compat.h"

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -54,38 +54,50 @@ library
     Servant.Server.Internal.RoutingApplication
     Servant.Server.Internal.ServantErr
     Servant.Utils.StaticFiles
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-        base               >= 4.7  && < 4.11
-      , base-compat        >= 0.9  && < 0.10
-      , aeson              >= 0.7  && < 1.3
-      , attoparsec         >= 0.12 && < 0.14
-      , base64-bytestring  >= 1.0  && < 1.1
-      , bytestring         >= 0.10 && < 0.11
-      , containers         >= 0.5  && < 0.6
-      , exceptions         >= 0.8  && < 0.9
-      , http-api-data      >= 0.3  && < 0.4
-      , http-media         >= 0.4  && < 0.8
-      , http-types         >= 0.8  && < 0.12
-      , network-uri        >= 2.6  && < 2.7
-      , monad-control      >= 1.0.0.4 && < 1.1
-      , mtl                >= 2    && < 2.3
-      , network            >= 2.6  && < 2.7
-      , safe               >= 0.3  && < 0.4
-      , servant            == 0.12.*
-      , split              >= 0.2  && < 0.3
-      , string-conversions >= 0.3  && < 0.5
-      , system-filepath    >= 0.4  && < 0.5
-      , filepath           >= 1    && < 1.5
-      , resourcet          >= 1.1.6 && <1.2
-      , tagged             >= 0.7.3 && <0.9
-      , text               >= 1.2  && < 1.3
-      , transformers       >= 0.3  && < 0.6
-      , transformers-base  >= 0.4.4 && < 0.5
-      , transformers-compat>= 0.4  && < 0.6
-      , wai                >= 3.0  && < 3.3
-      , wai-app-static     >= 3.1  && < 3.2
-      , warp               >= 3.0  && < 3.3
-      , word8              >= 0.1  && < 0.2
+      base               >= 4.7      && < 4.11
+    , bytestring         >= 0.10.4.0 && < 0.11
+    , containers         >= 0.5.5.1  && < 0.6
+    , mtl                >= 2.1      && < 2.3
+    , text               >= 1.2.3.0  && < 1.3
+    , transformers       >= 0.3.0.0  && < 0.6
+    , filepath           >= 1.3.0.2  && < 1.5
+
+  -- Servant dependencies
+  build-depends:
+      servant            == 0.12.*
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends:
+      aeson               >= 1.2.3.0  && < 1.3
+    , base-compat         >= 0.9.3    && < 0.10
+    , attoparsec          >= 0.13.2.0 && < 0.14
+    , base64-bytestring   >= 1.0.0.1  && < 1.1
+    , exceptions          >= 0.8.3    && < 0.9
+    , http-api-data       >= 0.3.7.1  && < 0.4
+    , http-media          >= 0.7.1.1  && < 0.8
+    , http-types          >= 0.9.1    && < 0.12
+    , network-uri         >= 2.6.1.0  && < 2.7
+    , monad-control       >= 1.0.0.4  && < 1.1
+    , network             >= 2.6.3.2  && < 2.7
+    , safe                >= 0.3.15   && < 0.4
+    , split               >= 0.2.3.2  && < 0.3
+    , string-conversions  >= 0.4.0.1  && < 0.5
+    , system-filepath     >= 0.4      && < 0.5
+    , resourcet           >= 1.1.10   && < 1.2
+    , tagged              >= 0.8.5    && < 0.9
+    , transformers-base   >= 0.4.4    && < 0.5
+    , transformers-compat >= 0.5.1    && < 0.6
+    , wai                 >= 3.2.1.1  && < 3.3
+    , wai-app-static      >= 3.1.6.1  && < 3.2
+    , warp                >= 3.2.13   && < 3.3
+    , word8               >= 0.1.3    && < 0.2
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -126,49 +138,53 @@ test-suite spec
       Servant.HoistSpec
       Servant.ServerSpec
       Servant.Utils.StaticFilesSpec
-  build-tool-depends:
-    hspec-discover:hspec-discover
+
+  -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base == 4.*
+      base
     , base-compat
     , aeson
     , base64-bytestring
     , bytestring
-    , directory
     , exceptions
-    , hspec == 2.*
-    , hspec-wai >= 0.8 && <0.10
     , http-types
     , mtl
-    , network >= 2.6
-    , parsec
-    , QuickCheck
+    , network
     , resourcet
     , safe
     , servant
     , servant-server
-    , should-not-typecheck == 2.1.*
     , string-conversions
-    , temporary
     , text
     , transformers
     , transformers-compat
     , wai
-    , wai-extra
     , warp
 
+  -- Additonal dependencies
+  build-depends:
+      directory            >= 1.2.1.0  && < 1.4
+    , hspec                >= 2.4.4    && < 2.5
+    , hspec-wai            >= 0.9      && < 0.10
+    , should-not-typecheck >= 2.1.0    && < 2.2
+    , parsec               >= 3.1.11   && < 3.2
+    , QuickCheck           >= 2.10.1   && < 2.12
+    , wai-extra            >= 3.0.21.0 && < 3.1
+    , temporary            >= 1.2.0.3  && < 1.3
+
+  build-tool-depends:
+    hspec-discover:hspec-discover >=2.4.4 && <2.5
+
 test-suite doctests
- build-depends: base
-              , servant
-              , doctest
-              , filemanip
-              , directory
-              , filepath
- type: exitcode-stdio-1.0
- main-is: test/doctests.hs
- buildable: True
- default-language: Haskell2010
- ghc-options: -Wall -threaded
- if impl(ghc >= 8.2)
-   x-doctest-options: -fdiagnostics-color=never
- include-dirs: include
+  build-depends:
+      base
+    , servant-server
+    , doctest >= 0.13.0 && <0.14
+  type: exitcode-stdio-1.0
+  main-is: test/doctests.hs
+  buildable: True
+  default-language: Haskell2010
+  ghc-options: -Wall -threaded
+  if impl(ghc >= 8.2)
+    x-doctest-options: -fdiagnostics-color=never
+  include-dirs: include

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -63,29 +63,38 @@ library
     Servant.API.WithNamedContext
     Servant.Utils.Links
     Servant.Utils.Enter
+
+  -- Bundled with GHC: Lower bound to not force re-installs
+  -- text and mtl are bundled starting with GHC-8.4
+  --
+  -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.7  && < 4.11
-    , base-compat           >= 0.9  && < 0.10
-    , aeson                 >= 0.7  && < 1.3
-    , attoparsec            >= 0.12 && < 0.14
-    , bytestring            >= 0.10 && < 0.11
-    , case-insensitive      >= 1.2  && < 1.3
-    , http-api-data         >= 0.3  && < 0.4
-    , http-media            >= 0.4  && < 0.8
-    , http-types            >= 0.8  && < 0.12
-    , natural-transformation >= 0.4 && < 0.5
-    , mtl                   >= 2.0  && < 2.3
-    , mmorph                >= 1    && < 1.2
-    , tagged                >= 0.7.3 && < 0.9
-    , text                  >= 1    && < 1.3
-    , singleton-bool        >= 0.1.2.0 && <0.2
-    , string-conversions    >= 0.3  && < 0.5
-    , network-uri           >= 2.6  && < 2.7
-    , vault                 >= 0.3  && < 0.4
+      base                  >= 4.7      && < 4.11
+    , bytestring            >= 0.10.4.0 && < 0.11
+    , mtl                   >= 2.0.1    && < 2.3
+    , text                  >= 1.2.3.0  && < 1.3
 
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups            >= 0.16 && < 0.19
+      semigroups            >= 0.18.3 && < 0.19
+
+  -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
+  -- Here can be exceptions if we really need features from the newer versions.
+  build-depends: 
+      base-compat            >= 0.9.3    && < 0.10
+    , aeson                  >= 1.2.3.0  && < 1.3
+    , attoparsec             >= 0.13.2.0 && < 0.14
+    , case-insensitive       >= 1.2.0.10 && < 1.3
+    , http-api-data          >= 0.3.7.1  && < 0.4
+    , http-media             >= 0.7.1.1  && < 0.8
+    , http-types             >= 0.9.1    && < 0.12
+    , natural-transformation >= 0.4      && < 0.5
+    , mmorph                 >= 1.1.0    && < 1.2
+    , tagged                 >= 0.8.5    && < 0.9
+    , singleton-bool         >= 0.1.2.0  && < 0.2
+    , string-conversions     >= 0.4.0.1  && < 0.5
+    , network-uri            >= 2.6.1.0  && < 2.7
+    , vault                  >= 0.3.0.7  && < 0.4
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -125,42 +134,49 @@ test-suite spec
       Servant.API.ResponseHeadersSpec
       Servant.Utils.LinksSpec
       Servant.Utils.EnterSpec
-  build-tool-depends:
-    hspec-discover:hspec-discover
+
+  -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base == 4.*
+      base
     , base-compat
     , aeson
-    , aeson-compat >=0.3.3 && <0.4
     , attoparsec
     , bytestring
-    , hspec == 2.*
-    , QuickCheck
-    , quickcheck-instances
     , servant
     , string-conversions
     , text
-    , url
 
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups            >= 0.16 && < 0.19
+      semigroups
+
+  -- Additonal dependencies
+  build-depends:
+      aeson-compat         >= 0.3.3  && < 0.4
+    , hspec                >= 2.4.4  && < 2.5
+    , QuickCheck           >= 2.10.1 && < 2.12
+    , quickcheck-instances >= 0.3.16 && < 0.4
+
+  build-tool-depends:
+    hspec-discover:hspec-discover >= 2.4.4 && < 2.5
 
 test-suite doctests
- build-depends: base
-              , servant
-              , doctest
-              , filemanip
-              , directory
-              , filepath
-              , hspec
- type: exitcode-stdio-1.0
- main-is: test/doctests.hs
- buildable: True
- default-language: Haskell2010
- ghc-options: -Wall -threaded
- if impl(ghc >= 8.2)
-   x-doctest-options: -fdiagnostics-color=never
- include-dirs: include
- x-doctest-source-dirs: test
- x-doctest-modules: Servant.Utils.LinksSpec
+  build-depends:
+      base
+    , servant
+    , doctest >= 0.13.0 && <0.14
+
+  -- We test Links failure with doctest, so we need extra dependencies
+  build-depends:
+      hspec                >= 2.4.4  && < 2.5
+
+  type: exitcode-stdio-1.0
+  main-is: test/doctests.hs
+  buildable: True
+  default-language: Haskell2010
+  ghc-options: -Wall -threaded
+  if impl(ghc >= 8.2)
+    x-doctest-options: -fdiagnostics-color=never
+  include-dirs: include
+  x-doctest-source-dirs: test
+  x-doctest-modules: Servant.Utils.LinksSpec

--- a/servant/test/Servant/Utils/LinksSpec.hs
+++ b/servant/test/Servant/Utils/LinksSpec.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE PolyKinds       #-}
 {-# LANGUAGE TypeOperators   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if __GLASGOW__HASKELL < 709
+#if __GLASGOW_HASKELL__ < 709
 {-# OPTIONS_GHC -fcontext-stack=41 #-}
 #endif
 module Servant.Utils.LinksSpec where

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,8 @@ packages:
 - servant-server/
 - servant/
 
+extra-deps:
+- text-1.2.3.0
+
 # allow-newer: true # ignores all bounds, that's a sledgehammer
 # - doc/tutorial/


### PR DESCRIPTION
- `text` is already 1.2.3.0 as https://github.com/fpco/stackage/issues/3147 is resolved AFAICS, though not closed.

- `http-types` bound is surprisingly low due: https://github.com/fpco/stackage/issues/2976

---

@alp and other @haskell-servant/maintainers: I'd like to try this bounds schema. It's less aggressive than "lowest versions there is build-plan for", but lessens maintaining burden (we have e.g. `MIN_VERSION_http_types` and `MIN_VERSION_wai_app_static` now, which I'd like to get rid off, we really don't test "other branch" that well)