### PR TITLE
ResponseHeaders: export GetHeaders'

### DIFF
--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -28,6 +28,7 @@ module Servant.API.ResponseHeaders
     , noHeader
     , BuildHeadersTo(buildHeadersTo)
     , GetHeaders(getHeaders)
+    , GetHeaders'
     , HeaderValMap
     , HList(..)
     ) where


### PR DESCRIPTION
Required for https://github.com/plow-technologies/servant-streaming/pull/14/files

PS: there are a few other typeclasses in that module that would be useful to be exported.