### PR TITLE
fix wrong markdowntype javascript for json

### DIFF
--- a/doc/tutorial/Docs.lhs
+++ b/doc/tutorial/Docs.lhs
@@ -132,13 +132,13 @@ That lets us see what our API docs look like in markdown, by looking at `markdow
 
 - When a value is provided for 'name' (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"msg":"Hello, Alp"}
     ```
 
 - When 'name' is not specified (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"msg":"Hello, anonymous coward"}
     ```
 
@@ -153,7 +153,7 @@ That lets us see what our API docs look like in markdown, by looking at `markdow
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"clientAge":26,"clientEmail":"alp@foo.com","clientName":"Alp","clientInterestedIn":["haskell","mathematics"]}
     ```
 
@@ -169,7 +169,7 @@ That lets us see what our API docs look like in markdown, by looking at `markdow
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"subject":"Hey Alp, we miss you!","body":"Hi Alp,\n\nSince you've recently turned 26, have you checked out our latest haskell, mathematics products? Give us a visit!","to":"alp@foo.com","from":"great@company.com"}
     ```
 
@@ -192,7 +192,7 @@ That lets us see what our API docs look like in markdown, by looking at `markdow
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"yCoord":14,"xCoord":3}
     ````
 
@@ -242,7 +242,7 @@ The relevant output of `markdown api2Docs` is now:
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-    ```javascript
+    ```json
 {"clientAge":26,"clientEmail":"alp@foo.com","clientName":"Alp","clientInterestedIn":["haskell","mathematics"]}
     ```
 

--- a/servant-docs/example/greet.md
+++ b/servant-docs/example/greet.md
@@ -19,13 +19,13 @@ You'll also note that multiple intros are possible.
 
 - If you use ?capital=true (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 "HELLO, HASKELLER"
 ```
 
 - If you use ?capital=false (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 "Hello, haskeller"
 ```
 
@@ -41,13 +41,13 @@ You'll also note that multiple intros are possible.
 
 - If you use ?capital=true (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 "HELLO, HASKELLER"
 ```
 
 - If you use ?capital=false (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 "Hello, haskeller"
 ```
 
@@ -81,7 +81,7 @@ And some more
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -111,12 +111,12 @@ And some more
 
 - If you use ?capital=true (`application/json;charset=utf-8`, `application/json`, `text/plain;charset=utf-8`):
 
-```javascript
+```json
 "HELLO, HASKELLER"
 ```
 
 - If you use ?capital=false (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 "Hello, haskeller"
 ```

--- a/servant-docs/golden/comprehensive.md
+++ b/servant-docs/golden/comprehensive.md
@@ -12,7 +12,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -30,7 +30,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -48,7 +48,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -70,7 +70,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -92,7 +92,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -114,7 +114,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -135,7 +135,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -160,7 +160,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -178,7 +178,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -200,7 +200,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -218,7 +218,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 17
 ```
 
@@ -240,7 +240,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -262,7 +262,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -280,7 +280,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -298,7 +298,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -316,7 +316,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -341,7 +341,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -366,7 +366,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -392,7 +392,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -410,7 +410,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 17
 ```
 
@@ -446,7 +446,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -461,7 +461,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 17
 ```
 
@@ -477,7 +477,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -492,7 +492,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 17
 ```
 
@@ -508,7 +508,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -526,7 +526,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -568,7 +568,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -586,7 +586,6 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
-

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -809,7 +809,7 @@ markdownWith RenderingOptions{..}  api = unlines $
                 ("text", "html") -> "html"
                 ("application", "xml") -> "xml"
                 ("text", "xml") -> "xml"
-                ("application", "json") -> "javascript"
+                ("application", "json") -> "json"
                 ("application", "javascript") -> "javascript"
                 ("text", "css") -> "css"
                 (_, _) -> ""


### PR DESCRIPTION
This PR fixes servant-docs: Wrong markdowntype javascript for json
https://github.com/haskell-servant/servant/issues/1358