### PR TITLE
Remove unused extensions from servant cabal file.

### DIFF
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -133,10 +133,8 @@ library
                   , OverlappingInstances
                   , OverloadedStrings
                   , PolyKinds
-                  , QuasiQuotes
                   , RecordWildCards
                   , ScopedTypeVariables
-                  , TemplateHaskell
                   , TypeFamilies
                   , TypeOperators
                   , TypeSynonymInstances


### PR DESCRIPTION
Useful for cross-compilation. Otherwise, `callCabal2nix` fails when compiling with `pkgs.pkgsCross.iphone64.haskell.packages.integer-simple.ghc865`