### PR TITLE
merge documentation from duplicate routes

### DIFF
--- a/changelog.d/issue1240
+++ b/changelog.d/issue1240
@@ -1,0 +1,15 @@
+synopsis: Merge documentation from duplicate routes
+prs: #1241
+issues: #1240
+
+description: {
+
+Servant supports defining the same route multiple times with different
+content-types and result-types, but servant-docs was only documenting
+the first of copy of such duplicated routes. It now combines the
+documentation from all the copies.
+
+Unfortunately, it is not yet possible for the documentation to specify
+multiple status codes.
+
+}

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -20,7 +20,6 @@
 #include "overlapping-compat.h"
 module Servant.Docs.Internal where
 
-import Debug.Trace
 import           Prelude                    ()
 import           Prelude.Compat
 
@@ -118,7 +117,7 @@ instance Semigroup API where
 
 instance Monoid API where
     API a1 b1 `mappend` API a2 b2 = API (a1 `mappend` a2)
-                                        (HM.unionWith combineAction b1 (traceShowId b2))
+                                        (HM.unionWith combineAction b1 b2)
     mempty = API mempty mempty
 
 -- | An empty 'API'

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -52,8 +52,10 @@ spec :: Spec
 spec = describe "Servant.Docs" $ do
 
   describe "markdown" $ do
-    let md = markdown (docs (Proxy :: Proxy TestApi1))
-    tests md
+    let md1 = markdown (docs (Proxy :: Proxy TestApi1))
+    tests1 md1
+    let md2 = markdown (docs (Proxy :: Proxy TestApi2))
+    tests2 md2
 
   describe "markdown with extra info" $ do
     let
@@ -65,7 +67,7 @@ spec = describe "Servant.Docs" $ do
               (Proxy :: Proxy (ReqBody '[JSON] String :> Post '[JSON] Datatype1))
               (defAction & notes <>~ [DocNote "Post data" ["Posts some Json data"]])
       md = markdown (docsWith defaultDocOptions [] extra (Proxy :: Proxy TestApi1))
-    tests md
+    tests1 md
     it "contains the extra info provided" $ do
       md `shouldContain` "Get an Integer"
       md `shouldContain` "Post data"
@@ -93,7 +95,7 @@ spec = describe "Servant.Docs" $ do
 
 
  where
-   tests md = do
+   tests1 md = do
     it "mentions supported content-types" $ do
       md `shouldContain` "application/json"
       md `shouldContain` "text/plain;charset=utf-8"
@@ -115,6 +117,11 @@ spec = describe "Servant.Docs" $ do
 
     it "does not generate any docs mentioning the 'empty-api' path" $
       md `shouldNotContain` "empty-api"
+
+   tests2 md = do
+    it "mentions the content-types from both copies of the route" $ do
+      md `shouldContain` "application/json"
+      md `shouldContain` "text/plain;charset=utf-8"
 
 
 -- * APIs
@@ -141,6 +148,10 @@ type TestApi1 = Get '[JSON, PlainText] (Headers '[Header "Location" String] Int)
            :<|> ReqBody '[JSON] String :> Post '[JSON] Datatype1
            :<|> Header "X-Test" Int :> Put '[JSON] Int
            :<|> "empty-api" :> EmptyAPI
+
+type TestApi2 = "duplicate-endpoint" :> Get '[JSON]      Datatype1
+           :<|> "duplicate-endpoint" :> Get '[PlainText] Int
+
 
 data TT = TT1 | TT2 deriving (Show, Eq)
 data UT = UT1 | UT2 deriving (Show, Eq)


### PR DESCRIPTION
Partially fixes #1240 .

Servant supports defining the same route multiple times with different
content-types and result-types, but servant-docs was only documenting
the first of copy of such duplicated routes. It now combines the
documentation from all the copies.

Unfortunately, it is not yet possible for the documentation to specify
multiple status codes. That's why this is only a partial fix for #1240 .