### PR TITLE
use queryString not rawQueryString to enable param  rewrites with

### DIFF
--- a/changelog.d/pr1249
+++ b/changelog.d/pr1249
@@ -1,0 +1,14 @@
+synopsis: use queryString to parse QueryParam, QueryParams and QueryFlag
+packages: servant-server
+prs: #1249
+description: {
+
+Some APIs need query parameters rewriting, e.g. in order to support
+ for multiple casing (camel, snake, etc) or something to that effect.
+
+This could be easily achieved by using WAI Middleware and modyfing
+request's `Query`. But QueryParam, QueryParams and QueryFlag use
+`rawQueryString`. By using `queryString` rather then `rawQueryString`
+we can enable such rewritings.
+
+}

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -318,13 +318,12 @@ type QueryParamApi = QueryParam "name" String :> Get '[JSON] Person
                 :<|> "b" :> QueryFlag "capitalize" :> Get '[JSON] Person
                 :<|> "param" :> QueryParam "age" Integer :> Get '[JSON] Person
                 :<|> "multiparam" :> QueryParams "ages" Integer :> Get '[JSON] Person
-                :<|> "rewrite" :> QueryParam "name" String :> Get '[JSON] Person
 
 queryParamApi :: Proxy QueryParamApi
 queryParamApi = Proxy
 
 qpServer :: Server QueryParamApi
-qpServer = queryParamServer :<|> qpNames :<|> qpCapitalize :<|> qpAge :<|> qpAges :<|> qpRewrite
+qpServer = queryParamServer :<|> qpNames :<|> qpCapitalize :<|> qpAge :<|> qpAges
 
   where qpNames (_:name2:_) = return alice { name = name2 }
         qpNames _           = return alice
@@ -336,9 +335,6 @@ qpServer = queryParamServer :<|> qpNames :<|> qpCapitalize :<|> qpAge :<|> qpAge
         qpAge (Just age') = return alice{ age = age'}
 
         qpAges ages = return alice{ age = sum ages}
-
-        qpRewrite Nothing = return alice
-        qpRewrite (Just name_) = return alice {name = name_}
 
         queryParamServer (Just name_) = return alice{name = name_}
         queryParamServer Nothing = return alice
@@ -469,8 +465,7 @@ queryParamSpec = do
         let params1 = "?person_name=bob"
         response1 <- Network.Wai.Test.request defaultRequest{
           rawQueryString = params1,
-          queryString = sampleRewrite $ parseQuery params1,
-          pathInfo = ["rewrite"]
+          queryString = sampleRewrite $ parseQuery params1
         }
         liftIO $ do
           decode' (simpleBody response1) `shouldBe` Just alice{


### PR DESCRIPTION
WAI middleware provides a handful way to rewrite queries, including query parameters name. Using of `rawQueryString` makes such rewrites useless. Can we use `queryString` instead of it to make it possible?