### PR TITLE
Implement HasForeign instance

### DIFF
--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -1,5 +1,5 @@
 name:                servant-foreign
-version:             0.11.1
+version:             0.11.2
 x-revision:          3
 synopsis:            Helpers for generating clients for servant APIs in any programming language
 description:

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -1,5 +1,5 @@
 name:                servant-foreign
-version:             0.11.2
+version:             0.11.1
 x-revision:          3
 synopsis:            Helpers for generating clients for servant APIs in any programming language
 description:

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -5,6 +5,7 @@ module Servant.Foreign
   , HeaderArg(..)
   , QueryArg(..)
   , Req(..)
+  , ReqBodyContentType(..)
   , Segment(..)
   , SegmentType(..)
   , Url(..)
@@ -21,7 +22,7 @@ module Servant.Foreign
   , reqMethod
   , reqHeaders
   , reqBody
-  , reqBodyIsJSON
+  , reqBodyContentType
   , reqReturnType
   , reqFuncName
   , path

--- a/servant-foreign/src/Servant/Foreign.hs
+++ b/servant-foreign/src/Servant/Foreign.hs
@@ -21,6 +21,7 @@ module Servant.Foreign
   , reqMethod
   , reqHeaders
   , reqBody
+  , reqBodyIsJSON
   , reqReturnType
   , reqFuncName
   , path

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -123,21 +123,24 @@ defUrl = Url [] []
 
 makeLenses ''Url
 
+data ReqBodyContentType = ReqBodyJSON | ReqBodyMultipart
+  deriving (Data, Eq, Show, Read)
+
 data Req f = Req
-  { _reqUrl        :: Url f
-  , _reqMethod     :: HTTP.Method
-  , _reqHeaders    :: [HeaderArg f]
-  , _reqBody       :: Maybe f
-  , _reqReturnType :: Maybe f
-  , _reqFuncName   :: FunctionName
-  , _reqBodyIsJSON :: Bool
+  { _reqUrl             :: Url f
+  , _reqMethod          :: HTTP.Method
+  , _reqHeaders         :: [HeaderArg f]
+  , _reqBody            :: Maybe f
+  , _reqReturnType      :: Maybe f
+  , _reqFuncName        :: FunctionName
+  , _reqBodyContentType :: ReqBodyContentType
   }
   deriving (Data, Eq, Show, Typeable)
 
 makeLenses ''Req
 
 defReq :: Req ftype
-defReq = Req defUrl "GET" [] Nothing Nothing (FunctionName []) True
+defReq = Req defUrl "GET" [] Nothing Nothing (FunctionName []) ReqBodyJSON
 
 -- | 'HasForeignType' maps Haskell types with types in the target
 -- language of your backend. For example, let's say you're

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -130,13 +130,14 @@ data Req f = Req
   , _reqBody       :: Maybe f
   , _reqReturnType :: Maybe f
   , _reqFuncName   :: FunctionName
+  , _reqBodyIsJSON :: Bool
   }
   deriving (Data, Eq, Show, Typeable)
 
 makeLenses ''Req
 
 defReq :: Req ftype
-defReq = Req defUrl "GET" [] Nothing Nothing (FunctionName [])
+defReq = Req defUrl "GET" [] Nothing Nothing (FunctionName []) True
 
 -- | 'HasForeignType' maps Haskell types with types in the target
 -- language of your backend. For example, let's say you're


### PR DESCRIPTION
This is three patches, to `servant-foreign`, `servant-multipart`, and `servant-js`.

https://github.com/haskell-servant/servant-multipart/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant-js/compare/master...afcady:multipart-foreign?expand=1

The patch to `servant-foreign` adds a Boolean field to the `Req` type specifying whether the request body is JSON (as is currently assumed).  The patch to `servant-multipart` implements a HasForeign instance that sets this field to `False`.  The patch to `servant-js` changes the output of `vanillaJS` when the flag is false, so that `JSON.stringify()` does not get called on the body and the content-type is not set to JSON.

This address https://github.com/haskell-servant/servant-multipart/issues/5