### PR TITLE
Remove dead link to google group from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ The central documentation can be found [here](http://docs.servant.dev/).
 Other blog posts, videos and slides can be found on the
 [website](http://www.servant.dev/).
 
-If you need help, drop by the IRC channel (#servant on freenode) or [mailing
-list](https://groups.google.com/forum/#!forum/haskell-servant).
+If you need help, drop by the IRC channel (#servant on freenode).
 
 ## Contributing
 


### PR DESCRIPTION
It looks to me like this link is dead.

Any facts, insights, opinions I'm missing?