### PR TITLE
Fixing Servant cookbooks part 1 (-testing + sqlite-simple)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ doc/_build
 doc/venv
 doc/tutorial/static/api.js
 doc/tutorial/static/jq.js
-shell.nix
 
 # nix
 result*

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ doc/_build
 doc/venv
 doc/tutorial/static/api.js
 doc/tutorial/static/jq.js
+shell.nix
 
 # nix
 result*

--- a/cabal.project
+++ b/cabal.project
@@ -26,7 +26,7 @@ packages:
   doc/cookbook/custom-errors
   doc/cookbook/basic-streaming
   doc/cookbook/db-postgres-pool
-  -- doc/cookbook/db-sqlite-simple
+  doc/cookbook/db-sqlite-simple
   doc/cookbook/file-upload
   doc/cookbook/generic
   -- doc/cookbook/hoist-server-with-context
@@ -54,9 +54,6 @@ constraints:
 constraints: base-compat ^>=0.11
 constraints: semigroups ^>=0.19
 
--- MonadFail
--- https://github.com/nurpax/sqlite-simple/issues/74
-constraints: sqlite-simple < 0
 -- allow-newer: sqlite-simple-0.4.16.0:semigroups
 -- allow-newer: direct-sqlite-2.3.24:semigroups
 

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -23,7 +23,7 @@ executable cookbook-db-sqlite-simple
                      , http-types >= 0.12
                      , markdown-unlit >= 0.4
                      , http-client >= 0.5
-                     , sqlite-simple >= 0.4
+                     , sqlite-simple >= 0.4.5.0
                      , transformers
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/servant-docs/test/Servant/DocsSpec.hs
+++ b/servant-docs/test/Servant/DocsSpec.hs
@@ -126,8 +126,11 @@ spec = describe "Servant.Docs" $ do
     it "mentions headers" $ do
       md `shouldContain` "- This endpoint is sensitive to the value of the **X-Test** HTTP header."
 
-    it "contains response samples" $
-      md `shouldContain` "{\"dt1field1\":\"field 1\",\"dt1field2\":13}"
+    it "contains response samples - dt1field1" $
+      md `shouldContain` "\"dt1field1\":\"field 1\""
+    it "contains response samples - dt1field2" $
+      md `shouldContain` "\"dt1field2\":13"
+
     it "contains request body samples" $
       md `shouldContain` "17"
 


### PR DESCRIPTION
The scope of this PR, as the others that will follow, is to fix servant cookbooks.

This PR make the project compiling and propose a first step through that goal.

Here are the tasks that have been made : 

- Fixing the network bug
- Commenting servant-quickcheck cookbook which is trapped into a dependency loop for now (see [this issue](https://github.com/haskell-servant/servant-quickcheck/issues/74))
- Fixing DocSpec failing test
- Bringing sqlite-simple cookbook back to life