### PR TITLE
Improve API for composing generic routes

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -52,6 +52,7 @@ library
   build-depends:
       base                  >= 4.9      && < 4.16
     , bytestring            >= 0.10.8.1 && < 0.12
+    , constraints
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , text                  >= 1.2.3.0  && < 1.3

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -52,7 +52,7 @@ library
   build-depends:
       base                  >= 4.9      && < 4.16
     , bytestring            >= 0.10.8.1 && < 0.12
-    , constraints
+    , constraints           >= 0.2      && < 0.14
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.5
     , text                  >= 1.2.3.0  && < 1.3

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -27,6 +27,7 @@ module Servant.Client.Core.HasClient (
     HasClient (..),
     EmptyClient (..),
     AsClientT,
+    (/:),
     foldMapUnion,
     matchUnion,
     ) where
@@ -871,6 +872,37 @@ instance
         toServant @api @(AsClientT ma) clientA
 
 #endif
+
+infixl 1 /:
+
+-- | Convenience function for working with nested record-clients.
+--
+-- Example:
+--
+-- @@
+-- type Api = NamedAPI RootApi
+--
+-- data RootApi mode = RootApi
+--   { subApi :: mode :- NamedAPI SubApi
+--   , …
+--   } deriving Generic
+--
+-- data SubAmi mode = SubApi
+--   { endpoint :: mode :- Get '[JSON] Person
+--   , …
+--   } deriving Generic
+--
+-- api :: Proxy API
+-- api = Proxy
+--
+-- rootClient :: RootApi (AsClientT ClientM)
+-- rootClient = client api
+--
+-- endpointClient :: ClientM Person
+-- endpointClient = client /: subApi /: endpoint
+-- @@
+(/:) :: a -> (a -> b) -> b
+x /: f = f x
 
 
 {- Note [Non-Empty Content Types]

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -7,20 +6,13 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
-
-#if MIN_VERSION_base(4,9,0) && __GLASGOW_HASKELL__ >= 802
-#define HAS_TYPE_ERROR
-#endif
-
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE QuantifiedConstraints  #-}
-#endif
 
 module Servant.Client.Core.HasClient (
     clientIn,
@@ -804,11 +796,7 @@ instance ( HasClient m api
 -- > getBooks = client myApi
 -- > -- then you can just use "getBooksBy" to query that endpoint.
 -- > -- 'getBooks' for all books.
-#ifdef HAS_TYPE_ERROR
 instance (AtLeastOneFragment api, FragmentUnique (Fragment a :> api), HasClient m api
-#else
-instance ( HasClient m api
-#endif
          ) => HasClient m (Fragment a :> api) where
 
   type Client m (Fragment a :> api) = Client m api
@@ -833,7 +821,6 @@ data AsClientT (m :: * -> *)
 instance GenericMode (AsClientT m) where
     type AsClientT m :- api = Client m api
 
-#if __GLASGOW_HASKELL__ >= 806
 
 type GClientConstraints api m =
   ( GenericServant api (AsClientT m)
@@ -873,8 +860,6 @@ instance
         hoistClientMonad @m @(ToServantApi api) @ma @mb Proxy Proxy nat $
         toServant @api @(AsClientT ma) clientA
 
-#endif
-
 infixl 1 //
 infixl 2 /:
 
@@ -885,14 +870,14 @@ infixl 2 /:
 -- Example:
 --
 -- @@
--- type Api = NamedAPI RootApi
+-- type Api = NamedRoutes RootApi
 --
 -- data RootApi mode = RootApi
---   { subApi :: mode :- NamedAPI SubApi
+--   { subApi :: mode :- NamedRoutes SubApi
 --   , …
 --   } deriving Generic
 --
--- data SubAmi mode = SubApi
+-- data SubApi mode = SubApi
 --   { endpoint :: mode :- Get '[JSON] Person
 --   , …
 --   } deriving Generic
@@ -912,20 +897,20 @@ x // f = f x
 -- | Convenience function for supplying arguments to client functions when
 -- working with records of clients.
 --
--- Intended to be use in conjunction with '(//)'.
+-- Intended to be used in conjunction with '(//)'.
 --
 -- Example:
 --
 -- @@
--- type Api = NamedAPI RootApi
+-- type Api = NamedRoutes RootApi
 --
 -- data RootApi mode = RootApi
---   { subApi :: mode :- Capture "token" String :> NamedAPI SubApi
+--   { subApi :: mode :- Capture "token" String :> NamedRoutes SubApi
 --   , hello :: mode :- Capture "name" String :> Get '[JSON] String
 --   , …
 --   } deriving Generic
 --
--- data SubAmi mode = SubApi
+-- data SubApi mode = SubApi
 --   { endpoint :: mode :- Get '[JSON] Person
 --   , …
 --   } deriving Generic

--- a/servant-client-core/src/Servant/Client/Core/Reexport.hs
+++ b/servant-client-core/src/Servant/Client/Core/Reexport.hs
@@ -7,6 +7,7 @@ module Servant.Client.Core.Reexport
     HasClient(..)
   , foldMapUnion
   , matchUnion
+  , AsClientT
 
     -- * Response (for @Raw@)
   , Response
@@ -23,6 +24,7 @@ module Servant.Client.Core.Reexport
   , showBaseUrl
   , parseBaseUrl
   , InvalidBaseUrlException
+
   ) where
 
 

--- a/servant-client-core/src/Servant/Client/Core/Reexport.hs
+++ b/servant-client-core/src/Servant/Client/Core/Reexport.hs
@@ -8,6 +8,7 @@ module Servant.Client.Core.Reexport
   , foldMapUnion
   , matchUnion
   , AsClientT
+  , (/:)
 
     -- * Response (for @Raw@)
   , Response

--- a/servant-client-core/src/Servant/Client/Core/Reexport.hs
+++ b/servant-client-core/src/Servant/Client/Core/Reexport.hs
@@ -8,6 +8,7 @@ module Servant.Client.Core.Reexport
   , foldMapUnion
   , matchUnion
   , AsClientT
+  , (//)
   , (/:)
 
     -- * Response (for @Raw@)

--- a/servant-client-core/src/Servant/Client/Generic.hs
+++ b/servant-client-core/src/Servant/Client/Generic.hs
@@ -1,16 +1,21 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints  #-}
+#endif
+
 module  Servant.Client.Generic (
     AsClientT,
     genericClient,
@@ -58,6 +63,8 @@ genericClientHoist nt
     m = Proxy :: Proxy m
     api = Proxy :: Proxy (ToServantApi routes)
 
+#if __GLASGOW_HASKELL__ >= 806
+
 type GClientConstraints api m =
   ( GenericServant api (AsClientT m)
   , Client m (ToServantApi api) ~ ToServant api (AsClientT m)
@@ -95,3 +102,5 @@ instance
         fromServant @api @(AsClientT mb) $
         hoistClientMonad @m @(ToServantApi api) @ma @mb Proxy Proxy nat $
         toServant @api @(AsClientT ma) clientA
+
+#endif

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -93,6 +93,7 @@ test-suite spec
       Servant.ConnectionErrorSpec
       Servant.FailSpec
       Servant.GenAuthSpec
+      Servant.GenericSpec
       Servant.HoistClientSpec
       Servant.StreamSpec
       Servant.SuccessSpec

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -64,13 +64,11 @@ import           Servant.API
                  JSON, MimeRender (mimeRender), MimeUnrender (mimeUnrender),
                  NoContent (NoContent), PlainText, Post, QueryFlag, QueryParam,
                  QueryParams, Raw, ReqBody, StdMethod (GET), ToHttpApiData (..), UVerb, Union,
-                 WithStatus (WithStatus), addHeader)
-import           Servant.API.Generic
+                 WithStatus (WithStatus), NamedRoutes, addHeader)
+import           Servant.API.Generic ((:-))
 import           Servant.Client
-import           Servant.Client.Generic
 import qualified Servant.Client.Core.Auth         as Auth
 import           Servant.Server
-import           Servant.Server.Generic
 import           Servant.Server.Experimental.Auth
 import           Servant.Test.ComprehensiveAPI
 
@@ -184,6 +182,7 @@ uverbGetSuccessOrRedirect :: Bool
                           -> ClientM (Union '[WithStatus 200 Person,
                                               WithStatus 301 Text])
 uverbGetCreated :: ClientM (Union '[WithStatus 201 Person])
+recordRoutes :: RecordRoutes (AsClientT ClientM)
 
 getRoot
   :<|> getGet

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -111,7 +111,7 @@ type TestHeaders = '[Header "X-Example1" Int, Header "X-Example2" String]
 data RecordRoutes mode = RecordRoutes
   { version :: mode :- "version" :> Get '[JSON] Int
   , echo :: mode :- "echo" :> Capture "string" String :> Get '[JSON] String
-  , otherRoutes :: mode :- "other" :> NamedRoutes OtherRoutes
+  , otherRoutes :: mode :- "other" :> Capture "someParam" Int :> NamedRoutes OtherRoutes
   } deriving Generic
 
 data OtherRoutes mode = OtherRoutes
@@ -246,7 +246,7 @@ server = serve api (
   :<|> RecordRoutes
          { version = pure 42
          , echo = pure
-         , otherRoutes = OtherRoutes
+         , otherRoutes = \_ -> OtherRoutes
              { something = pure ["foo", "bar", "pweet"]
              }
          }

--- a/servant-client/test/Servant/GenericSpec.hs
+++ b/servant-client/test/Servant/GenericSpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
+{-# OPTIONS_GHC -freduction-depth=100 #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
+module Servant.GenericSpec (spec) where
+
+import           Data.Function ((&))
+import           Test.Hspec
+
+import           Servant.ClientTestUtils
+
+spec :: Spec
+spec = describe "Servant.GenericSpec" $ do
+    genericSpec
+
+genericSpec :: Spec
+genericSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
+  context "Record clients work as expected" $ do
+
+    it "Client functions return expected values" $ \(_,baseUrl) -> do
+      runClient (recordRoutes & version) baseUrl `shouldReturn` Right 42
+      runClient (recordRoutes & echo $ "foo") baseUrl `shouldReturn` Right "foo"
+    it "Clients can be nested" $ \(_,baseUrl) -> do
+      runClient (recordRoutes & otherRoutes & something) baseUrl `shouldReturn` Right ["foo", "bar", "pweet"]

--- a/servant-client/test/Servant/GenericSpec.hs
+++ b/servant-client/test/Servant/GenericSpec.hs
@@ -19,7 +19,7 @@ module Servant.GenericSpec (spec) where
 
 import           Test.Hspec
 
-import           Servant.Client ((/:))
+import           Servant.Client ((//), (/:))
 import           Servant.ClientTestUtils
 
 spec :: Spec
@@ -31,7 +31,7 @@ genericSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
   context "Record clients work as expected" $ do
 
     it "Client functions return expected values" $ \(_,baseUrl) -> do
-      runClient (recordRoutes /: version) baseUrl `shouldReturn` Right 42
-      runClient (recordRoutes /: echo $ "foo") baseUrl `shouldReturn` Right "foo"
+      runClient (recordRoutes // version) baseUrl `shouldReturn` Right 42
+      runClient (recordRoutes // echo /: "foo") baseUrl `shouldReturn` Right "foo"
     it "Clients can be nested" $ \(_,baseUrl) -> do
-      runClient (recordRoutes /: otherRoutes /: something) baseUrl `shouldReturn` Right ["foo", "bar", "pweet"]
+      runClient (recordRoutes // otherRoutes /: 42 // something) baseUrl `shouldReturn` Right ["foo", "bar", "pweet"]

--- a/servant-client/test/Servant/GenericSpec.hs
+++ b/servant-client/test/Servant/GenericSpec.hs
@@ -17,9 +17,9 @@
 
 module Servant.GenericSpec (spec) where
 
-import           Data.Function ((&))
 import           Test.Hspec
 
+import           Servant.Client ((/:))
 import           Servant.ClientTestUtils
 
 spec :: Spec
@@ -31,7 +31,7 @@ genericSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
   context "Record clients work as expected" $ do
 
     it "Client functions return expected values" $ \(_,baseUrl) -> do
-      runClient (recordRoutes & version) baseUrl `shouldReturn` Right 42
-      runClient (recordRoutes & echo $ "foo") baseUrl `shouldReturn` Right "foo"
+      runClient (recordRoutes /: version) baseUrl `shouldReturn` Right 42
+      runClient (recordRoutes /: echo $ "foo") baseUrl `shouldReturn` Right "foo"
     it "Clients can be nested" $ \(_,baseUrl) -> do
-      runClient (recordRoutes & otherRoutes & something) baseUrl `shouldReturn` Right ["foo", "bar", "pweet"]
+      runClient (recordRoutes /: otherRoutes /: something) baseUrl `shouldReturn` Right ["foo", "bar", "pweet"]

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -62,6 +62,7 @@ library
   build-depends:
       base                >= 4.9      && < 4.16
     , bytestring          >= 0.10.8.1 && < 0.12
+    , constraints
     , containers          >= 0.5.7.1  && < 0.7
     , mtl                 >= 2.2.2    && < 2.3
     , text                >= 1.2.3.0  && < 1.3

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -62,7 +62,7 @@ library
   build-depends:
       base                >= 4.9      && < 4.16
     , bytestring          >= 0.10.8.1 && < 0.12
-    , constraints
+    , constraints         >= 0.2      && < 0.14
     , containers          >= 0.5.7.1  && < 0.7
     , mtl                 >= 2.2.2    && < 2.3
     , text                >= 1.2.3.0  && < 1.3

--- a/servant-server/src/Servant/Server/Generic.hs
+++ b/servant-server/src/Servant/Server/Generic.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans   #-}
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE FlexibleContexts       #-}
@@ -15,6 +16,11 @@
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
+
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints  #-}
+#endif
+
 -- | @since 0.14.1
 module Servant.Server.Generic (
     AsServerT,
@@ -113,6 +119,8 @@ genericServerT
     -> ToServant routes (AsServerT m)
 genericServerT = toServant
 
+#if __GLASGOW_HASKELL__ >= 806
+
 -- | Set of constraints required to convert to / from vanilla server types.
 type GServerConstraints api m =
   ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
@@ -173,3 +181,5 @@ instance
             toServant server
           servantSrvN :: ServerT (ToServantApi api) n =
             hoistServerWithContext (Proxy @(ToServantApi api)) pctx nat servantSrvM
+
+#endif

--- a/servant-server/src/Servant/Server/Generic.hs
+++ b/servant-server/src/Servant/Server/Generic.hs
@@ -1,25 +1,9 @@
-{-# OPTIONS_GHC -fno-warn-orphans   #-}
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE ConstraintKinds        #-}
-{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE InstanceSigs           #-}
-{-# LANGUAGE KindSignatures         #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE QuantifiedConstraints  #-}
 {-# LANGUAGE RankNTypes             #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
-{-# LANGUAGE UndecidableInstances   #-}
-
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE QuantifiedConstraints  #-}
-#endif
 
 -- | @since 0.14.1
 module Servant.Server.Generic (
@@ -29,28 +13,15 @@ module Servant.Server.Generic (
     genericServeT,
     genericServeTWithContext,
     genericServer,
-    genericServerT,
-    -- * Internal machinery
-    GServerConstraints,
-    GServer,
-    -- * Re-exports
-    NamedRoutes
+    genericServerT
   ) where
 
-import           Data.Constraint
 import           Data.Proxy
                  (Proxy (..))
 
-import           Servant.API.Generic
 import           Servant.Server
+import           Servant.API.Generic
 import           Servant.Server.Internal
-
--- | A type that specifies that an API record contains a server implementation.
-data AsServerT (m :: * -> *)
-instance GenericMode (AsServerT m) where
-    type AsServerT m :- api = ServerT api m
-
-type AsServer = AsServerT Handler
 
 -- | Transform a record of routes into a WAI 'Application'.
 genericServe
@@ -119,67 +90,3 @@ genericServerT
     -> ToServant routes (AsServerT m)
 genericServerT = toServant
 
-#if __GLASGOW_HASKELL__ >= 806
-
--- | Set of constraints required to convert to / from vanilla server types.
-type GServerConstraints api m =
-  ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
-  , GServantProduct (Rep (api (AsServerT m)))
-  )
-
--- | This class is a necessary evil: in the implementation of 'HasServer' for
---  @'NamedRoutes' api@, we essentially need the quantified constraint @forall
---  m. 'GServerConstraints' m@ to hold.
---
--- We cannot require do that directly as the definition of 'GServerConstraints'
--- contains type family applications ('Rep' and 'ServerT'). The trick is to hide
--- those type family applications behind a typeclass providing evidence for
--- @'GServerConstraints' api m@ in the form of a dictionary, and require that
--- @forall m. 'GServer' api m@ instead.
---
--- Users shouldn't have to worry about this class, as the only possible instance
--- is provided in this module for all record APIs.
-
-class GServer (api :: * -> *) (m :: * -> *) where
-  proof :: Dict (GServerConstraints api m)
-
-instance
-  ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
-  , GServantProduct (Rep (api (AsServerT m)))
-  ) => GServer api m where
-  proof = Dict
-
-instance
-  ( HasServer (ToServantApi api) context
-  , forall m. Generic (api (AsServerT m))
-  , forall m. GServer api m
-  ) => HasServer (NamedRoutes api) context where
-
-  type ServerT (NamedRoutes api) m = api (AsServerT m)
-
-  route
-    :: Proxy (NamedRoutes api)
-    -> Context context
-    -> Delayed env (api (AsServerT Handler))
-    -> Router env
-  route _ ctx delayed =
-    case proof @api @Handler of
-      Dict -> route (Proxy @(ToServantApi api)) ctx (toServant <$> delayed)
-
-  hoistServerWithContext
-    :: forall m n. Proxy (NamedRoutes api)
-    -> Proxy context
-    -> (forall x. m x -> n x)
-    -> api (AsServerT m)
-    -> api (AsServerT n)
-  hoistServerWithContext _ pctx nat server =
-    case (proof @api @m, proof @api @n) of
-      (Dict, Dict) ->
-        fromServant servantSrvN
-        where
-          servantSrvM :: ServerT (ToServantApi api) m =
-            toServant server
-          servantSrvN :: ServerT (ToServantApi api) n =
-            hoistServerWithContext (Proxy @(ToServantApi api)) pctx nat servantSrvM
-
-#endif

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -1,21 +1,28 @@
 {-# LANGUAGE CPP                   #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE InstanceSigs          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 #if MIN_VERSION_base(4,9,0) && __GLASGOW_HASKELL__ >= 802
 #define HAS_TYPE_ERROR
+#endif
+
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints  #-}
 #endif
 
 module Servant.Server.Internal
@@ -42,6 +49,7 @@ import qualified Data.ByteString                            as B
 import qualified Data.ByteString.Builder                    as BB
 import qualified Data.ByteString.Char8                      as BC8
 import qualified Data.ByteString.Lazy                       as BL
+import           Data.Constraint (Dict(..))
 import           Data.Either
                  (partitionEithers)
 import           Data.Maybe
@@ -54,6 +62,7 @@ import           Data.Tagged
                  (Tagged (..), retag, untag)
 import qualified Data.Text                                  as T
 import           Data.Typeable
+import           GHC.Generics
 import           GHC.TypeLits
                  (KnownNat, KnownSymbol, natVal, symbolVal)
 import qualified Network.HTTP.Media                         as NHM
@@ -75,7 +84,8 @@ import           Servant.API
                  QueryParam', QueryParams, Raw, ReflectMethod (reflectMethod),
                  RemoteHost, ReqBody', SBool (..), SBoolI (..), SourceIO,
                  Stream, StreamBody', Summary, ToSourceIO (..), Vault, Verb,
-                 WithNamedContext)
+                 WithNamedContext, NamedRoutes)
+import           Servant.API.Generic (GenericMode(..), ToServant, ToServantApi, GServantProduct, toServant, fromServant)
 import           Servant.API.ContentTypes
                  (AcceptHeader (..), AllCTRender (..), AllCTUnrender (..),
                  AllMime, MimeRender (..), MimeUnrender (..), NoContent,
@@ -905,3 +915,76 @@ instance (HasServer api context)
 
 -- $setup
 -- >>> import Servant
+
+-- | A type that specifies that an API record contains a server implementation.
+data AsServerT (m :: * -> *)
+instance GenericMode (AsServerT m) where
+    type AsServerT m :- api = ServerT api m
+
+type AsServer = AsServerT Handler
+
+
+#if __GLASGOW_HASKELL__ >= 806
+
+-- | Set of constraints required to convert to / from vanilla server types.
+type GServerConstraints api m =
+  ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
+  , GServantProduct (Rep (api (AsServerT m)))
+  )
+
+-- | This class is a necessary evil: in the implementation of 'HasServer' for
+--  @'NamedRoutes' api@, we essentially need the quantified constraint @forall
+--  m. 'GServerConstraints' m@ to hold.
+--
+-- We cannot require do that directly as the definition of 'GServerConstraints'
+-- contains type family applications ('Rep' and 'ServerT'). The trick is to hide
+-- those type family applications behind a typeclass providing evidence for
+-- @'GServerConstraints' api m@ in the form of a dictionary, and require that
+-- @forall m. 'GServer' api m@ instead.
+--
+-- Users shouldn't have to worry about this class, as the only possible instance
+-- is provided in this module for all record APIs.
+
+class GServer (api :: * -> *) (m :: * -> *) where
+  proof :: Dict (GServerConstraints api m)
+
+instance
+  ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
+  , GServantProduct (Rep (api (AsServerT m)))
+  ) => GServer api m where
+  proof = Dict
+
+instance
+  ( HasServer (ToServantApi api) context
+  , forall m. Generic (api (AsServerT m))
+  , forall m. GServer api m
+  ) => HasServer (NamedRoutes api) context where
+
+  type ServerT (NamedRoutes api) m = api (AsServerT m)
+
+  route
+    :: Proxy (NamedRoutes api)
+    -> Context context
+    -> Delayed env (api (AsServerT Handler))
+    -> Router env
+  route _ ctx delayed =
+    case proof @api @Handler of
+      Dict -> route (Proxy @(ToServantApi api)) ctx (toServant <$> delayed)
+
+  hoistServerWithContext
+    :: forall m n. Proxy (NamedRoutes api)
+    -> Proxy context
+    -> (forall x. m x -> n x)
+    -> api (AsServerT m)
+    -> api (AsServerT n)
+  hoistServerWithContext _ pctx nat server =
+    case (proof @api @m, proof @api @n) of
+      (Dict, Dict) ->
+        fromServant servantSrvN
+        where
+          servantSrvM :: ServerT (ToServantApi api) m =
+            toServant server
+          servantSrvN :: ServerT (ToServantApi api) n =
+            hoistServerWithContext (Proxy @(ToServantApi api)) pctx nat servantSrvM
+
+#endif

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -80,6 +80,7 @@ library
   build-depends:
       base                   >= 4.9      && < 4.16
     , bytestring             >= 0.10.8.1 && < 0.12
+    , constraints
     , mtl                    >= 2.2.2    && < 2.3
     , sop-core               >= 0.4.0.0  && < 0.6
     , transformers           >= 0.5.2.0  && < 0.6

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -46,6 +46,7 @@ library
     Servant.API.HttpVersion
     Servant.API.IsSecure
     Servant.API.Modifiers
+    Servant.API.NamedRoutes
     Servant.API.QueryParam
     Servant.API.Raw
     Servant.API.RemoteHost
@@ -80,7 +81,7 @@ library
   build-depends:
       base                   >= 4.9      && < 4.16
     , bytestring             >= 0.10.8.1 && < 0.12
-    , constraints
+    , constraints            >= 0.2
     , mtl                    >= 2.2.2    && < 2.3
     , sop-core               >= 0.4.0.0  && < 0.6
     , transformers           >= 0.5.2.0  && < 0.6

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -36,6 +36,9 @@ module Servant.API (
   module Servant.API.Verbs,
   module Servant.API.UVerb,
 
+  -- * Sub-APIs defined as records of routes
+  module Servant.API.NamedRoutes,
+
   -- * Streaming endpoints, distinguished by HTTP method
   module Servant.API.Stream,
 
@@ -130,6 +133,8 @@ import           Servant.API.UVerb
                  Unique, WithStatus (..), inject, statusOf)
 import           Servant.API.Vault
                  (Vault)
+import           Servant.API.NamedRoutes
+                 (NamedRoutes)
 import           Servant.API.Verbs
                  (Delete, DeleteAccepted, DeleteNoContent,
                  DeleteNonAuthoritative, Get, GetAccepted, GetNoContent,

--- a/servant/src/Servant/API/Generic.hs
+++ b/servant/src/Servant/API/Generic.hs
@@ -37,8 +37,6 @@ module Servant.API.Generic (
     ToServant,
     toServant,
     fromServant,
-    -- * NamedRoutes combinator
-    NamedRoutes,
     -- * AsApi
     AsApi,
     ToServantApi,
@@ -121,9 +119,6 @@ genericApi
     => Proxy routes
     -> Proxy (ToServantApi routes)
 genericApi _ = Proxy
-
--- | Combinator for embedding a record of named routes into a Servant API type.
-data NamedRoutes (api :: * -> *)
 
 -------------------------------------------------------------------------------
 -- Class

--- a/servant/src/Servant/API/Generic.hs
+++ b/servant/src/Servant/API/Generic.hs
@@ -37,6 +37,8 @@ module Servant.API.Generic (
     ToServant,
     toServant,
     fromServant,
+    -- * NamedRoutes combinator
+    NamedRoutes,
     -- * AsApi
     AsApi,
     ToServantApi,
@@ -119,6 +121,9 @@ genericApi
     => Proxy routes
     -> Proxy (ToServantApi routes)
 genericApi _ = Proxy
+
+-- | Combinator for embedding a record of named routes into a Servant API type.
+data NamedRoutes (api :: * -> *)
 
 -------------------------------------------------------------------------------
 -- Class

--- a/servant/src/Servant/API/NamedRoutes.hs
+++ b/servant/src/Servant/API/NamedRoutes.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE KindSignatures #-}
+{-# OPTIONS_HADDOCK not-home    #-}
+
+module Servant.API.NamedRoutes (
+    -- * NamedRoutes combinator
+    NamedRoutes
+  ) where
+
+-- | Combinator for embedding a record of named routes into a Servant API type.
+data NamedRoutes (api :: * -> *)

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -1,21 +1,17 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
-{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE InstanceSigs           #-}
 {-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE QuantifiedConstraints    #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
-
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE QuantifiedConstraints  #-}
-#endif
 
 {-# OPTIONS_HADDOCK not-home        #-}
 
@@ -593,7 +589,6 @@ instance HasLink (UVerb m ct a) where
     toLink toA _ = toA
 -- Instance for NamedRoutes combinator
 
-#if __GLASGOW_HASKELL__ >= 806
 type GLinkConstraints routes a =
   ( MkLink (ToServant routes AsApi) a ~ ToServant routes (AsLink a)
   , GenericServant routes (AsLink a)
@@ -620,7 +615,6 @@ instance
 
   toLink toA _ l = case proof @routes @a of
     Dict -> fromServant $ toLink toA (Proxy @(ToServantApi routes)) l
-#endif
 
 -- AuthProtext instances
 instance HasLink sub => HasLink (AuthProtect tag :> sub) where

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -173,6 +173,8 @@ import           Servant.API.IsSecure
                  (IsSecure)
 import           Servant.API.Modifiers
                  (FoldRequired)
+import           Servant.API.NamedRoutes
+                 (NamedRoutes)
 import           Servant.API.QueryParam
                  (QueryFlag, QueryParam', QueryParams)
 import           Servant.API.Raw


### PR DESCRIPTION
**Update (2021-11-17):**

The PR has significantly changed since its inception, so here is an updated example for newcomers that may want to see the current state. Users can now mark part of an API as being *directly* defined by a record using the `NamedRoutes` combinator. Here is an example:

```haskell
type Api = NamedRoutes RootApi

data RootApi mode = RootApi
  { subApi :: mode :- Capture "token" String :> NamedRoutes SubApi
  , hello :: mode :- Capture "name" String :> Get '[JSON] String
  , …
  } deriving Generic

data SubApi mode = SubApi
  { endpoint :: mode :- Get '[JSON] Person
  , …
  } deriving Generic
```

On the surface, it looks exactly the same as what servant's current support for generics provides, just replacing `ToServantApi` by `NamedRoutes`. The nuance here is that `NamedRoutes` is an actual combinator, while `ToServantApi` is type-family application which converts a record type to a “vanilla” servant product using `:<|>`, and thus loses all naming information. Defining `NamedRoutes` as a combinator allows us to define instances for `HasClient`, `HasServer` etc. which define servers / clients **directly as records**.

The most immediate benefits is that nested records of routes actually works, without the need for ugly, error-prone manual conversions between vanilla servant products and records. 

One can serve the above API as easily as:

```haskell
myApp :: Application
myApp = serve (Proxy @Api) server
  where server = 
    RootApi 
      { subApi = \token -> SubApi
          { endpoint = … }
      , hello = \name -> … 
      }
```

Similarly, generating clients produces nested records as needed. A few helpers (initially suggested by @clementd-fretlink ) have been added for convenience:

```haskell
rootClient :: RootApi (AsClientT ClientM)
rootClient = client (Proxy @API)

hello :: String -> ClientM String
hello name = rootClient // hello /: name

endpointClient :: ClientM Person
endpointClient = client // subApi /: "foobar123" // endpoint
```

An additional benefit is that error messages are now *much nicer*.

***END OF UPDATE***

-------

This pull request implements the ideas sketched in #1315 .

It introduces a new combinator:

```haskell
data GApi (routes :: * -> *)
```

which accepts a generic product of routes and can be embedded into a Servant API.

Instances of `HasClient` and `HasServer` are provided for `GApi routes`. The internal machinery requires
the generic routes to be instances of the  `GClient` and `GServer` typeclasses respectively for this to work. ~The necessary code can written (mostly) automatically for us by the compiler~ (EDIT: `deriving (Generic, GClient, GServer)` is now sufficient):

```haskell
data API' as = API
  { bookStore :: as :- "books" :> GApi BookStore
  , apiVersion :: as :- "version" :> Get '[JSON] Version
  }
  deriving (Generic, GClient)

instance
  (HasContextEntry (context .++ DefaultErrorFormatters) ErrorFormatters) =>
  GServer API' context
```

~The need to specify the context of error formatters for `GServer` is a bit unfortunate, I'd like to find a way to fix this.~ EDIT: Done.

Everything is pretty much automatic from there: defining servers and deriving clients works exactly as one would expect, with no added boilerplate and conversion between vanilla / generic servant types.

A complete example program with nested generic APIs can be found [here](https://gist.github.com/gdeest/ae32ab8db1be6e722b9cfd9c5244f583). This should probably be part of the PR as an example / test somewhere ; I am looking for guidance here.

Now, this PR features a change that I expect to be controversial: it removes the `m` parameter of the `HasClient` typeclass, making it more symmetric with `HasServer`, but breaking every third-party implementation.

This parameter is used to be able to constrain the monads for which a client can be defined (to define them in terms of `RunClient` / `RunStreamingClient`). The problem is that `Client m api` then only makes sense if `m` satisfies those constraints, which gets in the way when implementing `hoistClientMonad` with generics (GHC refuses to apply type families any further and cannot prove type equality when converting between vanilla / generic servant). We cannot add those constraints to the source / target monads, as we may want to hoist clients in monads that do not satisfy them. The solution I have found is to define said constraints as an associated type family:

```haskell
  type ClientConstraints (api :: *) (m :: * -> *) :: Constraint
```

The signature of `clientWithRoute` then becomes:

```haskell
  clientWithRoute :: ClientConstraints api m => Proxy m -> Proxy api -> Request -> Client m api
```
