### PR TITLE
Allow GHC 8.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/doc/cookbook/basic-auth/basic-auth.cabal
+++ b/doc/cookbook/basic-auth/basic-auth.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-basic-auth
   main-is:             BasicAuth.lhs

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-db-postgres-pool
   main-is:             PostgresPool.lhs

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-db-sqlite-simple
   main-is:             DBConnection.lhs

--- a/doc/cookbook/file-upload/file-upload.cabal
+++ b/doc/cookbook/file-upload/file-upload.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-file-upload
   main-is:             FileUpload.lhs

--- a/doc/cookbook/https/https.cabal
+++ b/doc/cookbook/https/https.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-https
   main-is:             Https.lhs

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -11,7 +11,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 category:            Servant
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-jwt-and-basic-auth
   if !impl(ghc >= 7.10)

--- a/doc/cookbook/structuring-apis/structuring-apis.cabal
+++ b/doc/cookbook/structuring-apis/structuring-apis.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-structuring-apis
   main-is:             StructuringApis.lhs

--- a/doc/cookbook/using-custom-monad/using-custom-monad.cabal
+++ b/doc/cookbook/using-custom-monad/using-custom-monad.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
 
 executable cookbook-using-custom-monad
   main-is:             UsingCustomMonad.lhs

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -17,6 +17,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 extra-source-files:
   static/index.html
   static/ui.js
@@ -34,7 +35,7 @@ library
   -- Packages `servant` depends on.
   -- We don't need to specify bounds here as this package is never released.
   build-depends:
-      base >= 4.7 && <4.11
+      base >= 4.7 && <4.12
     , aeson
     , aeson-compat
     , attoparsec

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -11,7 +11,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 homepage:            http://haskell-servant.readthedocs.org/
 bug-reports:         http://github.com/haskell-servant/servant/issues
 cabal-version:       >=1.10
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2017 Servant Contributors
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 category:            Web
 build-type:          Simple
 extra-source-files:
@@ -23,6 +23,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 
 source-repository head
   type:              git
@@ -47,7 +48,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.7      && < 4.11
+      base                  >= 4.7      && < 4.12
     , bytestring            >= 0.10.4.0 && < 0.11
     , containers            >= 0.5.5.1  && < 0.6
     , mtl                   >= 2.1      && < 2.3

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -31,7 +31,7 @@ library
     Servant.Client.Ghcjs
     Servant.Client.Internal.XhrClient
   build-depends:
-      base                  >= 4.7      && < 4.11
+      base                  >= 4.7      && < 4.12
     , bytestring            >= 0.10     && < 0.11
     , case-insensitive      >= 1.2.0.0  && < 1.3.0.0
     , containers            >= 0.5      && < 0.6

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -1,9 +1,9 @@
 name:                servant-client
 version:             0.13
-synopsis: automatical derivation of querying functions for servant webservices
+synopsis: Automatic derivation of querying functions for servant webservices
 description:
-  This library lets you derive automatically Haskell functions that
-  let you query each endpoint of a <http://hackage.haskell.org/package/servant servant> webservice.
+  This library lets you automatically derive Haskell functions that
+  query each endpoint of a <http://hackage.haskell.org/package/servant servant> webservice.
   .
   See <http://haskell-servant.readthedocs.org/en/stable/tutorial/Client.html the client section of the tutorial>.
   .
@@ -12,7 +12,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2017 Servant Contributors
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 category:            Servant, Web
 build-type:          Simple
 cabal-version:       >=1.10
@@ -21,6 +21,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 homepage:            http://haskell-servant.readthedocs.org/
 Bug-reports:         http://github.com/haskell-servant/servant/issues
 extra-source-files:
@@ -41,7 +42,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.7      && < 4.11
+      base                  >= 4.7      && < 4.12
     , bytestring            >= 0.10.4.0 && < 0.11
     , containers            >= 0.5.5.1  && < 0.6
     , mtl                   >= 2.1      && < 2.3

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -11,7 +11,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 category:            Servant, Web
 build-type:          Simple
 cabal-version:       >=1.10
@@ -20,6 +20,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 homepage:            http://haskell-servant.readthedocs.org/
 Bug-reports:         http://github.com/haskell-servant/servant/issues
 extra-source-files:

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -13,7 +13,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2015-2016 Servant Contributors
+copyright:           2015-2018 Servant Contributors
 category:            Servant, Web
 build-type:          Simple
 cabal-version:       >=1.10
@@ -27,6 +27,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 
 source-repository head
   type: git

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -17,7 +17,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 category:            Servant, Web
 build-type:          Custom
 cabal-version:       >=1.10
@@ -26,6 +26,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 extra-source-files:
   include/*.h
   CHANGELOG.md
@@ -60,7 +61,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base               >= 4.7      && < 4.11
+      base               >= 4.7      && < 4.12
     , bytestring         >= 0.10.4.0 && < 0.11
     , containers         >= 0.5.5.1  && < 0.6
     , mtl                >= 2.1      && < 2.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -13,7 +13,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 category:            Servant, Web
 build-type:          Custom
 cabal-version:       >=1.10
@@ -22,6 +22,7 @@ tested-with:
   GHC==7.10.3
   GHC==8.0.2
   GHC==8.2.2
+  GHC==8.4.1
 extra-source-files:
   include/*.h
   CHANGELOG.md
@@ -69,7 +70,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.7      && < 4.11
+      base                  >= 4.7      && < 4.12
     , bytestring            >= 0.10.4.0 && < 0.11
     , mtl                   >= 2.1      && < 2.3
     , text                  >= 1.2.3.0  && < 1.3
@@ -80,7 +81,7 @@ library
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
-  build-depends: 
+  build-depends:
       base-compat            >= 0.9.3    && < 0.10
     , aeson                  >= 1.2.3.0  && < 1.4
     , attoparsec             >= 0.13.2.0 && < 0.14


### PR DESCRIPTION
    And include it in the travis build matrix.
    Also includes fixes for a couple of typos and copyright dates in
    cabal files.