### PR TITLE
Better errors for partially applied combinators

### DIFF
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -54,6 +54,7 @@ library
     Servant.API.Status
     Servant.API.Stream
     Servant.API.Sub
+    Servant.API.TypeErrors
     Servant.API.TypeLevel
     Servant.API.UVerb
     Servant.API.UVerb.Union

--- a/servant/src/Servant/API/TypeErrors.hs
+++ b/servant/src/Servant/API/TypeErrors.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module defines the error messages used in type-level errors.
+-- Type-level errors can signal non-existing instances, for instance when
+-- a combinator is not applied to the correct number of arguments.
+
+module Servant.API.TypeErrors (
+  PartialApplication,
+  NoInstanceFor,
+  NoInstanceForSub,
+) where
+
+import Data.Kind
+import GHC.TypeLits
+
+-- | No instance exists for @tycls (expr :> ...)@ because 
+-- @expr@ is not recognised.
+type NoInstanceForSub (tycls :: k) (expr :: k') =
+  Text "There is no instance for " :<>: ShowType tycls
+  :<>: Text " (" :<>: ShowType expr :<>: Text " :> ...)"
+
+-- | No instance exists for @expr@.
+type NoInstanceFor (expr :: k) =
+  Text "There is no instance for " :<>: ShowType expr
+
+-- | No instance exists for @tycls (expr :> ...)@ because @expr@ is not fully saturated.
+type PartialApplication (tycls :: k) (expr :: k') =
+  NoInstanceForSub tycls expr
+  :$$: ShowType expr :<>: Text " expects " :<>: ShowType (Arity expr) :<>: Text " more arguments"
+
+-- The arity of a combinator, i.e. the number of required arguments.
+type Arity (ty :: k) = Arity' k
+
+type family Arity' (ty :: k) :: Nat where
+  Arity' (_ -> ty) = 1 + Arity' ty
+  Arity' _ = 0

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -614,7 +614,7 @@ simpleToLink _ toA _ = toLink toA (Proxy :: Proxy sub)
 -- Erroring instance for 'HasLink' when a combinator is not fully applied
 instance TypeError (PartialApplication HasLink arr) => HasLink ((arr :: a -> b) :> sub)
   where
-    type MkLink (arr :> _) _ = TypeError (PartialApplication HasLink arr)
+    type MkLink (arr :> sub) _ = TypeError (PartialApplication HasLink arr)
     toLink = error "unreachable"
 
 -- Erroring instances for 'HasLink' for unknown API combinators


### PR DESCRIPTION
#### Motivation
Expressions with partially applied combinators are actually well-typed, even though they do not represent valid endpoints.

Take for instance the following malformed API:
```haskell
> type BadAPI = CaptureAll "path" :> EmptyAPI
```
which is incorrect because `CaptureAll` requires an additional argument (the type of the values to capture). This definition does not produce a type error, but later when trying to use `BadAPI` one gets confusing errors due to non-existing instances:
```haskell

> err :: (Link -> a) -> Proxy BadAPI -> Link -> MkLink BadAPI a
> err = toLink
```
```
  * No instance for (HasLink BadAPI) arising from a use of `toLink'
  * In the expression: toLink
  ...
```
The goal is to have more explicative error messages.

#### Description of the solution
This PR proposes custom error messages at the type level. Basically, it adds one new instance for each non-existing instance due to combinators that are not fully-applied. These new instances have a type error as constraint, so to show a more precise message to the user.

For instance, the error shown above is caught by the following erroring instance:
```haskell
instance TypeError (...)
    => HasLink (CaptureAll sym :> sub)
  where ...
```
Compare the error message shown above with the following, resulting one:
```
  * There is no instance for HasLink (CaptureAll "path" :> ...)
    CaptureAll expects 2 arguments
  * In the expression: toLink
  ...
```

Currently, the code in the PR defines instances only for `HasLink` w.r.t. `CaptureAll`. If the mantainers find this approach valid, similar instances will be defined for other combinators and classes/families (e.g. `IsElem`).

#### Alternatives
The approach suggested above provides much nicer error messages; the only downside is code duplication (it requires a new instance for each class, combinator, and `0...arity-1`). The abbreviations defined in `TypeErrors.hs` mitigate the problem, and allow reuse.

An alternative would be to have a single catch-all instance for all partially-applied combinators, like the following (inspired from the one [here](https://github.com/haskell-servant/servant/blob/ec0cd8a9471da321cac127a36adb1f7c138b658c/servant-server/src/Servant/Server/Internal.hs#L808)):
```haskell
instance TypeError (...)
    => HasLink ((arr :: k -> l) :> sub)
  where ...
```
which only checks for generic unapplied stuff, and results in a less informative message:
```
  * There is no instance for HasLink (CaptureAll "path" :> ...)
  * In the expression: toLink
  ...
```
