### PR TITLE
Fix the tutorial app4 curl example

### DIFF
--- a/doc/tutorial/Server.lhs
+++ b/doc/tutorial/Server.lhs
@@ -1128,8 +1128,8 @@ This is the webservice in action:
 ``` bash
 $ curl http://localhost:8081/a
 1797
-$ curl http://localhost:8081/b
-"hi"
+$ curl http://localhost:8081/b -X GET -d '42.0' -H 'Content-Type: application/json'
+true
 ```
 
 ### An arrow is a reader too.


### PR DESCRIPTION
Change the app4 curl example to match the API definition.

As defined, it does not return "hi" and instead always returns true.