### PR TITLE
Build servant repo with nix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*/dist
+*~
 dist-*
 .ghc.environment.*
 /bin
@@ -29,6 +30,9 @@ doc/_build
 doc/venv
 doc/tutorial/static/api.js
 doc/tutorial/static/jq.js
+
+# nix
+result*
 
 # local versions of things
 servant-multipart

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,38 @@
+with (builtins.fromJSON (builtins.readFile ./nix/nixpkgs.json));
+{
+  pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+  }) {}
+, compiler ? "ghc883"
+}:
+let
+  overrides = self: super: {
+    servant              = self.callCabal2nix "servant"              ./servant              {};
+    servant-docs         = self.callCabal2nix "servant-docs"         ./servant-docs         {};
+    servant-pipes        = self.callCabal2nix "servant-pipes"        ./servant-pipes        {};
+    servant-server       = self.callCabal2nix "servant-server"       ./servant-server       {};
+    servant-client       = self.callCabal2nix "servant-client"       ./servant-client       {};
+    servant-foreign      = self.callCabal2nix "servant-foreign"      ./servant-foreign      {};
+    servant-conduit      = self.callCabal2nix "servant-conduit"      ./servant-conduit      {};
+    servant-machines     = self.callCabal2nix "servant-machines"     ./servant-machines     {};
+    servant-client-core  = self.callCabal2nix "servant-client-core"  ./servant-client-core  {};
+    servant-http-streams = self.callCabal2nix "servant-http-streams" ./servant-http-streams {};
+  };
+  hPkgs = pkgs.haskell.packages.${compiler}.override { inherit overrides; };
+in
+  with hPkgs;
+  {
+    inherit
+      servant
+      servant-client
+      servant-client-core
+      servant-conduit
+      servant-docs
+      servant-foreign
+      servant-http-streams
+      servant-machines
+      servant-pipes
+      servant-server;
+  }
+

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,4 @@
+{
+  "rev" : "05f0934825c2a0750d4888c4735f9420c906b388",
+  "sha256" : "1g8c2w0661qn89ajp44znmwfmghbbiygvdzq0rzlvlpdiz28v6gy"
+}


### PR DESCRIPTION
cc @fizruk @arianvp @fisx 

We can add `pkgs.haskell.lib.sdistTarball` as well for easy generation of release tarballs.