### PR TITLE
servant-client-core: depend on 0.18.2

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -64,7 +64,7 @@ library
 
   -- Servant dependencies
   build-depends:
-      servant            >= 0.18.1 && <0.19
+      servant            >= 0.18.2 && <0.19
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.


### PR DESCRIPTION
We should make a cabal revision for this too I suppose. Looks like this was an oversight

I don't know how to do this on hackage yet; but would be happy if someone could show me