### PR TITLE
PoC: Make context into simple data

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ packages: servant/
   doc/cookbook/file-upload
   doc/cookbook/generic
   doc/cookbook/https
-  doc/cookbook/jwt-and-basic-auth
+  -- doc/cookbook/jwt-and-basic-auth
   doc/cookbook/multiple-contexts
   doc/cookbook/pagination
   doc/cookbook/structuring-apis

--- a/cabal.project
+++ b/cabal.project
@@ -32,3 +32,5 @@ constraints:
 allow-newer:
   servant-pagination:servant,
   servant-pagination:servant-server
+
+packages: servant-multipart

--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,8 @@ packages: servant/
   servant-server/
   doc/tutorial/
 
+  servant-server-superrecord/
+
   -- doc/cookbook/*/*.cabal
 
   doc/cookbook/basic-auth

--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,7 @@ packages: servant/
   doc/cookbook/generic
   doc/cookbook/https
   doc/cookbook/jwt-and-basic-auth
+  doc/cookbook/multiple-contexts
   doc/cookbook/pagination
   doc/cookbook/structuring-apis
   doc/cookbook/using-custom-monad

--- a/doc/cookbook/basic-auth/BasicAuth.lhs
+++ b/doc/cookbook/basic-auth/BasicAuth.lhs
@@ -132,7 +132,7 @@ newtype BasicAuthCheck usr = BasicAuthCheck
   deriving (Generic, Typeable, Functor)
 ```
 
-This is all great, but how is our `BasicAuth` combinator supposed to know
+**FIXME** This is all great, but how is our `BasicAuth` combinator supposed to know
 that it should use our `checkBasicAuth` from above? The answer is that it
 simply expects to find a `BasicAuthCheck` value for the right user type in
 the `Context` with which we serve the application, where `Context` is just
@@ -144,8 +144,7 @@ code:
 ``` haskell
 runApp :: UserDB -> IO ()
 runApp db = run 8080 (serveWithContext api ctx server)
-
-  where ctx = checkBasicAuth db :. EmptyContext
+    where ctx = checkBasicAuth db
 ```
 
 `ctx` above is just a context with one element, `checkBasicAuth db`,

--- a/doc/cookbook/index.rst
+++ b/doc/cookbook/index.rst
@@ -28,3 +28,4 @@ you name it!
   jwt-and-basic-auth/JWTAndBasicAuth.lhs
   file-upload/FileUpload.lhs
   pagination/Pagination.lhs
+  multiple-contexts/MultipleContexts.lhs

--- a/doc/cookbook/multiple-contexts/MultipleContexts.lhs
+++ b/doc/cookbook/multiple-contexts/MultipleContexts.lhs
@@ -1,0 +1,254 @@
+Working with (multiple) contexts
+================================
+
+Occasionally you have a big API with different things needing a context.
+*FIXME:* explain what's context here. For example
+- file upload needs tweaked (param dependent) configuration
+- tow sub apis using different realms of basic authentication
+
+```haskell
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
+
+-- This is need for generics-lens instance
+{-# LANGUAGE UndecidableInstances  #-}
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+module Main (main) where
+
+import Prelude ()
+import Prelude.Compat
+
+import GHC.Generics (Generic)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import qualified Data.ByteString.Lazy as LBS
+
+import Control.Lens
+import Data.Generics.Product
+
+import Servant
+import Servant.Multipart
+import Network.Wai.Handler.Warp (run)
+import Network.Wai.Parse (defaultParseRequestBodyOptions, setMaxRequestFileSize)
+
+-- TODO: re-export from Servant
+import Servant.Server.Internal (GetNamedContext (..))
+```
+
+```haskell
+type API = 
+         "upload" :> MultipartForm Mem (MultipartData Mem) :> Post '[JSON] Int
+    :<|> "users" :>  WithNamedContext "users"
+        ( BasicAuth "User space" User :> Get '[PlainText] Text )
+    :<|> "admin" :>  WithNamedContext "admin"
+        ( BasicAuth "Admin UI" User :> Get '[PlainText] Text )
+
+api :: Proxy API
+api = Proxy
+
+newtype User = User Text
+```
+
+We'll use very simple handlers: upload handler returns the total size of uploaded files,
+where user space and admin ui handler echo the username.
+
+```haskell
+server :: Server API
+server = uploadH :<|> usersH :<|> adminH where
+    uploadH :: MultipartData Mem -> Handler Int
+    uploadH multipartData = return $ sum $ map (fromIntegral . LBS.length . fdPayload) $ files multipartData
+
+    usersH (User n) = return $ "User space for " <> n <> "\n"
+    adminH (User n) = return $ "Admin UI for " <> n <> "\n"
+```
+
+Serving
+-------
+
+So far so good, everything is quite simple. Complication starts when we want to serve our server.
+
+If we try:
+
+```haskell.ignore
+app :: Application
+app = serve api server
+```
+
+we get an error:
+
+```
+    • No instance for (Servant.Server.Internal.GetNamedContext
+                         () "admin" subContext1)
+        arising from a use of ‘serve’
+
+```
+
+*TODO* should we use `data EmptyContext =  EmptyContext` for better error message?
+
+We need to provide a context using `serveWithContext`.
+Starting with servant-0.15 we have to define own type,
+and write few instances for it. We trade a little of boilerplate
+for better errors and overall simplicity.
+
+```haskell
+
+data Ctx = Ctx
+    { ctxUploadOpts :: MultipartOptions Mem
+    , ctxUserSpace  :: BasicAuthCheck User
+    , ctxAdminUI    :: BasicAuthCheck User
+    }
+
+instance HasMultipartOptions Ctx Mem where
+    getMultipartOptions = ctxUploadOpts
+
+instance GetNamedContext Ctx "users" (BasicAuthCheck User) where
+    getNamedContext _ = ctxUserSpace
+
+instance GetNamedContext Ctx "admin" (BasicAuthCheck User) where
+    getNamedContext _ = ctxAdminUI
+```
+
+```haskell
+app :: Application
+app = serveWithContext api ctx server where
+    ctx = Ctx
+        { ctxUploadOpts = uploadOpts
+        , ctxUserSpace  = check ["alice", "bob"]
+        , ctxAdminUI    = check ["alice"]
+        }  
+
+uploadOpts :: MultipartOptions Mem
+uploadOpts = MultipartOptions
+    { generalOptions
+        = setMaxRequestFileSize 1024 
+        $ defaultParseRequestBodyOptions
+    , backendOptions = ()
+    }
+
+check :: [Text] -> BasicAuthCheck User
+check names = BasicAuthCheck $ \(BasicAuthData n _) -> do
+    let n' = TE.decodeLatin1 n
+    if n' `elem` names
+    then return $ Authorized $ User n'
+    else return NoSuchUser
+```
+
+We can test the server with:
+
+```
+% curl -D - -F 'data=@cabal.project' 'http://localhost:8000/upload'
+HTTP/1.1 100 Continue
+
+HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+Date: Tue, 10 Jul 2018 10:00:30 GMT
+Server: Warp/3.2.22
+Content-Type: application/json;charset=utf-8
+
+843
+```
+
+`README.md` is bigger than 1024 bytes:
+
+```
+% curl -D - -F 'data=@README.md' 'http://localhost:8000/upload'
+HTTP/1.1 100 Continue
+
+HTTP/1.0 500 Internal Server Error
+Date: Tue, 10 Jul 2018 10:00:42 GMT
+Server: Warp/3.2.22
+Content-Type: text/plain; charset=utf-8
+
+Something went wrong
+```
+
+and we see in server's output:
+
+```
+Maximum size exceeded
+CallStack (from HasCallStack):
+  error, called at ./Network/Wai/Parse.hs:635:49 in wai-extra-3.0.22.1-ae0cb2bee031e782f33b1ba1ca3b3f58e1eb5a0507374e4f2813a23774fde280:Network.Wai.Parse
+```
+
+auth tests:
+
+```
+% curl -D - 'http://localhost:8000/users'
+HTTP/1.1 401 Unauthorized
+...
+WWW-Authenticate: Basic realm="User space"
+```
+
+```
+% curl -D - -u bob:xyzzy 'http://localhost:8000/users'
+HTTP/1.1 200 OK
+...
+
+User space for bob
+```
+
+```
+% curl -D - -u bob:xyzzy 'http://localhost:8000/admin'
+HTTP/1.1 401 Unauthorized
+...
+WWW-Authenticate: Basic realm="Admin UI"
+```
+
+```
+% curl -D - -u alice:xyzzy 'http://localhost:8000/admin'
+HTTP/1.1 200 OK
+...
+
+Admin UI for alice
+```
+
+generics-lens
+-------------
+
+With [`generics-lens`](http://hackage.haskell.org/package/generic-lens)
+we can reduce the required boilerplate to bare minimum,
+it's in fact almost copy & pasteable.
+This combines best of both works, we get good error reporting
+of nominal typing, but most of the flexibility of structural typing.
+
+TODO: `AppendSymbol` is base-4.10, but can be used to allow prefix.
+Is it worth mentioning?
+
+```haskell
+data CtxGL = CtxGL
+    { upload :: MultipartOptions Mem
+    , users  :: BasicAuthCheck User
+    , admin  :: BasicAuthCheck User
+    }
+  deriving Generic
+
+-- | 'typed' application is contrained so it will find required field
+instance HasMultipartOptions CtxGL Mem where
+    getMultipartOptions = view typed
+
+instance HasField name CtxGL CtxGL sub sub => GetNamedContext CtxGL name sub where
+    getNamedContext _ = view (field @name)
+```
+
+and an evidence that it works:
+```haskell
+appGL :: Application
+appGL = serveWithContext api ctx server where
+    ctx = CtxGL
+        { upload = uploadOpts
+        , users  = check ["alice", "bob"]
+        , admin  = check ["alice"]
+        }  
+```
+
+```haskell
+main :: IO ()
+main = run 8000 appGL
+```

--- a/doc/cookbook/multiple-contexts/multiple-contexts.cabal
+++ b/doc/cookbook/multiple-contexts/multiple-contexts.cabal
@@ -16,7 +16,7 @@ executable cookbook-multiple-contexts
                      , base-compat   >= 0.10.4 && <0.11
                      , bytestring
                      , generic-lens  >=1.0.0.1 && <1.1
-		     , superrecord   >=0.5.0.0 && <0.6
+                     , superrecord   >=0.5.0.0 && <0.6
                      , lens
                      , text          >= 1.2.3.0 && <1.3
                      , servant

--- a/doc/cookbook/multiple-contexts/multiple-contexts.cabal
+++ b/doc/cookbook/multiple-contexts/multiple-contexts.cabal
@@ -1,0 +1,28 @@
+name:                cookbook-multiple-contexts
+version:             0.1
+synopsis:            Using multiple contexts
+homepage:            http://haskell-servant.readthedocs.org/
+license:             BSD3
+license-file:        ../../../servant/LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.3
+
+executable cookbook-multiple-contexts
+  main-is:             MultipleContexts.lhs
+  build-depends:       base          >=4.9 && <4.12
+                     , base-compat   >= 0.10.4 && <0.11
+                     , bytestring
+                     , generic-lens  >=1.0.0.1 && <1.1
+                     , lens
+                     , text          >= 1.2.3.0 && <1.3
+                     , servant
+                     , servant-server
+                     , servant-multipart
+                     , warp >= 3.2
+                     , wai-extra
+  default-language:    Haskell2010
+  ghc-options:         -Wall -pgmL markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit >= 0.4

--- a/doc/cookbook/multiple-contexts/multiple-contexts.cabal
+++ b/doc/cookbook/multiple-contexts/multiple-contexts.cabal
@@ -16,10 +16,12 @@ executable cookbook-multiple-contexts
                      , base-compat   >= 0.10.4 && <0.11
                      , bytestring
                      , generic-lens  >=1.0.0.1 && <1.1
+		     , superrecord   >=0.5.0.0 && <0.6
                      , lens
                      , text          >= 1.2.3.0 && <1.3
                      , servant
                      , servant-server
+                     , servant-server-superrecord
                      , servant-multipart
                      , warp >= 3.2
                      , wai-extra

--- a/doc/tutorial/Authentication.lhs
+++ b/doc/tutorial/Authentication.lhs
@@ -63,7 +63,6 @@ import Servant.Server                   (BasicAuthCheck (BasicAuthCheck),
                                          BasicAuthResult( Authorized
                                                         , Unauthorized
                                                         ),
-                                         Context ((:.), EmptyContext),
                                          err401, err403, errBody, Server,
                                          serveWithContext, Handler)
 import Servant.Server.Experimental.Auth (AuthHandler, AuthServerData,
@@ -169,15 +168,15 @@ authCheck =
   in BasicAuthCheck check
 ```
 
-And now we create the `Context` used by servant to find `BasicAuthCheck`:
+**FIXME** And now we create the `Context` used by servant to find `BasicAuthCheck`:
 
 ```haskell
 -- | We need to supply our handlers with the right Context. In this case,
 -- Basic Authentication requires a Context Entry with the 'BasicAuthCheck' value
 -- tagged with "foo-tag" This context is then supplied to 'server' and threaded
 -- to the BasicAuth HasServer handlers.
-basicAuthServerContext :: Context (BasicAuthCheck User ': '[])
-basicAuthServerContext = authCheck :. EmptyContext
+basicAuthServerContext :: BasicAuthCheck User
+basicAuthServerContext = authCheck
 ```
 
 We're now ready to write our `server` method that will tie everything together:
@@ -341,8 +340,8 @@ value of type `Server AuthGenAPI`, in addition to the server value:
 -- | The context that will be made available to request handlers. We supply the
 -- "cookie-auth"-tagged request handler defined above, so that the 'HasServer' instance
 -- of 'AuthProtect' can extract the handler and run it on the request.
-genAuthServerContext :: Context (AuthHandler Request Account ': '[])
-genAuthServerContext = authHandler :. EmptyContext
+genAuthServerContext :: AuthHandler Request Account
+genAuthServerContext = authHandler
 
 -- | Our API, where we provide all the author-supplied handlers for each end
 -- point. Note that 'privateDataFunc' is a function that takes 'Account' as an

--- a/servant-client-core/src/Servant/Client/Core/Internal/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/Internal/HasClient.hs
@@ -610,9 +610,9 @@ instance HasClient m api => HasClient m (IsSecure :> api) where
   hoistClientMonad pm _ f cl = hoistClientMonad pm (Proxy :: Proxy api) f cl
 
 instance HasClient m subapi =>
-  HasClient m (WithNamedContext name context subapi) where
+  HasClient m (WithNamedContext name subapi) where
 
-  type Client m (WithNamedContext name context subapi) = Client m subapi
+  type Client m (WithNamedContext name subapi) = Client m subapi
   clientWithRoute pm Proxy = clientWithRoute pm (Proxy :: Proxy subapi)
 
   hoistClientMonad pm _ f cl = hoistClientMonad pm (Proxy :: Proxy subapi) f cl

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -217,8 +217,8 @@ basicAuthHandler =
         else return Unauthorized
   in BasicAuthCheck check
 
-basicServerContext :: Context '[ BasicAuthCheck () ]
-basicServerContext = basicAuthHandler :. EmptyContext
+basicServerContext :: BasicAuthCheck ()
+basicServerContext = basicAuthHandler
 
 basicAuthServer :: Application
 basicAuthServer = serveWithContext basicAuthAPI basicServerContext (const (return alice))
@@ -241,8 +241,8 @@ genAuthHandler =
         Just _ -> return ()
   in mkAuthHandler handler
 
-genAuthServerContext :: Context '[ AuthHandler Wai.Request () ]
-genAuthServerContext = genAuthHandler :. EmptyContext
+genAuthServerContext :: AuthHandler Wai.Request ()
+genAuthServerContext = genAuthHandler
 
 genAuthServer :: Application
 genAuthServer = serveWithContext genAuthAPI genAuthServerContext (const (return alice))
@@ -431,7 +431,7 @@ failSpec = beforeAll (startWaiApp failServer) $ afterAll endWaiApp $ do
           _ -> fail $ "expected InvalidContentTypeHeader, but got " <> show res
 
 data WrappedApi where
-  WrappedApi :: (HasServer (api :: *) '[], Server api ~ Handler a,
+  WrappedApi :: (HasServer (api :: *) (), Server api ~ Handler a,
                  HasClient ClientM api, Client ClientM api ~ ClientM ()) =>
     Proxy api -> WrappedApi
 

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -994,7 +994,7 @@ instance HasDocs api => HasDocs (Vault :> api) where
   docsFor Proxy ep =
     docsFor (Proxy :: Proxy api) ep
 
-instance HasDocs api => HasDocs (WithNamedContext name context api) where
+instance HasDocs api => HasDocs (WithNamedContext name api) where
   docsFor Proxy = docsFor (Proxy :: Proxy api)
 
 instance (ToAuthInfo (BasicAuth realm usr), HasDocs api) => HasDocs (BasicAuth realm usr :> api) where

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -354,9 +354,9 @@ instance HasForeign lang ftype api => HasForeign lang ftype (Vault :> api) where
     foreignFor lang ftype (Proxy :: Proxy api) req
 
 instance HasForeign lang ftype api =>
-  HasForeign lang ftype (WithNamedContext name context api) where
+  HasForeign lang ftype (WithNamedContext name api) where
 
-  type Foreign ftype (WithNamedContext name context api) = Foreign ftype api
+  type Foreign ftype (WithNamedContext name api) = Foreign ftype api
 
   foreignFor lang ftype Proxy = foreignFor lang ftype (Proxy :: Proxy api)
 

--- a/servant-server-superrecord/LICENSE
+++ b/servant-server-superrecord/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2018, Servant Contributors
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Julian K. Arni nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servant-server-superrecord/README.md
+++ b/servant-server-superrecord/README.md
@@ -1,0 +1,3 @@
+# servant-server-superrecord - Use superrecord as servant-server context
+
+![servant](https://raw.githubusercontent.com/haskell-servant/servant/master/servant.png)

--- a/servant-server-superrecord/Setup.hs
+++ b/servant-server-superrecord/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/servant-server-superrecord/servant-server-superrecord.cabal
+++ b/servant-server-superrecord/servant-server-superrecord.cabal
@@ -1,0 +1,33 @@
+name:                servant-server-superrecord
+version:             0
+synopsis:            Use superrecord as servant-server context
+description:         Use superrecord as servant-server context.
+homepage:            http://haskell-servant.readthedocs.org/
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2018 Servant Contributors
+category:            Web, Servant, Records
+build-type:          Simple
+cabal-version:       >=1.10
+bug-reports:         http://github.com/haskell-servant/servant/issues
+tested-with:
+  GHC==8.0.2,
+  GHC==8.2.2,
+  GHC==8.4.3
+
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+library
+  exposed-modules:     Servant.Server.SuperRecord
+  build-depends:       base >=4.9 && <5
+                     , superrecord       >=0.5.0.0 && <0.6
+                     , servant           >=0.14    && <0.15
+                     , servant-server    >=0.14    && <0.15
+                     , servant-multipart >=0.11.2  && <0.12
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:        -Wall

--- a/servant-server-superrecord/src/Servant/Server/SuperRecord.hs
+++ b/servant-server-superrecord/src/Servant/Server/SuperRecord.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- | TODO: or maybe just Servant.SuperRecord?
+--
+-- TODO: Headers?
+module Servant.Server.SuperRecord () where
+
+import           Servant.Multipart
+                 (HasMultipartOptions (..), MultipartOptions)
+import           Servant.Server ()
+import           Servant.Server.Internal
+                 (GetNamedContext (..))
+
+import           SuperRecord
+
+-- TODO: hardcoded, there doesn't seem to be machinery to access fields by type in superrecord
+instance Has "upload" lts (MultipartOptions tag) => HasMultipartOptions (Rec lts) tag where
+    getMultipartOptions = get (FldProxy :: FldProxy "upload")
+
+instance Has l lts v => GetNamedContext (Rec lts) l v where
+    getNamedContext _ = get (FldProxy :: FldProxy l)

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -32,12 +32,14 @@ module Servant.Server
   -- ** Functions based on <https://hackage.haskell.org/package/mmorph mmorph>
   , tweakResponse
 
+{-
   -- * Context
   , Context(..)
   , HasContextEntry(getContextEntry)
   -- ** NamedContext
   , NamedContext(..)
   , descendIntoNamedContext
+-}
 
   -- * Basic Authentication
   , BasicAuthCheck(BasicAuthCheck, unBasicAuthCheck)
@@ -126,11 +128,11 @@ import           Servant.Server.Internal
 -- > main :: IO ()
 -- > main = Network.Wai.Handler.Warp.run 8080 app
 --
-serve :: (HasServer api '[]) => Proxy api -> Server api -> Application
-serve p = serveWithContext p EmptyContext
+serve :: HasServer api () => Proxy api -> Server api -> Application
+serve p = serveWithContext p ()
 
-serveWithContext :: (HasServer api context)
-    => Proxy api -> Context context -> Server api -> Application
+serveWithContext :: HasServer api context
+    => Proxy api -> context -> Server api -> Application
 serveWithContext p context server =
   toApplication (runRouter (route p context (emptyDelayed (Route server))))
 
@@ -154,9 +156,9 @@ serveWithContext p context server =
 -- >>> let nt x = return (runReader x "hi")
 -- >>> let mainServer = hoistServer readerApi nt readerServer :: Server ReaderAPI
 --
-hoistServer :: (HasServer api '[]) => Proxy api
+hoistServer :: HasServer api () => Proxy api
             -> (forall x. m x -> n x) -> ServerT api m -> ServerT api n
-hoistServer p = hoistServerWithContext p (Proxy :: Proxy '[])
+hoistServer p = hoistServerWithContext p (Proxy :: Proxy ())
 
 -- | The function 'layout' produces a textual description of the internal
 -- router layout for debugging purposes. Note that the router layout is
@@ -209,12 +211,12 @@ hoistServer p = hoistServerWithContext p (Proxy :: Proxy '[])
 -- that one takes precedence. If both parts fail, the \"better\" error
 -- code will be returned.
 --
-layout :: (HasServer api '[]) => Proxy api -> Text
-layout p = layoutWithContext p EmptyContext
+layout :: HasServer api () => Proxy api -> Text
+layout p = layoutWithContext p ()
 
 -- | Variant of 'layout' that takes an additional 'Context'.
-layoutWithContext :: (HasServer api context)
-    => Proxy api -> Context context -> Text
+layoutWithContext :: HasServer api context
+    => Proxy api -> context -> Text
 layoutWithContext p context =
   routerLayout (route p context (emptyDelayed (FailFatal err501)))
 

--- a/servant-server/src/Servant/Server/Generic.hs
+++ b/servant-server/src/Servant/Server/Generic.hs
@@ -31,7 +31,7 @@ type AsServer = AsServerT Handler
 -- | Transform record of routes into a WAI 'Application'.
 genericServe
     :: forall routes.
-       ( HasServer (ToServantApi routes) '[]
+       ( HasServer (ToServantApi routes) ()
        , GenericServant routes AsServer
        , Server (ToServantApi routes) ~ ToServant routes AsServer
        )

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -731,7 +731,7 @@ ct_wildcard = "*" <> "/" <> "*" -- Because CPP
 -- * contexts
 
 -- | This is an example of how to change the context.
-class GetNamedContext context name sub where
+class GetNamedContext context name sub | context name -> sub where
     getNamedContext :: Proxy name -> context -> sub
 
 -- write instances for vinyl, extensible-records, etc.
@@ -739,9 +739,9 @@ class GetNamedContext context name sub where
 instance
   ( GetNamedContext context name subContext
   , HasServer subApi subContext
-  ) => HasServer (WithNamedContext name subContext subApi) context where
+  ) => HasServer (WithNamedContext name subApi) context where
 
-  type ServerT (WithNamedContext name subContext subApi) m =
+  type ServerT (WithNamedContext name subApi) m =
     ServerT subApi m
 
   route Proxy context delayed =

--- a/servant-server/src/Servant/Server/Internal/Context.hs
+++ b/servant-server/src/Servant/Server/Internal/Context.hs
@@ -9,6 +9,7 @@
 
 module Servant.Server.Internal.Context where
 
+{-
 import           Data.Proxy
 import           GHC.TypeLits
 
@@ -99,3 +100,4 @@ descendIntoNamedContext :: forall context name subContext .
 descendIntoNamedContext Proxy context =
   let NamedContext subContext = getContextEntry context :: NamedContext name subContext
   in subContext
+-}

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -80,7 +80,7 @@ errorOrderSpec :: Spec
 errorOrderSpec =
   describe "HTTP error order" $
     with (return $ serveWithContext errorOrderApi
-                   (errorOrderAuthCheck :. EmptyContext)
+                   errorOrderAuthCheck
                    errorOrderServer
          ) $ do
   let badContentType  = (hContentType, "text/plain")
@@ -219,7 +219,7 @@ errorRetrySpec :: Spec
 errorRetrySpec =
   describe "Handler search" $
     with (return $ serveWithContext errorRetryApi
-                         (errorOrderAuthCheck :. EmptyContext)
+                         errorOrderAuthCheck
                          errorRetryServer
          ) $ do
 

--- a/servant-server/test/Servant/Server/Internal/ContextSpec.hs
+++ b/servant-server/test/Servant/Server/Internal/ContextSpec.hs
@@ -13,7 +13,9 @@ import           Servant.API
 import           Servant.Server.Internal.Context
 
 spec :: Spec
-spec = do
+spec = pure ()
+
+{-
   describe "getContextEntry" $ do
     it "gets the context if a matching one exists" $ do
       let cxt = 'a' :. EmptyContext
@@ -63,3 +65,4 @@ spec = do
     it "does not typecheck if subContext with that name doesn't exist" $ do
       let x = descendIntoNamedContext (Proxy :: Proxy "foo") cxt :: Context '[Char]
       shouldNotTypecheck (show x)
+-}

--- a/servant-server/test/Servant/Server/RouterSpec.hs
+++ b/servant-server/test/Servant/Server/RouterSpec.hs
@@ -74,14 +74,14 @@ distributivitySpec =
       level `shouldHaveSameStructureAs` levelRef
 
 shouldHaveSameStructureAs ::
-  (HasServer api1 '[], HasServer api2 '[]) => Proxy api1 -> Proxy api2 -> Expectation
+  (HasServer api1 (), HasServer api2 ()) => Proxy api1 -> Proxy api2 -> Expectation
 shouldHaveSameStructureAs p1 p2 =
   unless (sameStructure (makeTrivialRouter p1) (makeTrivialRouter p2)) $
     expectationFailure ("expected:\n" ++ unpack (layout p2) ++ "\nbut got:\n" ++ unpack (layout p1))
 
-makeTrivialRouter :: (HasServer layout '[]) => Proxy layout -> Router ()
+makeTrivialRouter :: (HasServer layout ()) => Proxy layout -> Router ()
 makeTrivialRouter p =
-  route p EmptyContext (emptyDelayed (FailFatal err501))
+  route p () (emptyDelayed (FailFatal err501))
 
 type End = Get '[JSON] NoContent
 

--- a/servant-server/test/Servant/Server/UsingContextSpec.hs
+++ b/servant-server/test/Servant/Server/UsingContextSpec.hs
@@ -14,7 +14,10 @@ import           Servant
 import           Servant.Server.UsingContextSpec.TestCombinators
 
 spec :: Spec
-spec = do
+spec =  pure ()
+
+{-
+do
   spec1
   spec2
   spec3
@@ -123,3 +126,4 @@ spec4 = do
     describe "WithNamedContext" $ do
       it "allows descending into a subcontext for a given api" $ do
         get "/" `shouldRespondWith` "\"descend\""
+-}

--- a/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
+++ b/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
@@ -21,6 +21,7 @@ import           GHC.TypeLits
 
 import           Servant
 
+{-
 data ExtractFromContext
 
 instance (HasContextEntry context String, HasServer subApi context) =>
@@ -77,3 +78,4 @@ instance (HasContextEntry context (NamedContext name subContext), HasServer subA
 
       subContext :: Context subContext
       subContext = descendIntoNamedContext (Proxy :: Proxy name) context
+-}

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -52,7 +52,7 @@ import           Servant.API
                  StreamGenerator (..), Verb, addHeader)
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Server
-                 (Context ((:.), EmptyContext), Handler, Server, Tagged (..),
+                 (Handler, Server, Tagged (..),
                  emptyServer, err401, err403, err404, serve, serveWithContext)
 import           Test.Hspec
                  (Spec, context, describe, it, shouldBe, shouldContain)
@@ -66,16 +66,16 @@ import           Servant.Server.Experimental.Auth
 import           Servant.Server.Internal.BasicAuth
                  (BasicAuthCheck (BasicAuthCheck),
                  BasicAuthResult (Authorized, Unauthorized))
-import           Servant.Server.Internal.Context
-                 (NamedContext (..))
+--import           Servant.Server.Internal.Context
+--                 (NamedContext (..))
 
 -- * comprehensive api test
 
 -- This declaration simply checks that all instances are in place.
-_ = serveWithContext comprehensiveAPI comprehensiveApiContext
+_ = serveWithContext comprehensiveAPI ()
 
-comprehensiveApiContext :: Context '[NamedContext "foo" '[]]
-comprehensiveApiContext = NamedContext EmptyContext :. EmptyContext
+-- comprehensiveApiContext :: Context '[NamedContext "foo" '[]]
+-- comprehensiveApiContext = NamedContext EmptyContext :. EmptyContext
 
 -- * Specs
 
@@ -672,13 +672,12 @@ basicAuthServer =
   const (return jerry) :<|>
   (Tagged $ \ _ respond -> respond $ responseLBS imATeapot418 [] "")
 
-basicAuthContext :: Context '[ BasicAuthCheck () ]
+basicAuthContext :: BasicAuthCheck ()
 basicAuthContext =
-  let basicHandler = BasicAuthCheck $ \(BasicAuthData usr pass) ->
-        if usr == "servant" && pass == "server"
-          then return (Authorized ())
-          else return Unauthorized
-  in basicHandler :. EmptyContext
+   BasicAuthCheck $ \(BasicAuthData usr pass) ->
+      if usr == "servant" && pass == "server"
+      then return (Authorized ())
+      else return Unauthorized
 
 basicAuthSpec :: Spec
 basicAuthSpec = do
@@ -719,13 +718,13 @@ genAuthServer = const (return tweety)
 
 type instance AuthServerData (AuthProtect "auth") = ()
 
-genAuthContext :: Context '[AuthHandler Request ()]
+genAuthContext :: AuthHandler Request ()
 genAuthContext =
   let authHandler = \req -> case lookup "Auth" (requestHeaders req) of
         Just "secret" -> return ()
         Just _ -> throwError err403
         Nothing -> throwError err401
-  in mkAuthHandler authHandler :. EmptyContext
+  in mkAuthHandler authHandler
 
 genAuthSpec :: Spec
 genAuthSpec = do

--- a/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/API/Internal/Test/ComprehensiveAPI.hs
@@ -19,6 +19,7 @@ type ComprehensiveAPI =
 comprehensiveAPI :: Proxy ComprehensiveAPI
 comprehensiveAPI = Proxy
 
+-- TODO: Add BasicAuth
 type ComprehensiveAPIWithoutRaw =
   GET :<|>
   Get '[JSON] Int :<|>
@@ -40,7 +41,7 @@ type ComprehensiveAPIWithoutRaw =
   Verb 'POST 204 '[JSON] NoContent :<|>
   Verb 'POST 204 '[JSON] Int :<|>
   Stream 'GET 200 NetstringFraming JSON [Int] :<|>
-  WithNamedContext "foo" '[] GET :<|>
+--  WithNamedContext "foo" '[] GET :<|>
   CaptureAll "foo" Int :> GET :<|>
   Summary "foo" :> GET :<|>
   Description "foo" :> GET :<|>

--- a/servant/src/Servant/API/WithNamedContext.hs
+++ b/servant/src/Servant/API/WithNamedContext.hs
@@ -18,4 +18,4 @@ import           GHC.TypeLits
 -- 'Context's are only relevant for @servant-server@.
 --
 -- For more information, see the tutorial.
-data WithNamedContext (name :: Symbol) (subContext :: [*]) subApi
+data WithNamedContext (name :: Symbol) (subContext :: *) subApi

--- a/servant/src/Servant/API/WithNamedContext.hs
+++ b/servant/src/Servant/API/WithNamedContext.hs
@@ -9,7 +9,7 @@ import           GHC.TypeLits
 -- combinators in the API. (See also in @servant-server@,
 -- @Servant.Server.Context@.) For example:
 --
--- > type UseNamedContextAPI = WithNamedContext "myContext" '[String] (
+-- > type UseNamedContextAPI = WithNamedContext "myContext" (
 -- >     ReqBody '[JSON] Int :> Get '[JSON] Int)
 --
 -- Both the 'ReqBody' and 'Get' combinators will use the 'WithNamedContext' with
@@ -18,4 +18,4 @@ import           GHC.TypeLits
 -- 'Context's are only relevant for @servant-server@.
 --
 -- For more information, see the tutorial.
-data WithNamedContext (name :: Symbol) (subContext :: *) subApi
+data WithNamedContext (name :: Symbol) (subApi :: *)

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -521,8 +521,8 @@ instance HasLink sub => HasLink (IsSecure :> sub) where
     type MkLink (IsSecure :> sub) a = MkLink sub a
     toLink = simpleToLink (Proxy :: Proxy sub)
 
-instance HasLink sub => HasLink (WithNamedContext name context sub) where
-    type MkLink (WithNamedContext name context sub) a = MkLink sub a
+instance HasLink sub => HasLink (WithNamedContext name sub) where
+    type MkLink (WithNamedContext name sub) a = MkLink sub a
     toLink toA _ = toLink toA (Proxy :: Proxy sub)
 
 instance HasLink sub => HasLink (RemoteHost :> sub) where


### PR DESCRIPTION
Turn `context` into ordinary data:

We have to write a little of boilerplate (class for each combinator using something from context), but OTOH the structure is way simpler. We can still alter context with `NamedContext` like stuff,
though users need to write some boilerplate (or use `vinyl` or other extensible records libraries).
For me this is mostly **win**, as we don't need to reinvent extensible records like thing in `servant`.
Also for simple cases when there's only one thing in a context, usage becomes simpler too,
as that one thing can be used as the context.

Changes needed for `servant-multipart`:

```diff
diff --git a/src/Servant/Multipart.hs b/src/Servant/Multipart.hs
index fb4e4be..66e643f 100644
--- a/src/Servant/Multipart.hs
+++ b/src/Servant/Multipart.hs
@@ -238,13 +238,24 @@ class FromMultipart tag a where
 instance FromMultipart tag (MultipartData tag) where
   fromMultipart = Just
 
+class HasMultipartOptions context tag where
+    getMultipartOptions :: context -> MultipartOptions tag
+
+instance HasMultipartOptions (MultipartOptions tag) tag where
+    getMultipartOptions = id
+
+-- | Note: now we can separate MultipartBackend into backends which have
+-- default options, and which don't!
+instance MultipartBackend tag => HasMultipartOptions () tag where
+    getMultipartOptions () = defaultMultipartOptions Proxy
+
 -- | Upon seeing @MultipartForm a :> ...@ in an API type,
 ---  servant-server will hand a value of type @a@ to your handler
 --   assuming the request body's content type is
 --   @multipart/form-data@ and the call to 'fromMultipart' succeeds.
 instance ( FromMultipart tag a
          , MultipartBackend tag
-         , LookupContext config (MultipartOptions tag)
+         , HasMultipartOptions config tag
          , HasServer sublayout config )
       => HasServer (MultipartForm tag a :> sublayout) config where
 
@@ -261,8 +272,10 @@ instance ( FromMultipart tag a
       psub  = Proxy :: Proxy sublayout
       pbak  = Proxy :: Proxy b
       popts = Proxy :: Proxy (MultipartOptions tag)
-      multipartOpts = fromMaybe (defaultMultipartOptions pbak)
-                    $ lookupContext popts config
+
+      multipartOpts :: MultipartOptions tag
+      multipartOpts = getMultipartOptions config
+
       subserver' = addMultipartHandling pbak multipartOpts subserver
```