### PR TITLE
Some admin (Stack, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ doc/_build
 doc/venv
 doc/tutorial/static/api.js
 doc/tutorial/static/jq.js
+tags
 
 # local versions of things
 servant-multipart

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -80,7 +80,7 @@ import           Servant.API
 import           Servant.API.ContentTypes
                  (AcceptHeader (..), AllCTRender (..), AllCTUnrender (..),
                  AllMime, MimeRender (..), MimeUnrender (..), canHandleAcceptH,
-                 NoContent (NoContent))
+                 NoContent)
 import           Servant.API.Modifiers
                  (FoldLenient, FoldRequired, RequestArgument,
                  unfoldRequestArgument)
@@ -89,7 +89,7 @@ import           Servant.API.ResponseHeaders
 import qualified Servant.Types.SourceT                      as S
 import           Web.HttpApiData
                  (FromHttpApiData, parseHeader, parseQueryParam,
-                 parseUrlPieceMaybe, parseUrlPieces, parseUrlPiece)
+                 parseUrlPieces, parseUrlPiece)
 
 import           Servant.Server.Internal.BasicAuth
 import           Servant.Server.Internal.Context
@@ -272,7 +272,7 @@ noContentRouter method status action = leafRouter route'
   where
     route' env request respond =
           runAction (action `addMethodCheck` methodCheck method request)
-                    env request respond $ \ output ->
+                    env request respond $ \ _output ->
                       Route $ responseLBS status [] ""
 
 instance {-# OVERLAPPABLE #-}

--- a/servant-server/src/Servant/Server/Internal/DelayedIO.hs
+++ b/servant-server/src/Servant/Server/Internal/DelayedIO.hs
@@ -12,13 +12,12 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans
                  (MonadIO (..), MonadTrans (..))
 import           Control.Monad.Trans.Control
-                 (ComposeSt, MonadBaseControl (..), MonadTransControl (..),
-                 defaultLiftBaseWith, defaultRestoreM)
+                 (MonadBaseControl (..))
 import           Control.Monad.Trans.Resource
                  (MonadResource (..), ResourceT, runInternalState,
-                 runResourceT, transResourceT, withInternalState)
+                 transResourceT, withInternalState)
 import           Network.Wai
-                 (Application, Request, Response, ResponseReceived)
+                 (Request)
 
 import           Servant.Server.Internal.RouteResult
 import           Servant.Server.Internal.ServerError

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,5 +28,6 @@ extra-deps:
 - QuickCheck-2.12.6.1
 - resourcet-1.2.2
 - sop-core-0.4.0.0
-- wai-extra-3.0.24.3
 - tasty-1.1.0.4
+- universe-base-1.1.1
+- wai-extra-3.0.24.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: nightly-2018-09-28 # Last nightly with GHC-8.4.3
 packages:
 - servant-client/
 - servant-client-core/
+- servant-http-streams/
 - servant-docs/
 - servant-foreign/
 - servant-server/


### PR DESCRIPTION
Fixes for some small things I encountered when trying to setup and build the project.

1. When running `stack build --fast --pedantic` I got:
    ```
    WARNING: Ignoring out of range dependency (allow-newer enabled): universe-base-1.0.2.1. servant-docs requires: >=1.1.1 && <1.2
    ```

    ```
        /home/shared/projects/servant/servant-docs/src/Servant/Docs/Internal.hs:498:18: error:
        Not in scope: ‘U.cartesianProduct’
        Module ‘Data.Universe.Helpers’ does not export ‘cartesianProduct’.
        |
    498 |   gtoSamples _ = U.cartesianProduct render ps qs
        |                  ^^^^^^^^^^^^^^^^^^
    ```
    This happened because `cartesianProduct` was added in `universe-base-1.1`, which is not in the specified `nightly-2018-09-28` snapshot.

2. When I tried running `stack ghci servant-http-streams`, I noticed it is not part of the stack.yaml (but of the cabal.project).

3. git picked up the `tags` file created by my editor.

Let me know if any of these are not wanted, I'm happy to amend the PR.