### PR TITLE
Documentation, adding full website project with servant,auth,elm,yeshql,postgresql

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -49,6 +49,11 @@
     [persistent](https://www.stackage.org/package/persistent) for writing data
     into a database.
 
+- **[full-example-servant-elm-auth-yeshql-postgresql](https://github.com/aRkadeFR/FlashCard)**:
+
+    A full open source website written with **servant-server**, yeshql, postgresql and elm 0.19.
+
+
 - [`import Servant` github search](https://github.com/search?q=%22import+Servant%22+language%3AHaskell&type=Code)
 
     It has thousands of results and can be a good way to see how people use servant in their projects or even to discover


### PR DESCRIPTION
Hello,

I just finished a working website with Servant, Elm 0.19, YeshQL / PostgreSQL, and I was wondering if you were interested to list it in the documentation.
I used a lot the servant documentation and the github search when I was learning Servant. This project will maybe help others learner.

In any case, thanks a bunch for Servant! :)