### PR TITLE
Allow newer versions of base, template-haskell, lens, & unliftio-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ install:
   - cat $CABALHOME/config
   - rm -fv cabal.project cabal.project.local cabal.project.freeze
   - travis_retry ${CABAL} v2-update -v
-  - if ! $GHCJS ; then (cd /tmp && ${CABAL} v2-install $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.2.*') ; fi
+  - if ! $GHCJS ; then (cd /tmp && ${CABAL} v2-install $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.3.*') ; fi
   - if $GHCJS ; then (cd /tmp && ${CABAL} v2-install -w ghc-8.4.4 cabal-plan --constraint='cabal-plan ^>=0.6.0.0' --constraint='cabal-plan +exe') ; fi
   - if $GHCJS ; then (cd /tmp && ${CABAL} v2-install -w ghc-8.4.4 hspec-discover) ; fi
   # Generate cabal.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ jobs:
     - compiler: ghcjs-8.4
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu bionic main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"},{"sourceline":"deb http://ppa.launchpad.net/hvr/ghcjs/ubuntu bionic main"},{"sourceline":"deb https://deb.nodesource.com/node_10.x bionic main","key_url":"https://deb.nodesource.com/gpgkey/nodesource.gpg.key"}],"packages":["ghcjs-8.4","cabal-install-3.0","ghc-8.4.4","nodejs"]}}
       os: linux
+    - compiler: ghc-8.10.1
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu bionic main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.1","cabal-install-3.2"]}}
+      os: linux
     - compiler: ghc-8.8.2
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu bionic main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.2","cabal-install-3.0"]}}
       os: linux

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -55,13 +55,13 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.9      && < 4.14
+      base                  >= 4.9      && < 4.15
     , bytestring            >= 0.10.8.1 && < 0.11
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , text                  >= 1.2.3.0  && < 1.3
     , transformers          >= 0.5.2.0  && < 0.6
-    , template-haskell      >= 2.11.1.0 && < 2.16
+    , template-haskell      >= 2.11.1.0 && < 2.17
 
   if !impl(ghc >= 8.2)
     build-depends:

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -45,7 +45,7 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                  >= 4.9      && < 4.14
+      base                  >= 4.9      && < 4.15
     , bytestring            >= 0.10.8.1 && < 0.11
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -40,7 +40,7 @@ library
     , mtl           >=2.2.2    && <2.3
     , resourcet     >=1.2.2    && <1.3
     , servant       >=0.15     && <0.18
-    , unliftio-core >=0.1.2.0  && <0.2
+    , unliftio-core >=0.1.2.0  && <0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -46,7 +46,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base       >= 4.9      && < 4.14
+      base       >= 4.9      && < 4.15
     , bytestring >= 0.10.8.1 && < 0.11
     , text       >= 1.2.3.0  && < 1.3
 
@@ -64,7 +64,7 @@ library
     , hashable             >= 1.2.7.0  && < 1.4
     , http-media           >= 0.7.1.3  && < 0.9
     , http-types           >= 0.12.2   && < 0.13
-    , lens                 >= 4.17     && < 4.19
+    , lens                 >= 4.17     && < 4.20
     , string-conversions   >= 0.4.0.1  && < 0.5
     , universe-base        >= 1.1.1    && < 1.2
     , unordered-containers >= 0.2.9.0  && < 0.3

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -46,7 +46,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base        >= 4.9     && < 4.14
+      base        >= 4.9     && < 4.15
     , text        >= 1.2.3.0 && < 1.3
 
   -- Servant dependencies

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -43,7 +43,7 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                  >= 4.9      && < 4.14
+      base                  >= 4.9      && < 4.15
     , bytestring            >= 0.10.8.1 && < 0.11
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -64,7 +64,7 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                >= 4.9      && < 4.14
+      base                >= 4.9      && < 4.15
     , bytestring          >= 0.10.8.1 && < 0.11
     , containers          >= 0.5.7.1  && < 0.7
     , mtl                 >= 2.2.2    && < 2.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -79,7 +79,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                   >= 4.9      && < 4.14
+      base                   >= 4.9      && < 4.15
     , bytestring             >= 0.10.8.1 && < 0.11
     , mtl                    >= 2.2.2    && < 2.3
     , transformers           >= 0.5.2.0  && < 0.6


### PR DESCRIPTION
To allow building on GHC 8.10.1
Fixes #1295