### PR TITLE
Fixing Servant cookbooks part 2 (+hoist-server-with-context, + jwt-and-basic-auth, +sentry, +https)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,7 +29,7 @@ packages:
   doc/cookbook/db-sqlite-simple
   doc/cookbook/file-upload
   doc/cookbook/generic
-  -- doc/cookbook/hoist-server-with-context
+  doc/cookbook/hoist-server-with-context
   -- doc/cookbook/https
   -- doc/cookbook/jwt-and-basic-auth/
   doc/cookbook/pagination


### PR DESCRIPTION
Following #1397 -> Based on its branch

I may not have the full story here but the following cookbooks are compiling with GHC 8.8.4 :

- hoist-server-with-context
- jwt-and-basic-auth
- sentry
- https