### PR TITLE
Bump lower bound of http-types >= 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
   - "printf 'packages: \"servant\" \"servant-client\" \"servant-client-core\" \"servant-docs\" \"servant-foreign\" \"servant-server\" \"doc/tutorial\" \"doc/cookbook/db-postgres-pool\" \"doc/cookbook/jwt-and-basic-auth\" \"doc/cookbook/db-sqlite-simple\" \"doc/cookbook/basic-auth\" \"doc/cookbook/https\" \"doc/cookbook/structuring-apis\" \"doc/cookbook/using-custom-monad\" \"doc/cookbook/file-upload\"\\n' > cabal.project"
   - "echo 'constraints: foundation >=0.0.14,memory <0.14.12 || >0.14.12' >> cabal.project"
-  - "echo 'allow-newer: servant-js:servant-foreign' >> cabal.project"
+  - "echo 'allow-newer: servant-js:servant-foreign, servant-auth-server:http-types, servant-multipart:lens' >> cabal.project"
   - cat cabal.project
   - if [ -f "servant/configure.ac" ]; then
       (cd "servant" && autoreconf -i);
@@ -149,14 +149,14 @@ script:
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: servant-*/*.cabal servant-client-*/*.cabal servant-client-core-*/*.cabal servant-docs-*/*.cabal servant-foreign-*/*.cabal servant-server-*/*.cabal tutorial-*/*.cabal cookbook-db-postgres-pool-*/*.cabal cookbook-jwt-and-basic-auth-*/*.cabal cookbook-db-sqlite-simple-*/*.cabal cookbook-basic-auth-*/*.cabal cookbook-https-*/*.cabal cookbook-structuring-apis-*/*.cabal cookbook-using-custom-monad-*/*.cabal cookbook-file-upload-*/*.cabal\\n' > cabal.project"
   - "echo 'constraints: foundation >=0.0.14,memory <0.14.12 || >0.14.12' >> cabal.project"
-  - "echo 'allow-newer: servant-js:servant-foreign' >> cabal.project"
+  - "echo 'allow-newer: servant-js:servant-foreign, servant-auth-server:http-types, servant-multipart:lens' >> cabal.project"
   - cat cabal.project
   - echo -en 'travis_fold:end:unpack\\r'
 
 
   - echo Building with tests and benchmarks... && echo -en 'travis_fold:start:build-everything\\r'
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all --max-backjumps=20000
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
   - echo -en 'travis_fold:end:build-everything\\r'
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 

--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ packages: servant/
   doc/tutorial/
   doc/cookbook/*/*.cabal
 
-allow-newer: servant-js:servant-foreign
+allow-newer: servant-js:servant-foreign, servant-auth-server:http-types, servant-multipart:lens
 
 constraints:
   -- see https://github.com/haskell-infra/hackage-trustees/issues/119

--- a/doc/cookbook/basic-auth/basic-auth.cabal
+++ b/doc/cookbook/basic-auth/basic-auth.cabal
@@ -21,7 +21,7 @@ executable cookbook-basic-auth
                      , servant-server
                      , warp >= 3.2
                      , wai >= 3.2
-                     , http-types >= 0.10
+                     , http-types >= 0.12
                      , markdown-unlit >= 0.4
                      , http-client >= 0.5
   default-language:    Haskell2010

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -21,7 +21,7 @@ executable cookbook-db-postgres-pool
                      , servant-server
                      , warp >= 3.2
                      , wai >= 3.2
-                     , http-types >= 0.10
+                     , http-types >= 0.12
                      , markdown-unlit >= 0.4
                      , http-client >= 0.5
                      , postgresql-simple >= 0.5

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -20,7 +20,7 @@ executable cookbook-db-sqlite-simple
                      , servant-server
                      , warp >= 3.2
                      , wai >= 3.2
-                     , http-types >= 0.10
+                     , http-types >= 0.12
                      , markdown-unlit >= 0.4
                      , http-client >= 0.5
                      , sqlite-simple >= 0.4

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -29,7 +29,7 @@ executable cookbook-jwt-and-basic-auth
                      , servant-auth-server >= 0.3.1.0
                      , warp >= 3.2
                      , wai >= 3.2
-                     , http-types >= 0.10
+                     , http-types >= 0.12
                      , markdown-unlit >= 0.4
                      , http-client >= 0.5
                      , bytestring >= 0.10.4

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -68,7 +68,7 @@ library
     , generics-sop          >= 0.3.1.0  && < 0.4
     , http-api-data         >= 0.3.7.1  && < 0.4
     , http-media            >= 0.7.1.1  && < 0.8
