### PR TITLE
Loosen bound on base16-bytestring

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -77,7 +77,7 @@ library
   build-depends:
       aeson                 >= 1.4.1.0  && < 1.6
     , base-compat           >= 0.10.5   && < 0.12
-    , base64-bytestring     >= 1.0.0.1  && < 1.1
+    , base64-bytestring     >= 1.0.0.1  && < 1.2
     , exceptions            >= 0.10.0   && < 0.11
     , free                  >= 5.1      && < 5.2
     , http-media            >= 0.7.1.3  && < 0.9


### PR DESCRIPTION
Fixes #1334 

I have checked locally that `servant-client-core` can build with `base16-bytestring` 1.1 without any modifications. According to the PVP I think we could loosen it further to `< 2`, but `< 1.2` works for now.