### PR TITLE
Derive HasClient good response status from Verb status

### DIFF
--- a/changelog.d/1469
+++ b/changelog.d/1469
@@ -1,0 +1,11 @@
+synopsis: Derive HasClient good response status from Verb status
+prs: #1469
+description: {
+`HasClient` instances for the `Verb` datatype use `runRequest` in
+`clientWithRoute` definitions.
+This means that a request performed with `runClientM` will be successful if and
+only if the endpoint specify a response status code >=200 and <300.
+This change replaces `runRequest` with `runRequestAcceptStatus` in `Verb`
+instances for the `HasClient` class, deriving the good response status from
+the `Verb` status.
+}

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -91,6 +91,8 @@ import           Servant.API.Modifiers
                  (FoldRequired, RequiredArgument, foldRequiredArgument)
 import           Servant.API.UVerb
                  (HasStatus, HasStatuses (Statuses, statuses), UVerb, Union, Unique, inject, statusOf, foldMapUnion, matchUnion)
+import           Servant.API.Status
+                 (KnownStatus, statusVal)
 
 import           Servant.Client.Core.Auth
 import           Servant.Client.Core.BasicAuth
@@ -249,11 +251,12 @@ instance (KnownSymbol capture, ToHttpApiData a, HasClient m sublayout)
 
 instance {-# OVERLAPPABLE #-}
   -- Note [Non-Empty Content Types]
-  ( RunClient m, MimeUnrender ct a, ReflectMethod method, cts' ~ (ct ': cts)
+  ( RunClient m, MimeUnrender ct a, ReflectMethod method, KnownStatus status
+  , cts' ~ (ct ': cts)
   ) => HasClient m (Verb method status cts' a) where
   type Client m (Verb method status cts' a) = m a
   clientWithRoute _pm Proxy req = do
-    response <- runRequest req
+    response <- runRequestAcceptStatus (Just acceptStatus) req
       { requestAccept = fromList $ toList accept
       , requestMethod = method
       }
@@ -261,18 +264,20 @@ instance {-# OVERLAPPABLE #-}
     where
       accept = contentTypes (Proxy :: Proxy ct)
       method = reflectMethod (Proxy :: Proxy method)
+      acceptStatus = [statusVal (Proxy :: Proxy status)]
 
   hoistClientMonad _ _ f ma = f ma
 
 instance {-# OVERLAPPING #-}
-  ( RunClient m, ReflectMethod method
+  ( RunClient m, ReflectMethod method, KnownStatus status
   ) => HasClient m (Verb method status cts NoContent) where
   type Client m (Verb method status cts NoContent)
     = m NoContent
   clientWithRoute _pm Proxy req = do
-    _response <- runRequest req { requestMethod = method }
+    _response <- runRequestAcceptStatus (Just acceptStatus) req { requestMethod = method }
     return NoContent
       where method = reflectMethod (Proxy :: Proxy method)
+            acceptStatus = [statusVal (Proxy :: Proxy status)]
 
   hoistClientMonad _ _ f ma = f ma
 
@@ -289,13 +294,13 @@ instance (RunClient m, ReflectMethod method) =>
 
 instance {-# OVERLAPPING #-}
   -- Note [Non-Empty Content Types]
-  ( RunClient m, MimeUnrender ct a, BuildHeadersTo ls
+  ( RunClient m, MimeUnrender ct a, BuildHeadersTo ls, KnownStatus status
   , ReflectMethod method, cts' ~ (ct ': cts)
   ) => HasClient m (Verb method status cts' (Headers ls a)) where
   type Client m (Verb method status cts' (Headers ls a))
     = m (Headers ls a)
   clientWithRoute _pm Proxy req = do
-    response <- runRequest req
+    response <- runRequestAcceptStatus (Just acceptStatus) req
        { requestMethod = method
        , requestAccept = fromList $ toList accept
        }
@@ -305,17 +310,19 @@ instance {-# OVERLAPPING #-}
                      }
       where method = reflectMethod (Proxy :: Proxy method)
             accept = contentTypes (Proxy :: Proxy ct)
+            acceptStatus = [statusVal (Proxy :: Proxy status)]
 
   hoistClientMonad _ _ f ma = f ma
 
 instance {-# OVERLAPPING #-}
-  ( RunClient m, BuildHeadersTo ls, ReflectMethod method
+  ( RunClient m, BuildHeadersTo ls, ReflectMethod method, KnownStatus status
   ) => HasClient m (Verb method status cts (Headers ls NoContent)) where
   type Client m (Verb method status cts (Headers ls NoContent))
     = m (Headers ls NoContent)
   clientWithRoute _pm Proxy req = do
     let method = reflectMethod (Proxy :: Proxy method)
-    response <- runRequest req { requestMethod = method }
+        acceptStatus = [statusVal (Proxy :: Proxy status)]
+    response <- runRequestAcceptStatus (Just acceptStatus) req { requestMethod = method }
     return $ Headers { getResponse = NoContent
                      , getHeadersHList = buildHeadersTo . toList $ responseHeaders response
                      }
@@ -784,7 +791,7 @@ instance ( HasClient m api
 
 -- | Ignore @'Fragment'@ in client functions.
 -- See <https://ietf.org/rfc/rfc2616.html#section-15.1.3> for more details.
--- 
+--
 -- Example:
 --
 -- > type MyApi = "books" :> Fragment Text :> Get '[JSON] [Book]
@@ -801,7 +808,7 @@ instance (AtLeastOneFragment api, FragmentUnique (Fragment a :> api), HasClient 
 
   type Client m (Fragment a :> api) = Client m api
 
-  clientWithRoute pm _ = clientWithRoute pm (Proxy :: Proxy api) 
+  clientWithRoute pm _ = clientWithRoute pm (Proxy :: Proxy api)
 
   hoistClientMonad pm _ = hoistClientMonad pm (Proxy :: Proxy api)
 

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -89,6 +89,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Servant.BasicAuthSpec
+      Servant.BrokenSpec
       Servant.ClientTestUtils
       Servant.ConnectionErrorSpec
       Servant.FailSpec

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -63,7 +63,7 @@ import           GHC.Generics
 import           Network.HTTP.Media
                  (renderHeader)
 import           Network.HTTP.Types
-                 (hContentType, renderQuery, statusCode, urlEncode, Status)
+                 (hContentType, renderQuery, statusIsSuccessful, urlEncode, Status)
 import           Servant.Client.Core
 
 import qualified Network.HTTP.Client         as Client
@@ -179,10 +179,9 @@ performRequest acceptStatus req = do
 
   response <- maybe (requestWithoutCookieJar m request) (requestWithCookieJar m request) cookieJar'
   let status = Client.responseStatus response
-      status_code = statusCode status
       ourResponse = clientResponseToResponse id response
       goodStatus = case acceptStatus of
-        Nothing -> status_code >= 200 && status_code < 300
+        Nothing -> statusIsSuccessful status
         Just good -> status `elem` good
   unless goodStatus $ do
     throwError $ mkFailureResponse burl req ourResponse

--- a/servant-client/test/Servant/BrokenSpec.hs
+++ b/servant-client/test/Servant/BrokenSpec.hs
@@ -38,9 +38,9 @@ brokenServer :: Application
 brokenServer = serve brokenApi (pure () :<|> pure ())
 
 type PublicAPI =
-  -- the client expcets 200
+  -- the client expects 200
        "get200" :> Get '[JSON] ()
-  -- the client expcets 307
+  -- the client expects 307
   :<|> "get307" :> Get307 '[JSON] ()
 
 publicApi :: Proxy PublicAPI

--- a/servant-client/test/Servant/BrokenSpec.hs
+++ b/servant-client/test/Servant/BrokenSpec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds                   #-}
+{-# LANGUAGE TypeOperators               #-}
+{-# OPTIONS_GHC -freduction-depth=100    #-}
+{-# OPTIONS_GHC -fno-warn-orphans        #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
+module Servant.BrokenSpec (spec) where
+
+import           Prelude ()
+import           Prelude.Compat
+
+import           Data.Monoid ()
+import           Data.Proxy
+import qualified Network.HTTP.Types as HTTP
+import           Test.Hspec
+
+import           Servant.API
+                 ((:<|>) ((:<|>)), (:>), JSON, Verb, Get, StdMethod (GET))
+import           Servant.Client
+import           Servant.ClientTestUtils
+import           Servant.Server
+
+-- * api for testing inconsistencies between client and server
+
+type Get201 = Verb 'GET 201
+type Get301 = Verb 'GET 301
+
+type BrokenAPI =
+  -- the server should respond with 200, but returns 201
+       "get200" :> Get201 '[JSON] ()
+  -- the server should respond with 307, but returns 301
+  :<|> "get307" :> Get301 '[JSON] ()
+
+brokenApi :: Proxy BrokenAPI
+brokenApi = Proxy
+
+brokenServer :: Application
+brokenServer = serve brokenApi (pure () :<|> pure ())
+
+type PublicAPI =
+  -- the client expcets 200
+       "get200" :> Get '[JSON] ()
+  -- the client expcets 307
+  :<|> "get307" :> Get307 '[JSON] ()
+
+publicApi :: Proxy PublicAPI
+publicApi = Proxy
+
+get200Client :: ClientM ()
+get307Client :: ClientM ()
+get200Client :<|> get307Client = client publicApi
+
+
+spec :: Spec
+spec = describe "Servant.BrokenSpec" $ do
+    brokenSpec
+
+brokenSpec :: Spec
+brokenSpec = beforeAll (startWaiApp brokenServer) $ afterAll endWaiApp $ do
+    context "client returns errors for inconsistencies between client and server api" $ do
+      it "reports FailureResponse with wrong 2xx status code" $ \(_, baseUrl) -> do
+        res <- runClient get200Client baseUrl
+        case res of
+          Left (FailureResponse _ r) | responseStatusCode r == HTTP.status201 -> return ()
+          _ -> fail $ "expected 201 broken response, but got " <> show res
+
+      it "reports FailureResponse with wrong 3xx status code" $ \(_, baseUrl) -> do
+        res <- runClient get307Client baseUrl
+        case res of
+          Left (FailureResponse _ r) | responseStatusCode r == HTTP.status301 -> return ()
+          _ -> fail $ "expected 301 broken response, but got " <> show res

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -64,7 +64,7 @@ import           Servant.API
                  JSON, MimeRender (mimeRender), MimeUnrender (mimeUnrender),
                  NoContent (NoContent), PlainText, Post, QueryFlag, QueryParam,
                  QueryParams, Raw, ReqBody, StdMethod (GET), ToHttpApiData (..), UVerb, Union,
-                 WithStatus (WithStatus), NamedRoutes, addHeader)
+                 Verb, WithStatus (WithStatus), NamedRoutes, addHeader)
 import           Servant.API.Generic ((:-))
 import           Servant.Client
 import qualified Servant.Client.Core.Auth         as Auth
@@ -125,6 +125,7 @@ type Api =
   :<|> "capture" :> Capture "name" String :> Get '[JSON,FormUrlEncoded] Person
   :<|> "captureAll" :> CaptureAll "names" String :> Get '[JSON] [Person]
   :<|> "body" :> ReqBody '[FormUrlEncoded,JSON] Person :> Post '[JSON] Person
+  :<|> "redirection" :> Verb 'GET 301 '[PlainText] Text
   :<|> "param" :> QueryParam "name" String :> Get '[FormUrlEncoded,JSON] Person
   -- This endpoint makes use of a 'Raw' server because it is not currently
   -- possible to handle arbitrary binary query param values with
@@ -164,6 +165,7 @@ getDeleteEmpty  :: ClientM NoContent
 getCapture      :: String -> ClientM Person
 getCaptureAll   :: [String] -> ClientM [Person]
 getBody         :: Person -> ClientM Person
+getRedirection  :: ClientM Text
 getQueryParam   :: Maybe String -> ClientM Person
 getQueryParamBinary :: Maybe UrlEncodedByteString -> HTTP.Method -> ClientM Response
 getQueryParams  :: [String] -> ClientM [Person]
@@ -190,6 +192,7 @@ getRoot
   :<|> getCapture
   :<|> getCaptureAll
   :<|> getBody
+  :<|> getRedirection
   :<|> getQueryParam
   :<|> getQueryParamBinary
   :<|> getQueryParams
@@ -216,6 +219,7 @@ server = serve api (
   :<|> (\ name -> return $ Person name 0)
   :<|> (\ names -> return (zipWith Person names [0..]))
   :<|> return
+  :<|> return "redirecting"
   :<|> (\ name -> case name of
                    Just "alice" -> return alice
                    Just n -> throwError $ ServerError 400 (n ++ " not found") "" []

--- a/servant-client/test/Servant/FailSpec.hs
+++ b/servant-client/test/Servant/FailSpec.hs
@@ -38,14 +38,14 @@ failSpec = beforeAll (startWaiApp failServer) $ afterAll endWaiApp $ do
 
     context "client returns errors appropriately" $ do
       it "reports FailureResponse" $ \(_, baseUrl) -> do
-        let (_ :<|> _ :<|> getDeleteEmpty :<|> _) = client api
+        let (_ :<|> _ :<|> _ :<|> getDeleteEmpty :<|> _) = client api
         Left res <- runClient getDeleteEmpty baseUrl
         case res of
           FailureResponse _ r | responseStatusCode r == HTTP.status404 -> return ()
           _ -> fail $ "expected 404 response, but got " <> show res
 
       it "reports DecodeFailure" $ \(_, baseUrl) -> do
-        let (_ :<|> _ :<|> _ :<|> getCapture :<|> _) = client api
+        let (_ :<|> _ :<|> _ :<|> _ :<|> getCapture :<|> _) = client api
         Left res <- runClient (getCapture "foo") baseUrl
         case res of
           DecodeFailure _ _ -> return ()
@@ -72,7 +72,7 @@ failSpec = beforeAll (startWaiApp failServer) $ afterAll endWaiApp $ do
           _ -> fail $ "expected UnsupportedContentType, but got " <> show res
 
       it "reports InvalidContentTypeHeader" $ \(_, baseUrl) -> do
-        let (_ :<|> _ :<|> _ :<|> _ :<|> _ :<|> getBody :<|> _) = client api
+        let (_ :<|> _ :<|> _ :<|> _ :<|> _ :<|> _ :<|> getBody :<|> _) = client api
         Left res <- runClient (getBody alice) baseUrl
         case res of
           InvalidContentTypeHeader _ -> return ()

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -59,11 +59,15 @@ spec = describe "Servant.SuccessSpec" $ do
 
 successSpec :: Spec
 successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
-    it "Servant.API.Get root" $ \(_, baseUrl) -> do
-      left show <$> runClient getRoot baseUrl  `shouldReturn` Right carol
+    describe "Servant.API.Get" $ do
+      it "get root endpoint" $ \(_, baseUrl) -> do
+        left show <$> runClient getRoot baseUrl  `shouldReturn` Right carol
 
-    it "Servant.API.Get" $ \(_, baseUrl) -> do
-      left show <$> runClient getGet baseUrl  `shouldReturn` Right alice
+      it "get simple endpoint" $ \(_, baseUrl) -> do
+        left show <$> runClient getGet baseUrl  `shouldReturn` Right alice
+
+      it "get redirection endpoint" $ \(_, baseUrl) -> do
+        left show <$> runClient getGet307 baseUrl `shouldReturn` Right "redirecting"
 
     describe "Servant.API.Delete" $ do
       it "allows empty content type" $ \(_, baseUrl) -> do
@@ -82,9 +86,6 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
     it "Servant.API.ReqBody" $ \(_, baseUrl) -> do
       let p = Person "Clara" 42
       left show <$> runClient (getBody p) baseUrl `shouldReturn` Right p
-
-    it "Servant.API.Get redirection" $ \(_, baseUrl) -> do
-      left show <$> runClient getRedirection baseUrl `shouldReturn` Right "redirecting"
 
     it "Servant.API FailureResponse" $ \(_, baseUrl) -> do
       left show <$> runClient (getQueryParam (Just "alice")) baseUrl `shouldReturn` Right alice

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -83,6 +83,9 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
       let p = Person "Clara" 42
       left show <$> runClient (getBody p) baseUrl `shouldReturn` Right p
 
+    it "Servant.API.Get redirection" $ \(_, baseUrl) -> do
+      left show <$> runClient getRedirection baseUrl `shouldReturn` Right "redirecting"
+
     it "Servant.API FailureResponse" $ \(_, baseUrl) -> do
       left show <$> runClient (getQueryParam (Just "alice")) baseUrl `shouldReturn` Right alice
       Left (FailureResponse req _) <- runClient (getQueryParam (Just "bob")) baseUrl
@@ -111,6 +114,7 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
 
     it "Servant.API.Fragment" $ \(_, baseUrl) -> do
       left id <$> runClient getFragment baseUrl `shouldReturn` Right alice
+
     it "Servant.API.Raw on success" $ \(_, baseUrl) -> do
       res <- runClient (getRawSuccess HTTP.methodGet) baseUrl
       case res of
@@ -156,7 +160,7 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
       -- In proper situation, extra headers should probably be visible in API type.
       -- However, testing for response timeout is difficult, so we test with something which is easy to observe
       let createClientRequest url r = (defaultMakeClientRequest url r) { C.requestHeaders = [("X-Added-Header", "XXX")] }
-      let clientEnv = (mkClientEnv mgr baseUrl) { makeClientRequest = createClientRequest }
+          clientEnv = (mkClientEnv mgr baseUrl) { makeClientRequest = createClientRequest }
       res <- runClientM (getRawSuccessPassHeaders HTTP.methodGet) clientEnv
       case res of
         Left e ->

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -56,7 +56,7 @@ import qualified Data.Text                                  as T
 import           Data.Typeable
 import           GHC.Generics
 import           GHC.TypeLits
-                 (KnownNat, KnownSymbol, natVal, symbolVal)
+                 (KnownNat, KnownSymbol, symbolVal)
 import qualified Network.HTTP.Media                         as NHM
 import           Network.HTTP.Types                         hiding
                  (Header, ResponseHeaders)
@@ -87,6 +87,8 @@ import           Servant.API.Modifiers
                  unfoldRequestArgument)
 import           Servant.API.ResponseHeaders
                  (GetHeaders, Headers, getHeaders, getResponse)
+import           Servant.API.Status
+                 (statusFromNat)
 import qualified Servant.Types.SourceT                      as S
 import           Web.HttpApiData
                  (FromHttpApiData, parseHeader, parseQueryParam, parseUrlPiece,
@@ -298,7 +300,7 @@ instance {-# OVERLAPPABLE #-}
 
   route Proxy _ = methodRouter ([],) method (Proxy :: Proxy ctypes) status
     where method = reflectMethod (Proxy :: Proxy method)
-          status = toEnum . fromInteger $ natVal (Proxy :: Proxy status)
+          status = statusFromNat (Proxy :: Proxy status)
 
 instance {-# OVERLAPPING #-}
          ( AllCTRender ctypes a, ReflectMethod method, KnownNat status
@@ -310,7 +312,7 @@ instance {-# OVERLAPPING #-}
 
   route Proxy _ = methodRouter (\x -> (getHeaders x, getResponse x)) method (Proxy :: Proxy ctypes) status
     where method = reflectMethod (Proxy :: Proxy method)
-          status = toEnum . fromInteger $ natVal (Proxy :: Proxy status)
+          status = statusFromNat (Proxy :: Proxy status)
 
 instance (ReflectMethod method) =>
          HasServer (NoContentVerb method) context where
@@ -331,7 +333,7 @@ instance {-# OVERLAPPABLE #-}
 
   route Proxy _ = streamRouter ([],) method status (Proxy :: Proxy framing) (Proxy :: Proxy ctype)
       where method = reflectMethod (Proxy :: Proxy method)
-            status = toEnum . fromInteger $ natVal (Proxy :: Proxy status)
+            status = statusFromNat (Proxy :: Proxy status)
 
 
 instance {-# OVERLAPPING #-}
@@ -345,7 +347,7 @@ instance {-# OVERLAPPING #-}
 
   route Proxy _ = streamRouter (\x -> (getHeaders x, getResponse x)) method status (Proxy :: Proxy framing) (Proxy :: Proxy ctype)
       where method = reflectMethod (Proxy :: Proxy method)
-            status = toEnum . fromInteger $ natVal (Proxy :: Proxy status)
+            status = statusFromNat (Proxy :: Proxy status)
 
 
 streamRouter :: forall ctype a c chunk env framing. (MimeRender ctype chunk, FramingRender framing, ToSourceIO chunk a) =>

--- a/servant/src/Servant/API/Status.hs
+++ b/servant/src/Servant/API/Status.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Servant.API.Status where
 
+import GHC.TypeLits (KnownNat, natVal)
 import Network.HTTP.Types.Status
-import GHC.TypeLits
 
 -- | Retrieve a known or unknown Status from a KnownNat
 statusFromNat :: forall a proxy. KnownNat a => proxy a -> Status

--- a/servant/src/Servant/API/Status.hs
+++ b/servant/src/Servant/API/Status.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 -- Flexible instances is necessary on GHC 8.4 and earlier
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Servant.API.Status where
 
 import Network.HTTP.Types.Status
 import GHC.TypeLits
+
+-- | Retrieve a known or unknown Status from a KnownNat
+statusFromNat :: forall a proxy. KnownNat a => proxy a -> Status
+statusFromNat = toEnum . fromInteger . natVal
 
 -- | Witness that a type-level natural number corresponds to a HTTP status code
 class KnownNat n => KnownStatus n where


### PR DESCRIPTION
Hi Everyone,
There's a limitation/bug in the `HasClient` instances for the `Verb` datatype.
If I try to perform a client request with `runClientM`, I'll obtain a successful response if and only if the backend endpoint returns a response with status code >=200 and <300. This is due to the use of `runRequest` in the `clientWithRoute` definitions.

This PR brings the following changes:
- Replace `runRequest` with `runRequestAcceptStatus` in the `Verb` instances for the `HasClient` class (as suggested by @alpmestan).
- Derive the good response status from the `Verb` status.
- Use `statusIsSuccessful` from `Network.HTTP.Types.Status` to lighten the code (not required to solve the issue).
