### PR TITLE
Update to GHC 9 (sub tasks)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,8 +25,7 @@ packages:
   doc/cookbook/custom-errors
   doc/cookbook/basic-streaming
   doc/cookbook/db-postgres-pool
-  --doc/cookbook/db-sqlite-simple
-  -- ^ BROKEN blaze-textual
+  doc/cookbook/db-sqlite-simple
   doc/cookbook/file-upload
   doc/cookbook/generic
   doc/cookbook/hoist-server-with-context

--- a/cabal.project
+++ b/cabal.project
@@ -36,8 +36,7 @@ packages:
   -- doc/cookbook/sentry
   -- Commented out because servant-quickcheck currently doesn't build.
   -- doc/cookbook/testing
-  --doc/cookbook/uverb
-  -- ^ BROKEN servant-swagger -> optics-th
+  doc/cookbook/uverb
   doc/cookbook/structuring-apis
   doc/cookbook/using-custom-monad
   doc/cookbook/using-free-client

--- a/doc/cookbook/uverb/uverb.cabal
+++ b/doc/cookbook/uverb/uverb.cabal
@@ -28,6 +28,8 @@ executable cookbook-uverb
                      , swagger2
                      , wai
                      , warp
+  if impl(ghc >= 9)
+      buildable: False
   default-language: Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends:  markdown-unlit:markdown-unlit

--- a/nix/README.md
+++ b/nix/README.md
@@ -26,6 +26,7 @@ $ nix-shell nix/shell.nix --argstr compiler ghcHEAD
 -   `ghc865Binary`
 -   `ghc884`
 -   `ghc8104` - default
+-   `ghc901`
 
 ### Cabal users
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,5 @@
 let nixos = fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.05.tar.gz"; 
+                           sha256 = "sha256:1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
 }; in
 
 { compiler ? "ghc8104"


### PR DESCRIPTION
Following #1409

- [X] Adding GHC 9 to the nix README
- [X] Uncomment cookbooks (uvert, db-sqlite-simple) and exclude them from the GHC 9 building plan if needed