### PR TITLE
Added a function to create Client.Request in ClientEnv

### DIFF
--- a/doc/cookbook/using-free-client/UsingFreeClient.lhs
+++ b/doc/cookbook/using-free-client/UsingFreeClient.lhs
@@ -2,7 +2,7 @@
 
 or simply put: _a practical introduction to `Servant.Client.Free`_.
 
-Someone asked on IRC how one could access the intermediate Requests (resp. Responses) 
+Someone asked on IRC how one could access the intermediate Requests (resp. Responses)
 produced (resp. received) by client functions derived using servant-client.
 My response to such inquiries is: to extend `servant-client` in an ad-hoc way (e.g for testing or debugging
 purposes), use `Servant.Client.Free`. This recipe shows how.
@@ -119,7 +119,7 @@ Now we can use `servant-client`'s internals to convert servant's `Request`
 to http-client's `Request`, and we can inspect it:
 
 ```haskell
-        let req' = I.requestToClientRequest burl req
+        let req' = I.defaultMakeClientRequest burl req
         putStrLn $ "Making request: " ++ show req'
 ```
 
@@ -136,11 +136,11 @@ and calling the continuation. We should get a `Pure` value.
 
 ```haskell
         let res = I.clientResponseToResponse id res'
-        
+
         case k res of
             Pure n ->
                 putStrLn $ "Expected 1764, got " ++ show n
-            _ -> 
+            _ ->
                 putStrLn "ERROR: didn't got a response"
 ```
 
@@ -153,7 +153,7 @@ and responses available for us to inspect, since `RunClient` only gives us
 access to one `Request` or `Response` at a time.
 
 On the other hand, a "batch collection" of requests and/or responses can be achieved
-with both free clients and a custom `RunClient` instance rather easily, for example 
+with both free clients and a custom `RunClient` instance rather easily, for example
 by using a `Writer [(Request, Response)]` monad.
 
 Here is an example of running our small `test` against a running server:

--- a/servant-client/src/Servant/Client.hs
+++ b/servant-client/src/Servant/Client.hs
@@ -9,6 +9,7 @@ module Servant.Client
   , runClientM
   , ClientEnv(..)
   , mkClientEnv
+  , defaultMakeClientRequest
   , hoistClient
   , module Servant.Client.Core.Reexport
   ) where

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -80,6 +80,10 @@ data ClientEnv
   , cookieJar :: Maybe (TVar Client.CookieJar)
   , makeClientRequest :: BaseUrl -> Request -> Client.Request
   -- ^ this function can be used to customize the creation of @http-client@ requests from @servant@ requests. Default value: 'defaultMakeClientRequest'
+  --   Note that:
+  --      1. 'makeClientRequest' exists to allow overriding operational semantics e.g. 'responseTimeout' per request,
+  --          If you need global modifications, you should use 'managerModifyRequest'
+  --      2. the 'cookieJar', if defined, is being applied after 'makeClientRequest' is called.
   }
 
 -- | 'ClientEnv' smart constructor.

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -68,18 +68,18 @@ import qualified Servant.Types.SourceT                    as S
 import qualified Network.HTTP.Client         as Client
 
 -- | The environment in which a request is run.
---   The baseUrl and makeClientRequest function are used to create a `http-client` request.
---   Cookies are then added to that request if a CookieJar is set on the environment.
---   Finally the request is executed with the manager.
+--   The 'baseUrl' and 'makeClientRequest' function are used to create a @http-client@ request.
+--   Cookies are then added to that request if a 'CookieJar' is set on the environment.
+--   Finally the request is executed with the 'manager'.
 --   The 'makeClientRequest' function can be used to modify the request to execute and set values which
---   are not specified on a `servant` Request like the `responseTimeout` or the `redirectCount`
+--   are not specified on a @servant@ 'Request' like 'responseTimeout' or 'redirectCount'
 data ClientEnv
   = ClientEnv
   { manager :: Client.Manager
   , baseUrl :: BaseUrl
   , cookieJar :: Maybe (TVar Client.CookieJar)
   , makeClientRequest :: BaseUrl -> Request -> Client.Request
-  -- ^ this function can be used to customize the creation of `http-client` requests from `servant` requests. Default value: 'defaultMakeClientRequest'
+  -- ^ this function can be used to customize the creation of @http-client@ requests from @servant@ requests. Default value: 'defaultMakeClientRequest'
   }
 
 -- | 'ClientEnv' smart constructor.
@@ -218,9 +218,9 @@ clientResponseToResponse f r = Response
     , responseHttpVersion = Client.responseVersion r
     }
 
