### PR TITLE
Implement CaptureMany, a non-greedy CaptureAll

### DIFF
--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -228,7 +228,7 @@ instance (KnownSymbol capture, FromHttpApiData a, HasServer api context)
 -- > server :: Server MyApi
 -- > server = getSourceFile
 -- >   where getSourceFile :: [Text] -> Text -> Handler Book
--- >         getSourceFile pathSegments = ...
+-- >         getSourceFile pathSegments pathLast = ...
 instance (KnownSymbol capture, FromHttpApiData a, HasServer api context)
       => HasServer (CaptureMany capture a :> api) context where
 

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -67,7 +67,7 @@ import           Prelude ()
 import           Prelude.Compat
 import           Servant.API
                  ((:<|>) (..), (:>), Accept (..), BasicAuth,
-                 BoundaryStrategy (..), Capture', CaptureAll, Description,
+                 BoundaryStrategy (..), Capture', CaptureAll, CaptureMany, Description,
                  EmptyAPI, FramingRender (..), Header', If, IsSecure (..),
                  QueryFlag, QueryParam', QueryParams, Raw,
                  ReflectMethod (reflectMethod), RemoteHost, ReqBody',
@@ -204,6 +204,41 @@ instance (KnownSymbol capture, FromHttpApiData a, HasServer api context)
 
   route Proxy context d =
     CaptureAllRouter $
+        route (Proxy :: Proxy api)
+              context
+              (addCapture d $ \ txts -> case parseUrlPieces txts of
+                 Left _  -> delayedFail err400
+                 Right v -> return v
+              )
+
+
+-- | If you use 'CaptureMany' in one of the endpoints for your API,
+-- this automatically requires your server-side handler to be a
+-- function that takes an argument of a list of the type specified by
+-- the 'CaptureMany'. This lets servant worry about getting values from
+-- the URL and turning them into values of the type you specify.
+--
+-- You can control how they'll be converted from 'Text' to your type
+-- by simply providing an instance of 'FromHttpApiData' for your type.
+--
+-- Example:
+--
+-- > type MyApi = "src" :> CaptureMany "segments" Text :> Capture "last" Text :> Get '[JSON] SourceFile
+-- >
+-- > server :: Server MyApi
+-- > server = getSourceFile
+-- >   where getSourceFile :: [Text] -> Text -> Handler Book
+-- >         getSourceFile pathSegments = ...
+instance (KnownSymbol capture, FromHttpApiData a, HasServer api context)
+      => HasServer (CaptureMany capture a :> api) context where
+
+  type ServerT (CaptureMany capture a :> api) m =
+    [a] -> ServerT api m
+
+  hoistServerWithContext _ pc nt s = hoistServerWithContext (Proxy :: Proxy api) pc nt . s
+
+  route Proxy context d =
+    CaptureManyRouter $
         route (Proxy :: Proxy api)
               context
               (addCapture d $ \ txts -> case parseUrlPieces txts of

--- a/servant-server/src/Servant/Server/Internal/Router.hs
+++ b/servant-server/src/Servant/Server/Internal/Router.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Servant.Server.Internal.Router where
 
+import           Data.List
+                 (inits, tails)
 import           Data.Map
                  (Map)
 import qualified Data.Map                                   as M
@@ -36,6 +38,9 @@ data Router' env a =
   | CaptureAllRouter (Router' ([Text], env) a)
       -- ^ all path components are passed to the child router in its
       --   environment and are removed afterwards
+  | CaptureManyRouter (Router' ([Text], env) a)
+      -- ^ pass as many path components as we can get, while still matching
+      -- the rest of the route, to the router, removing the ones we match
   | RawRouter     (env -> a)
       -- ^ to be used for routes we do not know anything about
   | Choice        (Router' env a) (Router' env a)
@@ -96,6 +101,9 @@ routerStructure (CaptureRouter router) =
   CaptureRouterStructure $
     routerStructure router
 routerStructure (CaptureAllRouter router) =
+  CaptureRouterStructure $
+    routerStructure router
+routerStructure (CaptureManyRouter router) =
   CaptureRouterStructure $
     routerStructure router
 routerStructure (RawRouter _) =
@@ -175,10 +183,26 @@ runRouterEnv router env request respond =
       let segments = pathInfo request
           request' = request { pathInfo = [] }
       in runRouterEnv router' (segments, env) request' respond
+    CaptureManyRouter router' ->
+      runCaptureMany router' env request respond
     RawRouter app ->
       app env request respond
     Choice r1 r2 ->
       runChoice [runRouterEnv r1, runRouterEnv r2] env request respond
+
+runCaptureMany :: Router ([Text], env) -> env -> RoutingApplication
+runCaptureMany router env request respond =
+  captureLongest (reverse (zip (inits segments) (tails segments)))
+
+  where
+    segments = pathInfo request
+
+    captureLongest [] = respond $ Fail err400
+    captureLongest ((captured, left):rest) =
+      runRouterEnv router (captured, env) request { pathInfo = left } $ \ response ->
+        case response of
+          Fail _ -> captureLongest rest
+          _ -> respond response
 
 -- | Try a list of routing applications in order.
 -- We stop as soon as one fails fatally or succeeds.

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -81,7 +81,7 @@ import           Servant.API.Alternative
 import           Servant.API.BasicAuth
                  (BasicAuth, BasicAuthData (..))
 import           Servant.API.Capture
-                 (Capture, Capture', CaptureAll)
+                 (Capture, Capture', CaptureAll, CaptureMany)
 import           Servant.API.ContentTypes
                  (Accept (..), FormUrlEncoded, JSON, MimeRender (..),
                  MimeUnrender (..), NoContent (NoContent), OctetStream,

--- a/servant/src/Servant/API/Capture.hs
+++ b/servant/src/Servant/API/Capture.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PolyKinds          #-}
 {-# OPTIONS_HADDOCK not-home    #-}
-module Servant.API.Capture (Capture, Capture', CaptureAll) where
+module Servant.API.Capture (Capture, Capture', CaptureAll, CaptureMany) where
 
 import           Data.Typeable
                  (Typeable)
@@ -28,6 +28,20 @@ data Capture' (mods :: [*]) (sym :: Symbol) (a :: *)
 -- >>>            -- GET /src/*
 -- >>> type MyAPI = "src" :> CaptureAll "segments" Text :> Get '[JSON] SourceFile
 data CaptureAll (sym :: Symbol) (a :: *)
+    deriving (Typeable)
+
+-- | Non-greedily capture many remaining values from the request path under a
+-- certain type @a@.
+--
+-- Example:
+--
+-- Where @<name>@ comprises one or more path segments:
+--
+-- >>>            -- GET /v2/<name>/tags/list
+-- >>> type MyAPI = "v2" :> CaptureMany "name" Text :> "tags" :> "list" :> Get '[JSON] [Text]
+--
+-- Which would capture a @[Text]@ for @"name"@.
+data CaptureMany (sym :: Symbol) (a :: *)
     deriving (Typeable)
 
 -- $setup


### PR DESCRIPTION
Takes a pretty simple approach of adding a new router, and having that router try all the routes, starting with the longest and working backwards.

I didn't think very hard about test coverage—I just copied and adjusted the `CaptureAll` tests.

It's very likely I've missed all sorts of things. Feedback very much welcome.

Fixes #962 