-    , http-types            >= 0.9.1    && < 0.12
+    , http-types            >= 0.12     && < 0.13
     , network-uri           >= 2.6.1.0  && < 2.7
     , safe                  >= 0.3.15   && < 0.4
 

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -39,7 +39,7 @@ library
     , ghcjs-base            >= 0.2.0.0  && < 0.3.0.0
     , ghcjs-prim            >= 0.1.0.0  && < 0.2.0.0
     , http-media            >= 0.6.2    && < 0.8
-    , http-types            >= 0.8.6    && < 0.12
+    , http-types            >= 0.12     && < 0.13
     , monad-control         >= 1.0.0.4  && < 1.1
     , mtl                   >= 2.1      && < 2.3
     , semigroupoids         >= 4.3      && < 5.3

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -62,7 +62,7 @@ library
     , http-client           >= 0.5.7.1  && < 0.6
     , http-client-tls       >= 0.3.5.1  && < 0.4
     , http-media            >= 0.7.1.1  && < 0.8
-    , http-types            >= 0.9.1    && < 0.12
+    , http-types            >= 0.12     && < 0.13
     , exceptions            >= 0.8.3    && < 0.9
     , monad-control         >= 1.0.0.4  && < 1.1
     , semigroupoids         >= 5.2.1    && < 5.3

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -63,8 +63,8 @@ library
     , control-monad-omega  >= 0.3.1    && < 0.4
     , hashable             >= 1.2.6.1  && < 1.3
     , http-media           >= 0.7.1.1  && < 0.8
-    , http-types           >= 0.9.1    && < 0.12
-    , lens                 >= 4.15.4   && < 4.16
+    , http-types           >= 0.12     && < 0.13
+    , lens                 >= 4.15.4   && < 4.17
     , string-conversions   >= 0.4.0.1  && < 0.5
     , unordered-containers >= 0.2.8.0  && < 0.3
 

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -53,8 +53,8 @@ library
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
       base-compat >= 0.9.3  && <0.10
-    , lens        >= 4.15.4 && <4.16
-    , http-types  >= 0.9.1  && < 0.12
+    , lens        >= 4.15.4 && <4.17
+    , http-types  >= 0.12   && < 0.13
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -82,7 +82,7 @@ library
     , exceptions          >= 0.8.3    && < 0.9
     , http-api-data       >= 0.3.7.1  && < 0.4
     , http-media          >= 0.7.1.1  && < 0.8
-    , http-types          >= 0.9.1    && < 0.12
+    , http-types          >= 0.12     && < 0.13
     , network-uri         >= 2.6.1.0  && < 2.7
     , monad-control       >= 1.0.0.4  && < 1.1
     , network             >= 2.6.3.2  && < 2.7

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
@@ -33,11 +32,7 @@ import           Network.HTTP.Types         (Status (..), hAccept, hContentType,
                                              methodDelete, methodGet,
                                              methodHead, methodPatch,
                                              methodPost, methodPut, ok200,
-#if MIN_VERSION_http_types(0,10,0)
                                              imATeapot418,
-#else
-                                             imATeaPot418,
-#endif
                                              parseQuery)
 import           Network.Wai                (Application, Request, requestHeaders, pathInfo,
                                              queryString, rawQueryString,
@@ -73,11 +68,6 @@ import           Servant.Server.Experimental.Auth
                                              mkAuthHandler)
 import           Servant.Server.Internal.Context
                                             (NamedContext(..))
-
-#if !MIN_VERSION_http_types(0,10,0)
-imATeapot418 :: Status
-imATeapot418 = imATeaPot418
-#endif
 
 -- * comprehensive api test
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -87,7 +87,7 @@ library
     , case-insensitive       >= 1.2.0.10 && < 1.3
     , http-api-data          >= 0.3.7.1  && < 0.4
     , http-media             >= 0.7.1.1  && < 0.8
-    , http-types             >= 0.9.1    && < 0.12
+    , http-types             >= 0.12     && < 0.13
     , natural-transformation >= 0.4      && < 0.5
     , mmorph                 >= 1.1.0    && < 1.2
     , tagged                 >= 0.8.5    && < 0.9

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,9 @@ packages:
 - servant/
 
 extra-deps:
+- cabal-doctest-1.0.6
+- http-api-data-0.3.7.2
+- http-types-0.12
 - text-1.2.3.0
 
 # allow-newer: true # ignores all bounds, that's a sledgehammer


### PR DESCRIPTION
- ~~WIP: pending http-api-data release~~
- ~~TODO: remove MIN_VERSION_http_types~~
- There have been 3 major releases of http-types:
  - 0.10 change name of variable
  - 0.11 lowercase escaped URIs
  - 0.12 uppercase escaped URIs
- It's easier for us to support only latest, migration from 0.9/0.10 to 0.12
  is trivial for the downstream. 0.11 may cause semantic (non-type-error) breakage somewhere.
- ~TODO: update `stack.yaml`~