### PR TITLE
Use ghcjs-dom instead of jsaddle-dom directly.

### DIFF
--- a/servant-client-jsaddle/servant-client-jsaddle.cabal
+++ b/servant-client-jsaddle/servant-client-jsaddle.cabal
@@ -62,7 +62,7 @@ library
     , http-media            >= 0.7.1.3  && < 0.8
     , http-types            >= 0.12.2   && < 0.13
     , jsaddle               >= 0.9.5.0  && < 0.10
-    , jsaddle-dom           >= 0.9.2.0  && < 0.10
+    , ghcjs-dom             >= 0.9.2.0  && < 0.10
     , monad-control         >= 1.0.2.3  && < 1.1
     , semigroupoids         >= 5.3.1    && < 5.4
     , string-conversions    >= 0.4.0.1  && < 0.5

--- a/servant-client-jsaddle/servant-client-jsaddle.cabal
+++ b/servant-client-jsaddle/servant-client-jsaddle.cabal
@@ -97,7 +97,7 @@ test-suite spec
     , http-types
     , jsaddle
     , jsaddle-webkit2gtk
-    , jsaddle-dom
+    , ghcjs-dom
     , monad-control
     , mtl
     , semigroupoids

--- a/servant-client-jsaddle/src/Servant/Client/Internal/JSaddleXhrClient.hs
+++ b/servant-client-jsaddle/src/Servant/Client/Internal/JSaddleXhrClient.hs
@@ -183,7 +183,6 @@ performXhr xhr burl request fixUp = do
 
   where
 
-    -- For jsaddle we get an XHRError - sigh.
     ignoreXHRError :: JS.XHRError -> DOM ()
     ignoreXHRError e = do
       liftIO $ hPutStrLn stderr $ "servant-client-jsaddle: Ignoring exception in `sendXhr`: " <> show e

--- a/servant-client-jsaddle/test/Servant/Client/JsSpec.hs
+++ b/servant-client-jsaddle/test/Servant/Client/JsSpec.hs
@@ -21,7 +21,7 @@ import qualified Language.Javascript.JSaddle.WebKitGTK as WK
 import qualified Language.Javascript.JSaddle.Monad as JSaddle
 import           Language.Javascript.JSaddle.Monad(JSM)
 import           Control.Concurrent
-import           Servant.Client.Js
+import           Servant.Client.JSaddle
 import qualified GHCJS.DOM
 import qualified GHCJS.DOM.Window as Window
 import qualified Network.Wai as Wai

--- a/servant-client-jsaddle/test/Servant/Client/JsSpec.hs
+++ b/servant-client-jsaddle/test/Servant/Client/JsSpec.hs
@@ -22,8 +22,8 @@ import qualified Language.Javascript.JSaddle.Monad as JSaddle
 import           Language.Javascript.JSaddle.Monad(JSM)
 import           Control.Concurrent
 import           Servant.Client.Js
-import qualified JSDOM
-import qualified JSDOM.Window as Window
+import qualified GHCJS.DOM
+import qualified GHCJS.DOM.Window as Window
 import qualified Network.Wai as Wai
 import           Network.Wai.Middleware.AddHeaders
 import qualified Network.HTTP.Types as Http
@@ -51,7 +51,7 @@ jsaddleFinally handler m = JSaddle.bracket (pure ()) (const handler) (const m)
 
 close :: JSM ()
 close = do
-  mw <- JSDOM.currentWindow
+  mw <- GHCJS.DOM.currentWindow
   case mw of
     Just w -> do
       liftIO $ putStrLn "Closing window..."
@@ -90,7 +90,7 @@ spec = do
                                             , baseUrlPort = fromIntegral portNr
                                             , baseUrlPath = "/"
                                             }
-        
+
         WK.run $ JSaddle.liftJSM $ jsaddleFinally close $ do
           liftIO $ threadDelay $ 1000 * 1000
           -- a mix of valid utf-8 and non-utf8 bytes


### PR DESCRIPTION
This way we avoid the dependency on jsaddle-dom on ghcjs and have
slightly better performance on ghcjs.

Seems to work fine on both ghc and ghcjs.