### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -51,7 +51,7 @@ library
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
       base                  >= 4.9      && < 4.15
-    , bytestring            >= 0.10.8.1 && < 0.11
+    , bytestring            >= 0.10.8.1 && < 0.12
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , text                  >= 1.2.3.0  && < 1.3

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -39,7 +39,7 @@ library
 
   build-depends:
       base                >=4.11    && <4.12
-    , bytestring          >=0.10    && <0.11
+    , bytestring          >=0.10    && <0.12
     , case-insensitive    >=1.2.0.0 && <1.3.0.0
     , containers          >=0.5     && <0.7
     , exceptions          >=0.8     && <0.11

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -41,7 +41,7 @@ library
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
       base                  >= 4.9      && < 4.15
-    , bytestring            >= 0.10.8.1 && < 0.11
+    , bytestring            >= 0.10.8.1 && < 0.12
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , mtl                   >= 2.2.2    && < 2.3

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -29,7 +29,7 @@ library
   exposed-modules:     Servant.Conduit
   build-depends:
       base          >=4.9      && <5
-    , bytestring    >=0.10.8.1 && <0.11
+    , bytestring    >=0.10.8.1 && <0.12
     , conduit       >=1.3.1    && <1.4
     , mtl           >=2.2.2    && <2.3
     , resourcet     >=1.2.2    && <1.3

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -42,7 +42,7 @@ library
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
       base       >= 4.9      && < 4.15
-    , bytestring >= 0.10.8.1 && < 0.11
+    , bytestring >= 0.10.8.1 && < 0.12
     , text       >= 1.2.3.0  && < 1.3
 
   -- Servant dependencies

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -39,7 +39,7 @@ library
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
       base                  >= 4.9      && < 4.15
-    , bytestring            >= 0.10.8.1 && < 0.11
+    , bytestring            >= 0.10.8.1 && < 0.12
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , mtl                   >= 2.2.2    && < 2.3

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -29,7 +29,7 @@ library
   exposed-modules:     Servant.Machines
   build-depends:
       base          >=4.9      && <5
-    , bytestring    >=0.10.8.1 && <0.11
+    , bytestring    >=0.10.8.1 && <0.12
     , machines      >=0.6.4    && <0.8
     , mtl           >=2.2.2    && <2.3
     , servant       >=0.15     && <0.19

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -29,7 +29,7 @@ library
   exposed-modules:     Servant.Pipes
   build-depends:
       base          >=4.9      && <5
-    , bytestring    >=0.10.8.1 && <0.11
+    , bytestring    >=0.10.8.1 && <0.12
     , pipes         >=4.3.9    && <4.4
     , pipes-safe    >=2.3.1    && <2.4
     , mtl           >=2.2.2    && <2.3

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -61,7 +61,7 @@ library
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
       base                >= 4.9      && < 4.15
-    , bytestring          >= 0.10.8.1 && < 0.11
+    , bytestring          >= 0.10.8.1 && < 0.12
     , containers          >= 0.5.7.1  && < 0.7
     , mtl                 >= 2.2.2    && < 2.3
     , text                >= 1.2.3.0  && < 1.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -79,7 +79,7 @@ library
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
       base                   >= 4.9      && < 4.15
-    , bytestring             >= 0.10.8.1 && < 0.11
+    , bytestring             >= 0.10.8.1 && < 0.12
     , mtl                    >= 2.2.2    && < 2.3
     , sop-core               >= 0.4.0.0  && < 0.6
     , transformers           >= 0.5.2.0  && < 0.6


### PR DESCRIPTION
Tested with 
```
constraints: bytestring >=0.11
allow-newer: *:bytestring

source-repository-package
  type: git
  location: https://github.com/Bodigrim/hspec-wai
  tag: master
```

Since `servant` does not support GHC < 8.0, version bumps are enough.