### PR TITLE
servant-docs: Add support of Pretty modifier for all verbs aliases

### DIFF
--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -32,9 +32,7 @@ import           Data.ByteString.Lazy.Char8
                  (ByteString)
 import qualified Data.CaseInsensitive       as CI
 import           Data.Foldable
-                 (toList)
-import           Data.Foldable
-                 (fold)
+                 (fold, toList)
 import           Data.Hashable
                  (Hashable)
 import           Data.HashMap.Strict

--- a/servant-docs/src/Servant/Docs/Internal/Pretty.hs
+++ b/servant-docs/src/Servant/Docs/Internal/Pretty.hs
@@ -18,6 +18,7 @@ import           Data.Proxy
 import           Network.HTTP.Media
                  ((//))
 import           Servant.API
+import           Servant.API.Verbs
 
 -- | PrettyJSON content type.
 data PrettyJSON
@@ -46,6 +47,24 @@ type family Pretty (api :: k) :: k where
     Pretty (Put cs r)     = Put     (Pretty cs) r
     Pretty (Delete cs r)  = Delete  (Pretty cs) r
     Pretty (Patch cs r)   = Patch   (Pretty cs) r
+    Pretty (GetPartialContent cs r)      = GetPartialContent      (Pretty cs) r
+    Pretty (PutResetContent cs r)        = PutResetContent        (Pretty cs) r
+    Pretty (PatchResetContent cs r)      = PatchResetContent      (Pretty cs) r
+    Pretty (DeleteResetContent cs r)     = DeleteResetContent     (Pretty cs) r
+    Pretty (PostResetContent cs r)       = PostResetContent       (Pretty cs) r
+    Pretty (GetResetContent cs r)        = GetResetContent        (Pretty cs) r
+    Pretty (PutNonAuthoritative cs r)    = PutNonAuthoritative    (Pretty cs) r
+    Pretty (PatchNonAuthoritative cs r)  = PatchNonAuthoritative  (Pretty cs) r
+    Pretty (DeleteNonAuthoritative cs r) = DeleteNonAuthoritative (Pretty cs) r
+    Pretty (PostNonAuthoritative cs r)   = PostNonAuthoritative   (Pretty cs) r
+    Pretty (GetNonAuthoritative cs r)    = GetNonAuthoritative    (Pretty cs) r
+    Pretty (PutAccepted cs r)            = PutAccepted            (Pretty cs) r
+    Pretty (PatchAccepted cs r)          = PatchAccepted          (Pretty cs) r
+    Pretty (DeleteAccepted cs r)         = DeleteAccepted         (Pretty cs) r
+    Pretty (PostAccepted cs r)           = PostAccepted           (Pretty cs) r
+    Pretty (GetAccepted cs r)            = GetAccepted            (Pretty cs) r
+    Pretty (PutCreated cs r)             = PutCreated             (Pretty cs) r
+    Pretty (PostCreated cs r)            = PostCreated            (Pretty cs) r
     Pretty (ReqBody cs r) = ReqBody (Pretty cs) r
     Pretty (JSON ': xs)   = PrettyJSON ': xs
     Pretty (x ': xs)      = x ': Pretty xs


### PR DESCRIPTION
I noticed that JSON prettifying works not for all endpoints servant verbs.
So I added missing cases with other verbs aliases to `Pretty` type family :)