### PR TITLE
relax the aeson constraint, allow 1.3.0.0

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -59,7 +59,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                 >= 1.2.3.0  && < 1.3
+      aeson                 >= 1.2.3.0  && < 1.4
     , base-compat           >= 0.9.3    && < 0.10
     , attoparsec            >= 0.13.2.0 && < 0.14
     , http-client           >= 0.5.7.1  && < 0.6

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -56,7 +56,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                >= 1.2.3.0  && < 1.3
+      aeson                >= 1.2.3.0  && < 1.4
     , aeson-pretty         >= 0.8.5    && < 0.9
     , base-compat          >= 0.9.3    && < 0.10
     , case-insensitive     >= 1.2.0.10 && < 1.3

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -75,7 +75,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson               >= 1.2.3.0  && < 1.3
+      aeson               >= 1.2.3.0  && < 1.4
     , base-compat         >= 0.9.3    && < 0.10
     , attoparsec          >= 0.13.2.0 && < 0.14
     , base64-bytestring   >= 1.0.0.1  && < 1.1

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -82,7 +82,7 @@ library
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends: 
       base-compat            >= 0.9.3    && < 0.10
-    , aeson                  >= 1.2.3.0  && < 1.3
+    , aeson                  >= 1.2.3.0  && < 1.4
     , attoparsec             >= 0.13.2.0 && < 0.14
     , case-insensitive       >= 1.2.0.10 && < 1.3
     , http-api-data          >= 0.3.7.1  && < 0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Let's try to keep resolver at the first day of the month
-resolver: nightly-2018-01-01
+resolver: nightly-2018-03-01
 packages:
 - servant-client/
 - servant-client-core/
@@ -13,6 +13,7 @@ extra-deps:
 - http-api-data-0.3.7.2
 - http-types-0.12
 - text-1.2.3.0
+- aeson-1.3.0.0
 
 # allow-newer: true # ignores all bounds, that's a sledgehammer
 # - doc/tutorial/


### PR DESCRIPTION
fixes https://github.com/fpco/stackage/issues/3337
I didn't actually test an app with the patched servant, I only ran the tests, but since it all compiles and the tests pass, it should be OK I assume.