### PR TITLE
add stack to tutorial docs

### DIFF
--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -6,7 +6,10 @@ This is an introductory tutorial to **servant**. Whilst browsing is fine, it mak
 Any comments, issues or feedback about the tutorial can be submitted
 to `servant's issue tracker <http://github.com/haskell-servant/servant/issues>`_.
 
-In fact, the whole tutorial is a `cabal <https://cabal.readthedocs.io/en/latest/>`_
+Cabal
+--------
+
+The whole tutorial is a `cabal <https://cabal.readthedocs.io/en/latest/>`_
 project and can be built and played with locally as follows:
 
 .. code-block:: bash
@@ -17,6 +20,20 @@ project and can be built and played with locally as follows:
    $ cabal new-build tutorial
    # load in ghci to play with it
    $ cabal new-repl tutorial
+
+Stack
+--------
+
+To build the tutorial using `stack <https://docs.haskellstack.org/en/stable/README/>`_ you can run the following:
+
+.. code-block:: bash
+
+   $ stack new myproj servant
+   $ cd myproj
+   # build
+   $ stack build
+   # start server
+   $ stack exec myproj-exe
 
 The code can be found in the `*.lhs` files under `doc/tutorial/` in the
 repository. Feel free to edit it while you're reading this documentation and

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -6,11 +6,11 @@ This is an introductory tutorial to **servant**. Whilst browsing is fine, it mak
 Any comments, issues or feedback about the tutorial can be submitted
 to `servant's issue tracker <http://github.com/haskell-servant/servant/issues>`_.
 
-Cabal
+cabal-install
 --------
 
 The whole tutorial is a `cabal <https://cabal.readthedocs.io/en/latest/>`_
-project and can be built and played with locally as follows:
+project and can be built locally as follows:
 
 .. code-block:: bash
 
@@ -21,10 +21,10 @@ project and can be built and played with locally as follows:
    # load in ghci to play with it
    $ cabal new-repl tutorial
 
-Stack
+stack
 --------
 
-To build the tutorial using `stack <https://docs.haskellstack.org/en/stable/README/>`_ you can run the following:
+The servant `stack <https://docs.haskellstack.org/en/stable/README/>`_ template includes the working tutorial. To initialize this template, run:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Follows up conversations around adding stack steps to the tutorial project documentation [here](https://github.com/haskell-servant/servant/issues/1101)