### PR TITLE
keep structured exceptions in `ConnectionError`

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/Internal/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Internal/Request.hs
@@ -18,7 +18,7 @@ import           Prelude.Compat
 import           Control.DeepSeq
                  (NFData (..))
 import           Control.Exception
-                 (SomeException)
+                 (SomeException (..))
 import           Control.Monad.Catch
                  (Exception)
 import           Data.Bifoldable
@@ -40,7 +40,7 @@ import           Data.Text
 import           Data.Text.Encoding
                  (encodeUtf8)
 import           Data.Typeable
-                 (Typeable)
+                 (Typeable, typeOf)
 import           GHC.Generics
                  (Generic)
 import           Network.HTTP.Media
@@ -76,7 +76,10 @@ instance Eq ServantError where
   DecodeFailure t r           == DecodeFailure t' r'           = t == t' && r == r'
   UnsupportedContentType mt r == UnsupportedContentType mt' r' = mt == mt' && r == r'
   InvalidContentTypeHeader r  == InvalidContentTypeHeader r'   = r == r'
-  ConnectionError _           == ConnectionError _             = True
+  ConnectionError exc         == ConnectionError exc'          = eqSomeException exc exc'
+    where
+      -- returns true, if type of exception is the same
+      eqSomeException (SomeException a) (SomeException b) = typeOf a == typeOf b
 
   -- prevent wild card blindness
   FailureResponse          {} == _ = False

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -256,4 +256,4 @@ requestToClientRequest burl r = Client.defaultRequest
 catchConnectionError :: IO a -> IO (Either ServantError a)
 catchConnectionError action =
   catch (Right <$> action) $ \e ->
-    pure . Left . ConnectionError . T.pack $ show (e :: Client.HttpException)
+    pure . Left . ConnectionError $ SomeException (e :: Client.HttpException)

--- a/servant-client/test/Servant/ClientSpec.hs
+++ b/servant-client/test/Servant/ClientSpec.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE StandaloneDeriving     #-}
+{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
@@ -33,7 +34,7 @@ import           Control.Concurrent.STM
 import           Control.Concurrent.STM.TVar
                  (newTVar, readTVar)
 import           Control.Exception
-                 (bracket)
+                 (bracket, fromException)
 import           Control.Monad.Error.Class
                  (throwError)
 import           Data.Aeson
@@ -42,7 +43,7 @@ import           Data.Char
 import           Data.Foldable
                  (forM_, toList)
 import           Data.Maybe
-                 (listToMaybe)
+                 (isJust, listToMaybe)
 import           Data.Monoid ()
 import           Data.Proxy
 import           Data.Semigroup
@@ -89,6 +90,7 @@ spec = describe "Servant.Client" $ do
     genAuthSpec
     genericClientSpec
     hoistClientSpec
+    connectionErrorSpec
 
 -- * test data types
 
@@ -530,6 +532,21 @@ hoistClientSpec = beforeAll (startWaiApp hoistClientServer) $ afterAll endWaiApp
 
       getInt `shouldReturn` 5
       postInt 5 `shouldReturn` 5
+
+-- * ConnectionError
+type ConnectionErrorAPI = Get '[JSON] Int
+
+connectionErrorAPI :: Proxy ConnectionErrorAPI
+connectionErrorAPI = Proxy
+
+connectionErrorSpec :: Spec
+connectionErrorSpec = describe "Servant.Client.ServantError" $
+    it "correctly catches ConnectionErrors when the HTTP request can't go through" $ do
+        let getInt = client connectionErrorAPI
+        let baseUrl' = BaseUrl Http "example.invalid" 80 ""
+        let isHttpError (Left (ConnectionError e)) = isJust $ fromException @C.HttpException e
+            isHttpError _ = False
+        (isHttpError <$> runClient getInt baseUrl') `shouldReturn` True
 
 -- * utils
 


### PR DESCRIPTION
fixes #807
Previously, there were two levels of `SomeException` (see #714). A
test makes sure there is only one level of wrapping.