### PR TITLE
Fix build under stack

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -61,7 +61,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                 >= 1.3.1.1  && < 1.5
+      aeson                 >= 1.4.0.0  && < 1.5
     , base-compat           >= 0.10.1   && < 0.11
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , exceptions            >= 0.10.0   && < 0.11

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -61,7 +61,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                 >= 1.4.0.0  && < 1.5
+      aeson                 >= 1.3.1.1  && < 1.5
     , base-compat           >= 0.10.1   && < 0.11
     , base64-bytestring     >= 1.0.0.1  && < 1.1
     , exceptions            >= 0.10.0   && < 0.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,8 @@ packages:
 - servant-foreign/
 - servant-server/
 - servant/
+extra-deps:
+- aeson-1.4.1.0
 
 # allow-newer: true # ignores all bounds, that's a sledgehammer
 # - doc/tutorial/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Let's try to keep resolver at the first day of the month
-resolver: nightly-2018-07-08
+resolver: lts-12.13
 packages:
 - servant-client/
 - servant-client-core/


### PR DESCRIPTION
Currently the project can't build with `stack build`, need to either relax the aeson dep or to specify a newer version in the stack.yaml. I propose relaxing.