### PR TITLE
Enable FlexibleContexts in Servant.API.ContentTypes

### DIFF
--- a/changelog.d/1477
+++ b/changelog.d/1477
@@ -1,0 +1,9 @@
+synopsis: Enable FlexibleContexts in Servant.API.ContentTypes
+prs: #1477
+
+description: {
+
+Starting with GHC 9.2, UndecidableInstances no longer implies FlexibleContexts.
+Add this extension where it's needed to make compilation succeed.
+
+}

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}


### PR DESCRIPTION
Starting with GHC 9.2, UndecidableInstances no longer implies FlexibleContexts.
Add this extension where it's needed to make compilation succeed.