### PR TITLE
Update travis once again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.2"
+    - compiler: "ghc-8.6.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
@@ -60,16 +60,40 @@ install:
   - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - BENCH=${BENCH---enable-benchmarks}
   - TEST=${TEST---enable-tests}
-  - HADDOCK=${HADDOCK-true}
   - UNCONSTRAINED=${UNCONSTRAINED-true}
-  - NOINSTALLEDCONSTRAINTS=${NOINSTALLEDCONSTRAINTS-false}
   - GHCHEAD=${GHCHEAD-false}
   - travis_retry cabal update -v
   - "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
   - rm -fv cabal.project cabal.project.local
-  - "if [ $HCNUMVER -ge 70800 ]; then sed -i.bak 's/-- ghc-options:.*/ghc-options: -j2/' ${HOME}/.cabal/config; fi"
+  - "sed -i.bak 's/-- ghc-options:.*/ghc-options: -j2/' ${HOME}/.cabal/config"
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - "printf 'packages: \"servant\" \"servant-client\" \"servant-client-core\" \"servant-http-streams\" \"servant-docs\" \"servant-foreign\" \"servant-server\" \"doc/tutorial\" \"servant-machines\" \"servant-conduit\" \"servant-pipes\" \"doc/cookbook/basic-auth\" \"doc/cookbook/curl-mock\" \"doc/cookbook/basic-streaming\" \"doc/cookbook/db-postgres-pool\" \"doc/cookbook/db-sqlite-simple\" \"doc/cookbook/file-upload\" \"doc/cookbook/generic\" \"doc/cookbook/hoist-server-with-context\" \"doc/cookbook/https\" \"doc/cookbook/jwt-and-basic-auth\" \"doc/cookbook/testing\" \"doc/cookbook/structuring-apis\" \"doc/cookbook/using-custom-monad\" \"doc/cookbook/using-free-client\"\\n' > cabal.project"
+  - rm -f cabal.project
+  - touch cabal.project
+  - "printf 'packages: \"servant\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-client\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-client-core\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-http-streams\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-docs\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-foreign\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-server\"\\n' >> cabal.project"
+  - "printf 'packages: \"doc/tutorial\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-machines\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-conduit\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-pipes\"\\n' >> cabal.project"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/basic-auth\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/curl-mock\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/basic-streaming\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/db-postgres-pool\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/db-sqlite-simple\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/file-upload\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/generic\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/hoist-server-with-context\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/https\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/jwt-and-basic-auth\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/testing\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/structuring-apis\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/using-custom-monad\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"doc/cookbook/using-free-client\"\\n' >> cabal.project ; fi"
   - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - "echo 'constraints: foundation >=0.0.14' >> cabal.project"
   - "echo 'constraints: memory <0.14.12 || >0.14.12' >> cabal.project"
