### PR TITLE
Change definition of StreamGenerator

### DIFF
--- a/doc/tutorial/ApiType.lhs
+++ b/doc/tutorial/ApiType.lhs
@@ -137,7 +137,7 @@ type StreamGet  = Stream 'GET
 type StreamPost = Stream 'POST
 ```
 
-These describe endpoints that return a stream of values rather than just a single value. They not only take a single content type as a parameter, but also a framing strategy -- this specifies how the individual results are delineated from one another in the stream. The two standard strategies given with Servant are `NewlineFraming` and `NetstringFraming`, but others can be written to match other protocols.
+These describe endpoints that return a stream of values rather than just a single value. They not only take a single content type as a parameter, but also a framing strategy -- this specifies how the individual results are delineated from one another in the stream. The three standard strategies given with Servant are `NewlineFraming`, `NetstringFraming` and `NoFraming`, but others can be written to match other protocols.
 
 
 ### `Capture`

--- a/servant-client/test/Servant/StreamSpec.hs
+++ b/servant-client/test/Servant/StreamSpec.hs
@@ -41,7 +41,8 @@ import           Test.QuickCheck
 import           Servant.API         ((:<|>) ((:<|>)), (:>), JSON,
                                       NetstringFraming, NewlineFraming,
                                       OctetStream, ResultStream (..),
-                                      StreamGenerator (..), StreamGet)
+                                      StreamGenerator (..), StreamGet,
+                                      NoFraming)
 import           Servant.Client
 import           Servant.ClientSpec  (Person (..))
 import qualified Servant.ClientSpec  as CS
@@ -55,7 +56,7 @@ spec = describe "Servant.Stream" $ do
 type StreamApi f =
        "streamGetNewline" :> StreamGet NewlineFraming JSON (f Person)
   :<|> "streamGetNetstring" :> StreamGet  NetstringFraming JSON (f Person)
-  :<|> "streamALot" :> StreamGet NewlineFraming OctetStream (f BS.ByteString)
+  :<|> "streamALot" :> StreamGet NoFraming OctetStream (f BS.ByteString)
 
 
 capi :: Proxy (StreamApi ResultStream)

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -117,8 +117,8 @@ import           Servant.API.Stream
                  (BoundaryStrategy (..), BuildFromStream (..),
                  ByteStringParser (..), FramingRender (..),
                  FramingUnrender (..), NetstringFraming, NewlineFraming,
-                 ResultStream (..), Stream, StreamGenerator (..), StreamGet,
-                 StreamPost, ToStreamGenerator (..))
+                 NoFraming, ResultStream (..), Stream, StreamGenerator (..),
+                 StreamGet, StreamPost, ToStreamGenerator (..))
 import           Servant.API.Sub
                  ((:>))
 import           Servant.API.Vault

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -81,6 +81,18 @@ data ByteStringParser a = ByteStringParser {
 class FramingUnrender strategy a where
    unrenderFrames :: Proxy strategy -> Proxy a -> ByteStringParser (ByteStringParser (Either String ByteString))
 
+-- | A framing strategy that does not do any framing at all, it just passes the input data
+--   This will be used most of the time with binary data, such as files
+data NoFraming
+
+instance FramingRender NoFraming a where
+    header   _ _ = empty
+    boundary _ _ = BoundaryStrategyGeneral id
+    trailer  _ _ = empty
+
+instance FramingUnrender NoFraming a where
+    unrenderFrames _ _ = ByteStringParser (Just . (go,)) (go,)
+          where go = ByteStringParser (Just . (, empty) . Right) ((, empty) . Right)
 
 -- | A simple framing strategy that has no header or termination, and inserts a newline character between each frame.
 --   This assumes that it is used with a Content-Type that encodes without newlines (e.g. JSON).


### PR DESCRIPTION
Currently it is not possible to write an instance for `StreamGenerator` for conduit, despite the comment saying otherwise.
Furthermore you cannot use Streams that use a ReaderT IO stack.
This PR trys to solve that
DISCLAIMER: I have to idea what I'm doing