--- | Create a `http-client` Request from a `servant` Request
---    The host, path and port fields are extracted from the BaseUrl
---    otherwise the body, headers and query string are derived from the `servant` Request
+-- | Create a @http-client@ 'Client.Request' from a @servant@ 'Request'
+--    The 'Client.host', 'Client.path' and 'Client.port' fields are extracted from the 'BaseUrl'
+--    otherwise the body, headers and query string are derived from the @servant@ 'Request'
 defaultMakeClientRequest :: BaseUrl -> Request -> Client.Request
 defaultMakeClientRequest burl r = Client.defaultRequest
     { Client.method = requestMethod r

--- a/servant-client/src/Servant/Client/Streaming.hs
+++ b/servant-client/src/Servant/Client/Streaming.hs
@@ -10,6 +10,7 @@ module Servant.Client.Streaming
     , runClientM
     , ClientEnv(..)
     , mkClientEnv
+    , defaultMakeClientRequest
     , hoistClient
     , module Servant.Client.Core.Reexport
     ) where

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -93,6 +93,7 @@ type Api =
   :<|> "params" :> QueryParams "names" String :> Get '[JSON] [Person]
   :<|> "flag" :> QueryFlag "flag" :> Get '[JSON] Bool
   :<|> "rawSuccess" :> Raw
+  :<|> "rawSuccessPassHeaders" :> Raw
   :<|> "rawFailure" :> Raw
   :<|> "multiple" :>
             Capture "first" String :>
@@ -118,6 +119,7 @@ getQueryParam   :: Maybe String -> ClientM Person
 getQueryParams  :: [String] -> ClientM [Person]
 getQueryFlag    :: Bool -> ClientM Bool
 getRawSuccess   :: HTTP.Method -> ClientM Response
+getRawSuccessPassHeaders :: HTTP.Method -> ClientM Response
 getRawFailure   :: HTTP.Method -> ClientM Response
 getMultiple     :: String -> Maybe Int -> Bool -> [(String, [Rational])]
   -> ClientM (String, Maybe Int, Bool, [(String, [Rational])])
@@ -135,6 +137,7 @@ getRoot
   :<|> getQueryParams
   :<|> getQueryFlag
   :<|> getRawSuccess
+  :<|> getRawSuccessPassHeaders
   :<|> getRawFailure
   :<|> getMultiple
   :<|> getRespHeaders
@@ -157,6 +160,7 @@ server = serve api (
   :<|> (\ names -> return (zipWith Person names [0..]))
   :<|> return
   :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
+  :<|> (Tagged $ \ request respond -> (respond $ Wai.responseLBS HTTP.ok200 (Wai.requestHeaders $ request) "rawSuccess"))
   :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -133,8 +133,10 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
 
     it "Can modify the outgoing Request using the ClientEnv" $ \(_, baseUrl) -> do
       mgr <- C.newManager C.defaultManagerSettings
+      -- In proper situation, extra headers should probably be visible in API type.
+      -- However, testing for response timeout is difficult, so we test with something which is easy to observe
       let createClientRequest url r = (defaultMakeClientRequest url r) { C.requestHeaders = [("X-Added-Header", "XXX")] }
-      let clientEnv = ClientEnv mgr baseUrl Nothing createClientRequest
+      let clientEnv = (mkClientEnv mgr baseUrl) { makeClientRequest = createClientRequest }
       res <- runClientM (getRawSuccessPassHeaders HTTP.methodGet) clientEnv
       case res of
         Left e ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,16 +17,20 @@ packages:
 
 extra-deps:
 - base-compat-0.10.5
+- base-orphans-0.8.1
 - conduit-1.3.1
 - hspec-2.6.0
 - hspec-core-2.6.0
 - hspec-discover-2.6.0
-- http-api-data-0.4
+- http-api-data-0.4.1
 - http-media-0.7.1.3
+- http-types-0.12.3
 - network-2.8.0.0
 - pipes-safe-2.3.1
 - QuickCheck-2.12.6.1
 - resourcet-1.2.2
 - sop-core-0.4.0.0
+- time-compat-1.9.2.2
+- unordered-containers-0.2.10.0
 - wai-extra-3.0.24.3
 - tasty-1.1.0.4


### PR DESCRIPTION
Hi, I am proposing this PR to fix an issue I am currently facing but you might propose a better solution. Basically I need to set "dynamic timeouts" on HTTP requests based on previous attempts (I try a query, if it times out, I try with a bigger timeout).

Unfortunately at the moment when I get to execute a `ClientM` action there is nothing I can do to intercept the code in `performRequest` which is transforming a `Servant.Client.Core.Request` into a `Network.HTTP.Client.Request` (that function is requestToClientRequest). This PR adds such a function into the `ClientEnv` so that I can override it with some fine-tuning behaviour for changing the sent `Network.HTTP.Client.Requests`.

Some other options would be to more massively use `Free ClientF` in our code (instead of `ClientM`) and rely on a specific interpreter. The drawback would be that we would have to embed all the code in `performRequest` (in theory, because in our specific use case we don't rely on cookies so this would be less code).

What do you think? Do you see better alternatives?