### PR TITLE
Change HasDocs instances for Summary and Description

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -866,7 +866,6 @@ instance {-# OVERLAPPABLE #-}
           t = Proxy :: Proxy '[ct]
           method' = reflectMethod (Proxy :: Proxy method)
           status = fromInteger $ natVal (Proxy :: Proxy status)
-          p = Proxy :: Proxy a
 
 instance {-# OVERLAPPING #-}
         (ToSample a, AllMimeRender (ct ': cts) a, KnownNat status


### PR DESCRIPTION
- if a description follows a summary, the summary is used as a title and the
lines of description form a body.

- if a description occurs without a preceding summary, it's first line is used
  as a title, and the remainder are used as a body.

Fixes #1026