### PR TITLE
Add MonadMask instance for Handler

### DIFF
--- a/servant-server/src/Servant/Server/Internal/Handler.hs
+++ b/servant-server/src/Servant/Server/Internal/Handler.hs
@@ -11,7 +11,7 @@ import           Prelude.Compat
 import           Control.Monad.Base
                  (MonadBase (..))
 import           Control.Monad.Catch
-                 (MonadCatch, MonadThrow)
+                 (MonadCatch, MonadMask, MonadThrow)
 import           Control.Monad.Error.Class
                  (MonadError)
 import           Control.Monad.IO.Class
@@ -29,7 +29,7 @@ newtype Handler a = Handler { runHandler' :: ExceptT ServantErr IO a }
   deriving
     ( Functor, Applicative, Monad, MonadIO, Generic
     , MonadError ServantErr
-    , MonadThrow, MonadCatch
+    , MonadThrow, MonadCatch, MonadMask
     )
 
 instance MonadBase IO Handler where


### PR DESCRIPTION
`exceptions-0.10` has introduced a working `MonadMask` instancesfor `ExceptT` so we can now also provide this for `Handler`. `servant-server` already has a lower bound of `>= 0.10` on `exceptions`, so this doesn’t impose any additional restrictions.