### PR TITLE
servant-client: update README.md and test it

### DIFF
--- a/servant-client/README.lhs
+++ b/servant-client/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/servant-client/README.md
+++ b/servant-client/README.md
@@ -7,14 +7,35 @@ This library lets you automatically derive Haskell functions that let you query 
 ## Example
 
 ``` haskell
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+import Data.Proxy
+import Data.Text
+import Network.HTTP.Client (newManager, defaultManagerSettings)
+import Servant.API
+import Servant.Client
+
+
+type Book = Text
+
 type MyApi = "books" :> Get '[JSON] [Book] -- GET /books
-        :<|> "books" :> ReqBody Book :> Post '[JSON] Book -- POST /books
+        :<|> "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book -- POST /books
 
 myApi :: Proxy MyApi
 myApi = Proxy
 
-getAllBooks :: Manager -> BaseUrl -> ExceptT String IO [Book]
-postNewBook :: Book -> Manager -> BaseUrl -> ExceptT String IO Book
 -- 'client' allows you to produce operations to query an API from a client.
+postNewBook :: Book -> ClientM Book
+getAllBooks :: ClientM [Book]
 (getAllBooks :<|> postNewBook) = client myApi
+
+
+main :: IO ()
+main = do
+  manager' <- newManager defaultManagerSettings
+  res <- runClientM getAllBooks (mkClientEnv manager' (BaseUrl Http "localhost" 8081 ""))
+  case res of
+    Left err -> putStrLn $ "Error: " ++ show err
+    Right books -> print books
 ```

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -128,3 +128,10 @@ test-suite spec
 
   build-tool-depends:
     hspec-discover:hspec-discover >= 2.4.4 && < 2.6
+
+test-suite readme
+  type:           exitcode-stdio-1.0
+  main-is:        README.lhs
+  build-depends:  base, servant, http-client, text, servant-client, markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit
+  ghc-options:    -pgmL markdown-unlit


### PR DESCRIPTION
`README.md` was outdated, so I've brought it up in sync with the codebase and made sure it won't happen again.

I've tried to keep example in sync with http://haskell-servant.readthedocs.io/en/stable/tutorial/Client.html but with some simplification so that it's closer to a hello world.