### PR TITLE
Fix tests for some servant-auth pkgs on GHC 9

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ packages:
   doc/cookbook/generic
   doc/cookbook/hoist-server-with-context
   doc/cookbook/https
-  -- doc/cookbook/jwt-and-basic-auth/
+  doc/cookbook/jwt-and-basic-auth
   doc/cookbook/pagination
   -- doc/cookbook/sentry
   -- Commented out because servant-quickcheck currently doesn't build.

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -22,7 +22,7 @@ executable cookbook-jwt-and-basic-auth
                      , servant
                      , servant-client
                      , servant-server
-                     , servant-auth ==0.3.*
+                     , servant-auth == 0.4.*
                      , servant-auth-server >= 0.3.1.0
                      , warp >= 3.2
                      , wai >= 3.2

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -59,8 +59,6 @@ test-suite spec
     , servant-auth
     , servant
     , servant-auth-client
-  if impl(ghc >= 9)
-    buildable: False
  
   -- test dependencies
   build-depends:

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base                    >= 4.10     && < 4.16
     , aeson                   >= 1.3.1.1  && < 1.6
-    , base64-bytestring       >= 1.0.0.1  && < 1.2
+    , base64-bytestring       >= 1.0.0.1  && < 1.3
     , blaze-builder           >= 0.4.1.0  && < 0.5
     , bytestring              >= 0.10.6.0 && < 0.11
     , case-insensitive        >= 1.2.0.11 && < 1.3
@@ -54,6 +54,13 @@ library
     , time                    >= 1.5.0.1  && < 1.10
     , unordered-containers    >= 0.2.9.0  && < 0.3
     , wai                     >= 3.2.1.2  && < 3.3
+
+  if impl(ghc >= 9)
+    build-depends:
+      -- base64-bytestring 1.2.1.0 contains important fix for GHC-9, lower versions
+      -- produce wrong results, thus corrupring JWT via jose package.
+      -- See: https://github.com/haskell/base64-bytestring/pull/46
+      base64-bytestring       >= 1.2.1.0
 
   exposed-modules:
       Servant.Auth.Server
@@ -87,8 +94,6 @@ test-suite readme
   default-language: Haskell2010
   if impl(ghcjs)
     buildable: False
-  if impl(ghc >= 9)
-    buildable: False
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -114,8 +119,6 @@ test-suite spec
     , servant
     , servant-server
     , transformers
-  if impl(ghc >= 9)
-    buildable: False
 
   -- test dependencies
   build-depends:


### PR DESCRIPTION
Turns out the tests broke because of base64-bytestring issue specific to
GHC-9 that was fixed in 1.2.1.0.

Fixes #1473
Fixes #1474