### PR TITLE
Wrap Application in custom monad for Raw endpoint

### DIFF
--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -18,6 +18,7 @@ import Data.ByteString.Lazy (ByteString)
 import Data.Proxy
 import Data.Text.Lazy.Encoding (encodeUtf8)
 import Data.Text.Lazy (pack)
+import Control.Monad.IO.Class
 import Network.HTTP.Types
 import Network.Wai
 import Servant.API
@@ -264,9 +265,9 @@ api :: Proxy DocsAPI
 api = Proxy
 
 server :: Server DocsAPI
-server = Server.server3 :<|> return serveDocs where
+server = Server.server3 :<|> serveDocs where
     serveDocs _ respond =
-        respond $ responseLBS ok200 [plain] docsBS
+        liftIO $ respond $ responseLBS ok200 [plain] docsBS
     plain = ("Content-Type", "text/plain")
 
 app :: Application

--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -264,7 +264,7 @@ api :: Proxy DocsAPI
 api = Proxy
 
 server :: Server DocsAPI
-server = Server.server3 :<|> Tagged serveDocs where
+server = Server.server3 :<|> return serveDocs where
     serveDocs _ respond =
         respond $ responseLBS ok200 [plain] docsBS
     plain = ("Content-Type", "text/plain")

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -159,13 +159,13 @@ server = serve api (
                    Nothing -> throwError $ ServerError 400 "missing parameter" "" [])
   :<|> (\ names -> return (zipWith Person names [0..]))
   :<|> return
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
-  :<|> (Tagged $ \ request respond -> (respond $ Wai.responseLBS HTTP.ok200 (Wai.requestHeaders $ request) "rawSuccess"))
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
+  :<|> (return $ \ request respond -> (respond $ Wai.responseLBS HTTP.ok200 (Wai.requestHeaders $ request) "rawSuccess"))
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)
   :<|> return NoContent
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
   :<|> emptyServer)
 
 type FailApi =
