### PR TITLE
Allow to specify a status for streaming endpoints

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/Internal/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/Internal/HasClient.hs
@@ -285,9 +285,9 @@ instance OVERLAPPING_
 instance OVERLAPPABLE_
   ( RunClient m, MimeUnrender ct a, ReflectMethod method,
     FramingUnrender framing a, BuildFromStream a (f a)
-  ) => HasClient m (Stream method framing ct (f a)) where
+  ) => HasClient m (Stream method status framing ct (f a)) where
 
-  type Client m (Stream method framing ct (f a)) = m (f a)
+  type Client m (Stream method status framing ct (f a)) = m (f a)
 
   clientWithRoute _pm Proxy req = do
    sresp <- streamingRequest req

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -26,17 +26,19 @@ import           Data.Typeable
                  (Typeable)
 import           GHC.Generics
                  (Generic)
+import           GHC.TypeLits
+                 (Nat)
 import           Network.HTTP.Types.Method
                  (StdMethod (..))
 import           Text.Read
                  (readMaybe)
 
 -- | A Stream endpoint for a given method emits a stream of encoded values at a given Content-Type, delimited by a framing strategy. Stream endpoints always return response code 200 on success. Type synonyms are provided for standard methods.
-data Stream (method :: k1) (framing :: *) (contentType :: *) (a :: *)
+data Stream (method :: k1) (status :: Nat) (framing :: *) (contentType :: *) (a :: *)
   deriving (Typeable, Generic)
 
-type StreamGet  = Stream 'GET
-type StreamPost = Stream 'POST
+type StreamGet  = Stream 'GET 200
+type StreamPost = Stream 'POST 200
 
 -- | Stream endpoints may be implemented as producing a @StreamGenerator@ -- a function that itself takes two emit functions -- the first to be used on the first value the stream emits, and the second to be used on all subsequent values (to allow interspersed framing strategies such as comma separation).
 newtype StreamGenerator a = StreamGenerator {getStreamGenerator :: (a -> IO ()) -> (a -> IO ()) -> IO ()}


### PR DESCRIPTION
Currently streaming endpoints are always returning `200 OK`. With this it is not possible to implement e.g. Range Requests, as those need to return `206 Partial Content`. This PR changes this.