### PR TITLE
Added type synonym for error in mimeUnrender and ResultStream

### DIFF
--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -215,17 +215,19 @@ instance TL.TypeError ('TL.Text "No instance for (), use NoContent instead.")
 -- >>> type MyAPI = "path" :> ReqBody '[MyContentType] Int :> Get '[JSON] Int
 --
 class Accept ctype => MimeUnrender ctype a where
-    mimeUnrender :: Proxy ctype -> ByteString -> Either String a
+    mimeUnrender :: Proxy ctype -> ByteString -> Either BodyDecodingError a
     mimeUnrender p = mimeUnrenderWithType p (contentType p)
 
     -- | Variant which is given the actual 'M.MediaType' provided by the other party.
     --
     -- In the most cases you don't want to branch based on the 'M.MediaType'.
     -- See <https://github.com/haskell-servant/servant/pull/552 pr552> for a motivating example.
-    mimeUnrenderWithType :: Proxy ctype -> M.MediaType -> ByteString -> Either String a
+    mimeUnrenderWithType :: Proxy ctype -> M.MediaType -> ByteString -> Either BodyDecodingError a
     mimeUnrenderWithType p _ = mimeUnrender p
 
     {-# MINIMAL mimeUnrender | mimeUnrenderWithType #-}
+
+type BodyDecodingError = String
 
 class AllCTUnrender (list :: [*]) a where
     canHandleCTypeH

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -94,7 +94,9 @@ instance ToStreamGenerator [a] a where
 -- @ResultStream@ that captures the setup, takedown, and incremental logic for
 -- a read, being an IO continuation that takes a producer of Just either values
 -- or errors that terminates with a Nothing.
-newtype ResultStream a = ResultStream { runResultStream :: forall b. (IO (Maybe (Either String a)) -> IO b) -> IO b }
+newtype ResultStream a = ResultStream { runResultStream :: forall b. (IO (Maybe (Either BodyDecodingError a)) -> IO b) -> IO b }
+
+type BodyDecodingError = String
 
 -- | FromResultStream is intended to be implemented for types such as Conduit, Pipe, etc. By implementing this class, all such streaming abstractions can be used directly on the client side for talking to streaming endpoints.
 class FromResultStream a b | b -> a where


### PR DESCRIPTION
Just used one of the type names suggested in the issue, is that name still OK? 