@@ -81,84 +105,34 @@ install:
   - "echo 'allow-newer: servant-quickcheck:http-client' >> cabal.project"
   - "echo 'optimization: False' >> cabal.project "
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- servant | grep -vw -- servant-client | grep -vw -- servant-client-core | grep -vw -- servant-http-streams | grep -vw -- servant-docs | grep -vw -- servant-foreign | grep -vw -- servant-server | grep -vw -- tutorial | grep -vw -- servant-machines | grep -vw -- servant-conduit | grep -vw -- servant-pipes | grep -vw -- cookbook-basic-auth | grep -vw -- cookbook-curl-mock | grep -vw -- cookbook-basic-streaming | grep -vw -- cookbook-db-postgres-pool | grep -vw -- cookbook-db-sqlite-simple | grep -vw -- cookbook-file-upload | grep -vw -- cookbook-generic | grep -vw -- cookbook-hoist-server-with-context | grep -vw -- cookbook-https | grep -vw -- cookbook-jwt-and-basic-auth | grep -vw -- cookbook-testing | grep -vw -- cookbook-structuring-apis | grep -vw -- cookbook-using-custom-monad | grep -vw -- cookbook-using-free-client | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(cookbook-basic-auth|cookbook-basic-streaming|cookbook-curl-mock|cookbook-db-postgres-pool|cookbook-db-sqlite-simple|cookbook-file-upload|cookbook-generic|cookbook-hoist-server-with-context|cookbook-https|cookbook-jwt-and-basic-auth|cookbook-structuring-apis|cookbook-testing|cookbook-using-custom-monad|cookbook-using-free-client|servant|servant-client|servant-client-core|servant-conduit|servant-docs|servant-foreign|servant-http-streams|servant-machines|servant-pipes|servant-server|tutorial)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
-  - if [ -f "servant/configure.ac" ]; then
-      (cd "servant" && autoreconf -i);
-    fi
-  - if [ -f "servant-client/configure.ac" ]; then
-      (cd "servant-client" && autoreconf -i);
-    fi
-  - if [ -f "servant-client-core/configure.ac" ]; then
-      (cd "servant-client-core" && autoreconf -i);
-    fi
-  - if [ -f "servant-http-streams/configure.ac" ]; then
-      (cd "servant-http-streams" && autoreconf -i);
-    fi
-  - if [ -f "servant-docs/configure.ac" ]; then
-      (cd "servant-docs" && autoreconf -i);
-    fi
-  - if [ -f "servant-foreign/configure.ac" ]; then
-      (cd "servant-foreign" && autoreconf -i);
-    fi
-  - if [ -f "servant-server/configure.ac" ]; then
-      (cd "servant-server" && autoreconf -i);
-    fi
-  - if [ -f "doc/tutorial/configure.ac" ]; then
-      (cd "doc/tutorial" && autoreconf -i);
-    fi
-  - if [ -f "servant-machines/configure.ac" ]; then
-      (cd "servant-machines" && autoreconf -i);
-    fi
-  - if [ -f "servant-conduit/configure.ac" ]; then
-      (cd "servant-conduit" && autoreconf -i);
-    fi
-  - if [ -f "servant-pipes/configure.ac" ]; then
-      (cd "servant-pipes" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/basic-auth/configure.ac" ]; then
-      (cd "doc/cookbook/basic-auth" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/curl-mock/configure.ac" ]; then
-      (cd "doc/cookbook/curl-mock" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/basic-streaming/configure.ac" ]; then
-      (cd "doc/cookbook/basic-streaming" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/db-postgres-pool/configure.ac" ]; then
-      (cd "doc/cookbook/db-postgres-pool" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/db-sqlite-simple/configure.ac" ]; then
-      (cd "doc/cookbook/db-sqlite-simple" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/file-upload/configure.ac" ]; then
-      (cd "doc/cookbook/file-upload" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/generic/configure.ac" ]; then
-      (cd "doc/cookbook/generic" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/hoist-server-with-context/configure.ac" ]; then
-      (cd "doc/cookbook/hoist-server-with-context" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/https/configure.ac" ]; then
-      (cd "doc/cookbook/https" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/jwt-and-basic-auth/configure.ac" ]; then
-      (cd "doc/cookbook/jwt-and-basic-auth" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/testing/configure.ac" ]; then
-      (cd "doc/cookbook/testing" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/structuring-apis/configure.ac" ]; then
-      (cd "doc/cookbook/structuring-apis" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/using-custom-monad/configure.ac" ]; then
-      (cd "doc/cookbook/using-custom-monad" && autoreconf -i);
-    fi
-  - if [ -f "doc/cookbook/using-free-client/configure.ac" ]; then
-      (cd "doc/cookbook/using-free-client" && autoreconf -i);
-    fi
+  - if [ -f "servant/configure.ac" ]; then (cd "servant" && autoreconf -i); fi
+  - if [ -f "servant-client/configure.ac" ]; then (cd "servant-client" && autoreconf -i); fi
+  - if [ -f "servant-client-core/configure.ac" ]; then (cd "servant-client-core" && autoreconf -i); fi
+  - if [ -f "servant-http-streams/configure.ac" ]; then (cd "servant-http-streams" && autoreconf -i); fi
+  - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
+  - if [ -f "servant-foreign/configure.ac" ]; then (cd "servant-foreign" && autoreconf -i); fi
+  - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
+  - if [ -f "doc/tutorial/configure.ac" ]; then (cd "doc/tutorial" && autoreconf -i); fi
+  - if [ -f "servant-machines/configure.ac" ]; then (cd "servant-machines" && autoreconf -i); fi
+  - if [ -f "servant-conduit/configure.ac" ]; then (cd "servant-conduit" && autoreconf -i); fi
+  - if [ -f "servant-pipes/configure.ac" ]; then (cd "servant-pipes" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/basic-auth/configure.ac" ]; then (cd "doc/cookbook/basic-auth" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/curl-mock/configure.ac" ]; then (cd "doc/cookbook/curl-mock" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/basic-streaming/configure.ac" ]; then (cd "doc/cookbook/basic-streaming" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/db-postgres-pool/configure.ac" ]; then (cd "doc/cookbook/db-postgres-pool" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/db-sqlite-simple/configure.ac" ]; then (cd "doc/cookbook/db-sqlite-simple" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/file-upload/configure.ac" ]; then (cd "doc/cookbook/file-upload" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/generic/configure.ac" ]; then (cd "doc/cookbook/generic" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/hoist-server-with-context/configure.ac" ]; then (cd "doc/cookbook/hoist-server-with-context" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/https/configure.ac" ]; then (cd "doc/cookbook/https" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/jwt-and-basic-auth/configure.ac" ]; then (cd "doc/cookbook/jwt-and-basic-auth" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/testing/configure.ac" ]; then (cd "doc/cookbook/testing" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/structuring-apis/configure.ac" ]; then (cd "doc/cookbook/structuring-apis" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/using-custom-monad/configure.ac" ]; then (cd "doc/cookbook/using-custom-monad" && autoreconf -i); fi
+  - if [ -f "doc/cookbook/using-free-client/configure.ac" ]; then (cd "doc/cookbook/using-free-client" && autoreconf -i); fi
   - rm -f cabal.project.freeze
   - rm -rf .ghc.environment.* "servant"/dist "servant-client"/dist "servant-client-core"/dist "servant-http-streams"/dist "servant-docs"/dist "servant-foreign"/dist "servant-server"/dist "doc/tutorial"/dist "servant-machines"/dist "servant-conduit"/dist "servant-pipes"/dist "doc/cookbook/basic-auth"/dist "doc/cookbook/curl-mock"/dist "doc/cookbook/basic-streaming"/dist "doc/cookbook/db-postgres-pool"/dist "doc/cookbook/db-sqlite-simple"/dist "doc/cookbook/file-upload"/dist "doc/cookbook/generic"/dist "doc/cookbook/hoist-server-with-context"/dist "doc/cookbook/https"/dist "doc/cookbook/jwt-and-basic-auth"/dist "doc/cookbook/testing"/dist "doc/cookbook/structuring-apis"/dist "doc/cookbook/using-custom-monad"/dist "doc/cookbook/using-free-client"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
@@ -174,7 +148,33 @@ script:
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-  - "printf 'packages: servant-*/*.cabal servant-client-*/*.cabal servant-client-core-*/*.cabal servant-http-streams-*/*.cabal servant-docs-*/*.cabal servant-foreign-*/*.cabal servant-server-*/*.cabal tutorial-*/*.cabal servant-machines-*/*.cabal servant-conduit-*/*.cabal servant-pipes-*/*.cabal cookbook-basic-auth-*/*.cabal cookbook-curl-mock-*/*.cabal cookbook-basic-streaming-*/*.cabal cookbook-db-postgres-pool-*/*.cabal cookbook-db-sqlite-simple-*/*.cabal cookbook-file-upload-*/*.cabal cookbook-generic-*/*.cabal cookbook-hoist-server-with-context-*/*.cabal cookbook-https-*/*.cabal cookbook-jwt-and-basic-auth-*/*.cabal cookbook-testing-*/*.cabal cookbook-structuring-apis-*/*.cabal cookbook-using-custom-monad-*/*.cabal cookbook-using-free-client-*/*.cabal\\n' > cabal.project"
+  - rm -f cabal.project
+  - touch cabal.project
+  - "printf 'packages: \"servant-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-client-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-client-core-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-http-streams-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-docs-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-foreign-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-server-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"tutorial-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-machines-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-conduit-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'packages: \"servant-pipes-*/*.cabal\"\\n' >> cabal.project"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-basic-auth-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-curl-mock-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-basic-streaming-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-db-postgres-pool-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-db-sqlite-simple-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-file-upload-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-generic-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-hoist-server-with-context-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-https-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-jwt-and-basic-auth-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-testing-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-structuring-apis-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-using-custom-monad-*/*.cabal\"\\n' >> cabal.project ; fi"
+  - "if [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"cookbook-using-free-client-*/*.cabal\"\\n' >> cabal.project ; fi"
   - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - "echo 'constraints: foundation >=0.0.14' >> cabal.project"
   - "echo 'constraints: memory <0.14.12 || >0.14.12' >> cabal.project"
@@ -186,7 +186,7 @@ script:
   - "echo 'allow-newer: servant-quickcheck:http-client' >> cabal.project"
   - "echo 'optimization: False' >> cabal.project "
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- servant | grep -vw -- servant-client | grep -vw -- servant-client-core | grep -vw -- servant-http-streams | grep -vw -- servant-docs | grep -vw -- servant-foreign | grep -vw -- servant-server | grep -vw -- tutorial | grep -vw -- servant-machines | grep -vw -- servant-conduit | grep -vw -- servant-pipes | grep -vw -- cookbook-basic-auth | grep -vw -- cookbook-curl-mock | grep -vw -- cookbook-basic-streaming | grep -vw -- cookbook-db-postgres-pool | grep -vw -- cookbook-db-sqlite-simple | grep -vw -- cookbook-file-upload | grep -vw -- cookbook-generic | grep -vw -- cookbook-hoist-server-with-context | grep -vw -- cookbook-https | grep -vw -- cookbook-jwt-and-basic-auth | grep -vw -- cookbook-testing | grep -vw -- cookbook-structuring-apis | grep -vw -- cookbook-using-custom-monad | grep -vw -- cookbook-using-free-client | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(cookbook-basic-auth|cookbook-basic-streaming|cookbook-curl-mock|cookbook-db-postgres-pool|cookbook-db-sqlite-simple|cookbook-file-upload|cookbook-generic|cookbook-hoist-server-with-context|cookbook-https|cookbook-jwt-and-basic-auth|cookbook-structuring-apis|cookbook-testing|cookbook-using-custom-monad|cookbook-using-free-client|servant|servant-client|servant-client-core|servant-conduit|servant-docs|servant-foreign|servant-http-streams|servant-machines|servant-pipes|servant-server|tutorial)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - echo -en 'travis_fold:end:unpack\\r'
@@ -199,7 +199,7 @@ script:
 
   - echo Haddock... && echo -en 'travis_fold:start:haddock\\r'
   # haddock
-  - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
+  - cabal new-haddock -w ${HC} ${TEST} ${BENCH} all
 
   - echo -en 'travis_fold:end:haddock\\r'
 # REGENDATA ["--config=cabal.haskell-ci","--output=.travis.yml","cabal.project"]

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,12 +1,13 @@
 folds: all-but-test
 branches: master
+jobs-selection: any
 
 -- We have inplace packages (servant-js) so we skip installing dependencies in a separate step
-install-dependencies-step: False
+install-dependencies: False
 
 -- this speed-ups the build a little, but we have to check these for release
 no-tests-no-benchmarks: False
-unconstrained-step: False
+unconstrained: False
 
 -- Don't run cabal check, as cookbook examples won't pass it
 cabal-check: False

--- a/doc/cookbook/basic-auth/basic-auth.cabal
+++ b/doc/cookbook/basic-auth/basic-auth.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-basic-auth
   main-is:             BasicAuth.lhs

--- a/doc/cookbook/basic-streaming/basic-streaming.cabal
+++ b/doc/cookbook/basic-streaming/basic-streaming.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-basic-streaming
   main-is:             Streaming.lhs

--- a/doc/cookbook/curl-mock/curl-mock.cabal
+++ b/doc/cookbook/curl-mock/curl-mock.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbock-curl-mock
   main-is:             CurlMock.lhs

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-db-postgres-pool
   main-is:             PostgresPool.lhs

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-db-sqlite-simple
   main-is:             DBConnection.lhs

--- a/doc/cookbook/file-upload/file-upload.cabal
+++ b/doc/cookbook/file-upload/file-upload.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-file-upload
   main-is:             FileUpload.lhs

--- a/doc/cookbook/generic/generic.cabal
+++ b/doc/cookbook/generic/generic.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-using-custom-monad
   main-is:             Generic.lhs

--- a/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
+++ b/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
@@ -11,7 +11,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 category:            Servant
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-hoist-server-with-context
   main-is:             HoistServerWithContext.lhs

--- a/doc/cookbook/https/https.cabal
+++ b/doc/cookbook/https/https.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-https
   main-is:             Https.lhs

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -11,7 +11,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 category:            Servant
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-jwt-and-basic-auth
   main-is:             JWTAndBasicAuth.lhs

--- a/doc/cookbook/pagination/pagination.cabal
+++ b/doc/cookbook/pagination/pagination.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-pagination
   main-is:             Pagination.lhs

--- a/doc/cookbook/sentry/sentry.cabal
+++ b/doc/cookbook/sentry/sentry.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-sentry
   main-is:             Sentry.lhs

--- a/doc/cookbook/structuring-apis/structuring-apis.cabal
+++ b/doc/cookbook/structuring-apis/structuring-apis.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-structuring-apis
   main-is:             StructuringApis.lhs

--- a/doc/cookbook/testing/testing.cabal
+++ b/doc/cookbook/testing/testing.cabal
@@ -10,7 +10,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 category:            Servant
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-testing
   main-is:             Testing.lhs

--- a/doc/cookbook/using-custom-monad/using-custom-monad.cabal
+++ b/doc/cookbook/using-custom-monad/using-custom-monad.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-using-custom-monad
   main-is:             UsingCustomMonad.lhs

--- a/doc/cookbook/using-free-client/using-free-client.cabal
+++ b/doc/cookbook/using-free-client/using-free-client.cabal
@@ -8,7 +8,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:         GHC==8.4.4, GHC==8.6.3
 
 executable cookbook-using-free-client
   main-is:             UsingFreeClient.lhs

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -16,7 +16,7 @@ tested-with:
   GHC==8.0.2
   GHC==8.2.2
   GHC==8.4.4
-  GHC==8.6.2
+  GHC==8.6.3
 extra-source-files:
   static/index.html
   static/ui.js

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -20,7 +20,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -25,7 +25,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -20,7 +20,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -23,7 +23,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -25,7 +25,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -24,7 +24,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -20,7 +20,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -20,7 +20,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -27,7 +27,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -24,7 +24,7 @@ tested-with:
   GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
-   || ==8.6.2
+   || ==8.6.3
 
 extra-source-files:
   CHANGELOG.md


### PR DESCRIPTION
- Update GHC-8.6.2 to GHC-8.6.3
- Build cookbook only with GHC-8.4.4 and GHC-8.6.3, thus
  making 8.0 and 8.2 jobs a little faster