### PR TITLE
enabling https cookbook

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,7 +30,7 @@ packages:
   doc/cookbook/file-upload
   doc/cookbook/generic
   -- doc/cookbook/hoist-server-with-context
-  -- doc/cookbook/https
+  doc/cookbook/https
   -- doc/cookbook/jwt-and-basic-auth/
   doc/cookbook/pagination
   -- doc/cookbook/sentry

--- a/doc/cookbook/https/https.cabal
+++ b/doc/cookbook/https/https.cabal
@@ -17,7 +17,7 @@ executable cookbook-https
                      , servant-server
                      , wai >= 3.2
                      , warp >= 3.2
-                     , warp-tls >= 3.2
+                     , warp-tls >= 3.2.9
                      , markdown-unlit >= 0.4
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit


### PR DESCRIPTION
Related to : https://github.com/haskell-servant/servant/issues/1411

enabling https cookbook