### PR TITLE
Fix CI by adding a constraint to http-common to make it build against ghc 8.2.2

### DIFF
--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -66,7 +66,7 @@ library
     , http-media            >= 0.7.1.3  && < 0.9
     , io-streams            >= 1.5.0.1  && < 1.6
     , http-types            >= 0.12.2   && < 0.13
-    , http-common           >= 0.8.2.0  && < 0.9
+    , http-common           >= 0.8.2.0  && < 0.8.3
     , exceptions            >= 0.10.0   && < 0.11
     , kan-extensions        >= 5.2      && < 5.3
     , monad-control         >= 1.0.2.3  && < 1.1


### PR DESCRIPTION
Master doesn't compile anymore : 

```
lib/Network/Http/Internal.hs:291:13: error:
Error:     • Variable not in scope: (<>) :: Builder -> Builder -> t7
from servant-http-streams-0.18.3 and test:readme from
    • Perhaps you meant one of these:
        ‘<’ (imported from Prelude), ‘<$>’ (imported from Prelude),
servant-http-streams-0.18.3). See the build log above for details.
        ‘*>’ (imported from Prelude)

    |
291 |             <> dashdash
    |             ^^
```

add a constraint to http-common to make it build against ghc 8.2.2

