### PR TITLE
enabling hoist-server-with-context cookbook

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,7 +29,7 @@ packages:
   doc/cookbook/db-sqlite-simple
   doc/cookbook/file-upload
   doc/cookbook/generic
-  -- doc/cookbook/hoist-server-with-context
+  doc/cookbook/hoist-server-with-context
   doc/cookbook/https
   -- doc/cookbook/jwt-and-basic-auth/
   doc/cookbook/pagination

--- a/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
+++ b/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
@@ -24,7 +24,7 @@ executable cookbook-hoist-server-with-context
                      , servant
                      , servant-server
                      , servant-auth >= 0.3.2
-                     , servant-auth-server
+                     , servant-auth-server >= 0.4.4.0
                      , time
                      , warp >= 3.2
                      , wai >= 3.2
@@ -32,6 +32,8 @@ executable cookbook-hoist-server-with-context
                      , http-types >= 0.12
                      , bytestring >= 0.10.4
                      , mtl
+  if impl(ghc < 8.2.1)
+    buildable: False
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends:  markdown-unlit:markdown-unlit


### PR DESCRIPTION
Related to https://github.com/haskell-servant/servant/issues/1411

Enabling hoist-server-with-context cookbook

Compability with GHC 8.0.2 has been dropped because `servant-auth-server-0.4.4.0` isn't compatible with it anymore. See : haskell-servant/servant-auth@90d14b4