### PR TITLE
Using DerivingVia in UVerb's cookbook

### DIFF
--- a/doc/cookbook/uverb/UVerb.lhs
+++ b/doc/cookbook/uverb/UVerb.lhs
@@ -15,6 +15,7 @@ handlers that respond with arbitrary open unions of types.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/doc/cookbook/uverb/UVerb.lhs
+++ b/doc/cookbook/uverb/UVerb.lhs
@@ -10,6 +10,8 @@ handlers that respond with arbitrary open unions of types.
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -154,12 +156,8 @@ Example usage:
 
 ```haskell
 data Foo = Foo Int Int Int
-  deriving (Show, Eq, GHC.Generic)
-
-instance ToJSON Foo
-
-instance HasStatus Foo where
-  type StatusOf Foo = 200
+  deriving (Show, Eq, GHC.Generic, ToJSON)
+  deriving HasStatus via WithStatus 200 Foo
 
 data Bar = Bar
   deriving (Show, Eq, GHC.Generic)

--- a/doc/cookbook/uverb/UVerb.lhs
+++ b/doc/cookbook/uverb/UVerb.lhs
@@ -4,6 +4,10 @@ Servant allows you to talk about the exceptions you throw in your API
 types.  This is not limited to actual exceptions, you can write
 handlers that respond with arbitrary open unions of types.
 
+## Compatibility
+
+:warning: This cookbook is compatible with GHC 8.6.1 or higher :warning:
+
 ## Preliminaries
 
 ```haskell

--- a/doc/cookbook/uverb/uverb.cabal
+++ b/doc/cookbook/uverb/uverb.cabal
@@ -28,6 +28,8 @@ executable cookbook-uverb
                      , swagger2
                      , wai
                      , warp
-  default-language:    Haskell2010
+  if impl(ghc < 8.6.1)
+        buildable: False
+  default-language: Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends:  markdown-unlit:markdown-unlit


### PR DESCRIPTION
As discussed in https://github.com/haskell-servant/servant/issues/1404 some cookbooks will have a minimal version of GHC, higher than 8.0.2.

Here the first PR to fix UVerb cookbook by using `DerivingVia` and `DerivingStrategies` extensions.

@gdeest Would you please add a minimal GHC constraint for this cookbook into the CI checks plan?