### PR TITLE
keep structured exceptions in `ConnectionError`

### DIFF
--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -248,4 +248,4 @@ requestToClientRequest burl r = Client.defaultRequest
 catchConnectionError :: IO a -> IO (Either ServantError a)
 catchConnectionError action =
   catch (Right <$> action) $ \e ->
-    pure . Left . ConnectionError . T.pack $ show (e :: Client.HttpException)
+    pure . Left . ConnectionError $ SomeException (e :: Client.HttpException)


### PR DESCRIPTION
fixes #807
Previously, there were two levels of `SomeException` (see #714). A
test makes sure there is only one level of wrapping.