@@ -178,10 +178,10 @@ failApi = Proxy
 
 failServer :: Application
 failServer = serve failApi (
-       (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "")
-  :<|> (\ _capture -> Tagged $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
-  :<|> (Tagged $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
-  :<|> (Tagged $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/x-www-form-urlencoded"), ("X-Example1", "1"), ("X-Example2", "foo")] "")
+       (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "")
+  :<|> (\ _capture -> return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
+  :<|> (return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
+  :<|> (return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/x-www-form-urlencoded"), ("X-Example1", "1"), ("X-Example2", "foo")] "")
  )
 
 -- * basic auth stuff

--- a/servant-http-streams/test/Servant/ClientSpec.hs
+++ b/servant-http-streams/test/Servant/ClientSpec.hs
@@ -186,12 +186,12 @@ server = serve api (
                    Nothing -> throwError $ ServerError 400 "missing parameter" "" [])
   :<|> (\ names -> return (zipWith Person names [0..]))
   :<|> return
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)
   :<|> return NoContent
-  :<|> (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
+  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
   :<|> emptyServer)
 
 type FailApi =
@@ -203,9 +203,9 @@ failApi = Proxy
 
 failServer :: Application
 failServer = serve failApi (
-       (Tagged $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "")
-  :<|> (\ _capture -> Tagged $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
-  :<|> (Tagged $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
+       (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "")
+  :<|> (\ _capture -> return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
+  :<|> (return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
  )
 
 -- * basic auth stuff

--- a/servant-http-streams/test/Servant/ClientSpec.hs
+++ b/servant-http-streams/test/Servant/ClientSpec.hs
@@ -35,6 +35,8 @@ import           Control.Exception
                  (bracket, fromException, IOException)
 import           Control.Monad.Error.Class
                  (throwError)
+import           Control.Monad.IO.Class
+                 (liftIO)
 import           Data.Aeson
 import           Data.Char
                  (chr, isPrint)
@@ -186,12 +188,12 @@ server = serve api (
                    Nothing -> throwError $ ServerError 400 "missing parameter" "" [])
   :<|> (\ names -> return (zipWith Person names [0..]))
   :<|> return
-  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
-  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
+  :<|> (\ _request respond -> liftIO $ respond $ Wai.responseLBS HTTP.ok200 [] "rawSuccess")
+  :<|> (\ _request respond -> liftIO $ respond $ Wai.responseLBS HTTP.badRequest400 [] "rawFailure")
   :<|> (\ a b c d -> return (a, b, c, d))
   :<|> (return $ addHeader 1729 $ addHeader "eg2" True)
   :<|> return NoContent
-  :<|> (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
+  :<|> (\ _request respond -> liftIO $ respond $ Wai.responseLBS HTTP.found302 [("Location", "testlocation"), ("Set-Cookie", "testcookie=test")] "")
   :<|> emptyServer)
 
 type FailApi =
@@ -203,9 +205,9 @@ failApi = Proxy
 
 failServer :: Application
 failServer = serve failApi (
-       (return $ \ _request respond -> respond $ Wai.responseLBS HTTP.ok200 [] "")
-  :<|> (\ _capture -> return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
-  :<|> (return $ \_request respond -> respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
+       (\ _request respond -> liftIO $ respond $ Wai.responseLBS HTTP.ok200 [] "")
+  :<|> (\ _capture -> \_request respond -> liftIO $ respond $ Wai.responseLBS HTTP.ok200 [("content-type", "application/json")] "")
+  :<|> (\_request respond -> liftIO $ respond $ Wai.responseLBS HTTP.ok200 [("content-type", "fooooo")] "")
  )
 
 -- * basic auth stuff

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -173,12 +173,10 @@ serveWithContext p context server =
 -- to convert any number of endpoints from one type constructor to
 -- another. For example
 --
--- /Note:/ 'Server' 'Raw' can also be entered. It will be retagged.
---
 -- >>> import Control.Monad.Reader
 -- >>> type ReaderAPI = "ep1" :> Get '[JSON] Int :<|> "ep2" :> Get '[JSON] String :<|> Raw :<|> EmptyAPI
 -- >>> let readerApi = Proxy :: Proxy ReaderAPI
--- >>> let readerServer = return 1797 :<|> ask :<|> Tagged (error "raw server") :<|> emptyServer :: ServerT ReaderAPI (Reader String)
+-- >>> let readerServer = return 1797 :<|> ask :<|> return (error "raw server") :<|> emptyServer :: ServerT ReaderAPI (Reader String)
 -- >>> let nt x = return (runReader x "hi")
 -- >>> let mainServer = hoistServer readerApi nt readerServer :: Server ReaderAPI
 --

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -176,7 +176,7 @@ serveWithContext p context server =
 -- >>> import Control.Monad.Reader
 -- >>> type ReaderAPI = "ep1" :> Get '[JSON] Int :<|> "ep2" :> Get '[JSON] String :<|> Raw :<|> EmptyAPI
 -- >>> let readerApi = Proxy :: Proxy ReaderAPI
--- >>> let readerServer = return 1797 :<|> ask :<|> return (error "raw server") :<|> emptyServer :: ServerT ReaderAPI (Reader String)
+-- >>> let readerServer = return 1797 :<|> ask :<|> error "raw server" :<|> emptyServer :: ServerT ReaderAPI (Reader String)
 -- >>> let nt x = return (runReader x "hi")
 -- >>> let mainServer = hoistServer readerApi nt readerServer :: Server ReaderAPI
 --

--- a/servant-server/src/Servant/Server/StaticFiles.hs
+++ b/servant-server/src/Servant/Server/StaticFiles.hs
@@ -21,7 +21,7 @@ import           Network.Wai.Application.Static
 import           Servant.API.Raw
                  (Raw)
 import           Servant.Server
-                 (ServerT, Tagged (..))
+                 (ServerT)
 import           System.FilePath
                  (addTrailingPathSeparator)
 import           WaiAppStatic.Storage.Filesystem
@@ -49,33 +49,33 @@ import           WaiAppStatic.Storage.Filesystem
 -- in order.
 --
 -- Corresponds to the `defaultWebAppSettings` `StaticSettings` value.
-serveDirectoryWebApp :: FilePath -> ServerT Raw m
+serveDirectoryWebApp :: Monad m => FilePath -> ServerT Raw m
 serveDirectoryWebApp = serveDirectoryWith . defaultWebAppSettings . fixPath
 
 -- | Same as 'serveDirectoryWebApp', but uses `defaultFileServerSettings`.
-serveDirectoryFileServer :: FilePath -> ServerT Raw m
+serveDirectoryFileServer :: Monad m => FilePath -> ServerT Raw m
 serveDirectoryFileServer = serveDirectoryWith . defaultFileServerSettings . fixPath
 
 -- | Same as 'serveDirectoryWebApp', but uses 'webAppSettingsWithLookup'.
-serveDirectoryWebAppLookup :: ETagLookup -> FilePath -> ServerT Raw m
+serveDirectoryWebAppLookup :: Monad m => ETagLookup -> FilePath -> ServerT Raw m
 serveDirectoryWebAppLookup etag =
   serveDirectoryWith . flip webAppSettingsWithLookup etag . fixPath
 
 -- | Uses 'embeddedSettings'.
-serveDirectoryEmbedded :: [(FilePath, ByteString)] -> ServerT Raw m
+serveDirectoryEmbedded :: Monad m => [(FilePath, ByteString)] -> ServerT Raw m
 serveDirectoryEmbedded files = serveDirectoryWith (embeddedSettings files)
 
 -- | Alias for 'staticApp'. Lets you serve a directory
 --   with arbitrary 'StaticSettings'. Useful when you want
 --   particular settings not covered by the four other
 --   variants. This is the most flexible method.
-serveDirectoryWith :: StaticSettings -> ServerT Raw m
-serveDirectoryWith = Tagged . staticApp
+serveDirectoryWith :: Monad m => StaticSettings -> ServerT Raw m
+serveDirectoryWith = return . staticApp
 
 -- | Same as 'serveDirectoryFileServer'. It used to be the only
 --   file serving function in servant pre-0.10 and will be kept
 --   around for a few versions, but is deprecated.
-serveDirectory :: FilePath -> ServerT Raw m
+serveDirectory :: Monad m => FilePath -> ServerT Raw m
 serveDirectory = serveDirectoryFileServer
 {-# DEPRECATED serveDirectory "Use serveDirectoryFileServer instead" #-}
 

--- a/servant-server/src/Servant/Server/StaticFiles.hs
+++ b/servant-server/src/Servant/Server/StaticFiles.hs
@@ -17,6 +17,8 @@ module Servant.Server.StaticFiles
 
 import           Data.ByteString
                  (ByteString)
+import           Control.Monad.IO.Class
+                 (MonadIO(..))
 import           Network.Wai.Application.Static
 import           Servant.API.Raw
                  (Raw)
@@ -49,33 +51,33 @@ import           WaiAppStatic.Storage.Filesystem
 -- in order.
 --
 -- Corresponds to the `defaultWebAppSettings` `StaticSettings` value.
-serveDirectoryWebApp :: Monad m => FilePath -> ServerT Raw m
+serveDirectoryWebApp :: MonadIO m => FilePath -> ServerT Raw m
 serveDirectoryWebApp = serveDirectoryWith . defaultWebAppSettings . fixPath
 
 -- | Same as 'serveDirectoryWebApp', but uses `defaultFileServerSettings`.
-serveDirectoryFileServer :: Monad m => FilePath -> ServerT Raw m
+serveDirectoryFileServer :: MonadIO m => FilePath -> ServerT Raw m
 serveDirectoryFileServer = serveDirectoryWith . defaultFileServerSettings . fixPath
 
 -- | Same as 'serveDirectoryWebApp', but uses 'webAppSettingsWithLookup'.
-serveDirectoryWebAppLookup :: Monad m => ETagLookup -> FilePath -> ServerT Raw m
+serveDirectoryWebAppLookup :: MonadIO m => ETagLookup -> FilePath -> ServerT Raw m
 serveDirectoryWebAppLookup etag =
   serveDirectoryWith . flip webAppSettingsWithLookup etag . fixPath
 
 -- | Uses 'embeddedSettings'.
-serveDirectoryEmbedded :: Monad m => [(FilePath, ByteString)] -> ServerT Raw m
+serveDirectoryEmbedded :: MonadIO m => [(FilePath, ByteString)] -> ServerT Raw m
 serveDirectoryEmbedded files = serveDirectoryWith (embeddedSettings files)
 
 -- | Alias for 'staticApp'. Lets you serve a directory
 --   with arbitrary 'StaticSettings'. Useful when you want
 --   particular settings not covered by the four other
 --   variants. This is the most flexible method.
-serveDirectoryWith :: Monad m => StaticSettings -> ServerT Raw m
-serveDirectoryWith = return . staticApp
+serveDirectoryWith :: MonadIO m => StaticSettings -> ServerT Raw m
+serveDirectoryWith settings request respond = liftIO $ staticApp settings request respond --
 
 -- | Same as 'serveDirectoryFileServer'. It used to be the only
 --   file serving function in servant pre-0.10 and will be kept
 --   around for a few versions, but is deprecated.
-serveDirectory :: Monad m => FilePath -> ServerT Raw m
+serveDirectory :: MonadIO m => FilePath -> ServerT Raw m
 serveDirectory = serveDirectoryFileServer
 {-# DEPRECATED serveDirectory "Use serveDirectoryFileServer instead" #-}
 


### PR DESCRIPTION
Currently handler `Raw` endpoint for is just an `Application`: a value.
This value has no access to the context of an arbitrary monad that may
be used instead of the default `Handler`.

This commit changes handler type to `m Application`, allowing the user
to do arbitrary actions in `m` prior to generating an `Application`.

This is useful to do custom logic behind `servant`s back while still
having access to the environment of user's monad.