### PR TITLE
Fix servant-docs code sample in README

### DIFF
--- a/servant-docs/README.md
+++ b/servant-docs/README.md
@@ -61,6 +61,7 @@ data Greet = Greet { _msg :: Text }
 -- 'MimeRender' instance for 'JSON'.
 instance FromJSON Greet
 instance ToJSON Greet
+instance ToSample ()
 
 -- We can also implement 'MimeRender' explicitly for additional formats.
 instance MimeRender PlainText Greet where
@@ -88,7 +89,7 @@ instance ToCapture (Capture "greetid" Text) where
 type TestApi =
        "hello" :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON,PlainText] Greet
   :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
-  :<|> "delete" :> Capture "greetid" Text :> Delete '[] ()
+  :<|> "delete" :> Capture "greetid" Text :> Delete '[JSON] ()
 
 testApi :: Proxy TestApi
 testApi = Proxy


### PR DESCRIPTION
I found a few problems in the code sample of servant-docs, so I fixed them for later users:
- `toSample` function no longer exists
- `DocQueryParam` needs a `ParamKind` argument
- `RQBody` should be `ReqBody`
- added implicit imports for better readability

Related issue:
https://github.com/haskell-servant/servant/issues/1212