### PR TITLE
Get rid of Unicode in err404 example

### DIFF
--- a/servant-server/src/Servant/Server/Internal/ServerError.hs
+++ b/servant-server/src/Servant/Server/Internal/ServerError.hs
@@ -187,7 +187,7 @@ err403 = ServerError { errHTTPCode = 403
 -- Example:
 --
 -- > failingHandler :: Handler ()
--- > failingHandler = throwError $ err404 { errBody = "(╯°□°）╯︵ ┻━┻)." }
+-- > failingHandler = throwError $ err404 { errBody = "Are you lost?" }
 --
 err404 :: ServerError
 err404 = ServerError { errHTTPCode = 404


### PR DESCRIPTION
ServerError field errBody uses ByteString, whose IsString instance kills
Unicode, thus turning example into garbage. Changed it to simple ASCII
string, since Unicode art did not exactly correspond to 404 error
anyway.

Fixes #1371