### PR TITLE
Run `captureAllSpec`

### DIFF
--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -88,6 +88,7 @@ spec :: Spec
 spec = do
   verbSpec
   captureSpec
+  captureAllSpec
   queryParamSpec
   reqBodySpec
   headerSpec


### PR DESCRIPTION
This was missed due to an oversight.

Adding an explicit export list to `ServantSpec.hs` would allow a computer to catch these problems. I haven't done that here.