### PR TITLE
Fix URLs to pull requests in servant-server/CHANGELOG.md

### DIFF
--- a/servant-server/CHANGELOG.md
+++ b/servant-server/CHANGELOG.md
@@ -5,13 +5,13 @@
 ----
 
 - Rename `ServantError` to `ClientError`, `ServantErr` to `ServerError`
-  [#1131](https://github.com/haskell-servant/pull/1131)
+  [#1131](https://github.com/haskell-servant/servant/pull/1131)
 - *servant-server* Reorder HTTP failure code priorities
   [#1103](https://github.com/haskell-servant/servant/pull/1103)
 - *servant-server* Re-organise internal modules
   [#1139](https://github.com/haskell-servant/servant/pull/1139)
 - Allow `network-3.0`
-  [#1107](https://github.com/haskell-servant/pull/1107)
+  [#1107](https://github.com/haskell-servant/servant/pull/1107)
 
 0.15
 ----


### PR DESCRIPTION
Just fix for [servant-server/CHANGELOG.md](https://github.com/haskell-servant/servant/blob/94e0acc3d265f1a7e3c4fb7f8c60fc4e502277c6/servant/CHANGELOG.md), no code modified.