### PR TITLE
use Capture Description if available

### DIFF
--- a/servant-docs/golden/comprehensive.md
+++ b/servant-docs/golden/comprehensive.md
@@ -52,11 +52,11 @@
 
 ```
 
-## GET /capture/:foo
+## GET /capture/:bar
 
 ### Captures:
 
-- *foo*: example description
+- *bar*: example description
 
 ### Response:
 

--- a/servant-docs/golden/comprehensive.md
+++ b/servant-docs/golden/comprehensive.md
@@ -56,7 +56,7 @@
 
 ### Captures:
 
-- *foo*: Capture foo Int
+- *foo*: example description
 
 ### Response:
 

--- a/servant/src/Servant/Test/ComprehensiveAPI.hs
+++ b/servant/src/Servant/Test/ComprehensiveAPI.hs
@@ -48,7 +48,7 @@ comprehensiveAPIWithoutStreaming = Proxy
 type ComprehensiveAPIWithoutStreamingOrRaw' endpoint =
     GET
     :<|> "get-int"          :> Get '[JSON] Int
-    :<|> "capture"          :> Capture' '[Description "example description"] "foo" Int :> GET
+    :<|> "capture"          :> Capture' '[Description "example description"] "bar" Int :> GET
     :<|> "capture-lenient"  :> Capture' '[Lenient] "foo" Int :> GET
     :<|> "header"           :> Header "foo" Int :> GET
     :<|> "header-lenient"   :> Header' '[Required, Lenient] "bar" Int :> GET


### PR DESCRIPTION
fixes #1422

When a capture includes a description, e.g. `Capture' '[Description "the id of the Foo to retrieve"] "id" Text]` instead of `Capture "id" Text`, the description is now used in the generated documentation. Previously, the `Description` was ignored and the user had to specify an instance repeating both strings at the value level:

    instance ToCapture (Capture "id" Text) where
      toCapture _ = DocCapture "id" "the id of the Foo to retrieve"

[The example `ComprehensiveAPI`](https://github.com/haskell-servant/servant/blob/d06b65c4e6116f992debbac2eeeb83eafb960321/servant/src/Servant/Test/ComprehensiveAPI.hs#L51) already uses both `Capture' '[Description "example description"] "foo" Int` and `Capture "foo" Int`, and ./servant-docs/test/Servant/DocsSpec.hs provides a `ToCapture (Capture "foo" Int)` instance which covers both cases. With this PR, the first capture now uses `example description` instead of that `ToCapture` instance.

This is thus technically a breaking change, because if a `Capture` has both a `Description` and a `ToCapture` instance, the `Description` now takes precedence. Since this `Description` wasn't doing anything before, I am guessing that most projects currently only use `Description` to describe their endpoints and not their `Capture`s, and thus that few people will be affected by this breaking change.

The case I am more interested in is the case in which there is only a `Description` and no `ToCapture` instance; I want to make sure that a `ToCapture` instance is not required. I have thus changed the `ComprehensiveAPI` example from `Capture' '[Description "example description"] "foo" Int` to `Capture' '[Description "example description"] "bar" Int`, this way this parameter has a `Description` but no `ToCapture (Capture "bar" Int)` instance, while the `Capture "foo" Int` parameter still tests the case in which there is a `ToCapture (Capture "foo" Int)` instance but no `Description`.