### PR TITLE
Change the license value to a valid SPDX identifier

### DIFF
--- a/doc/cookbook/basic-auth/basic-auth.cabal
+++ b/doc/cookbook/basic-auth/basic-auth.cabal
@@ -2,7 +2,7 @@ name:                cookbook-basic-auth
 version:             0.1
 synopsis:            Basic Authentication cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/basic-streaming/basic-streaming.cabal
+++ b/doc/cookbook/basic-streaming/basic-streaming.cabal
@@ -2,7 +2,7 @@ name:                cookbook-basic-streaming
 version:             2.1
 synopsis:            Streaming in servant without streaming libs
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/curl-mock/curl-mock.cabal
+++ b/doc/cookbook/curl-mock/curl-mock.cabal
@@ -2,7 +2,7 @@ name:                cookbook-curl-mock
 version:             0.1
 synopsis:            Generate curl mock requests cookbook example
 homepage:            http://docs.servant.dev
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/custom-errors/custom-errors.cabal
+++ b/doc/cookbook/custom-errors/custom-errors.cabal
@@ -2,7 +2,7 @@ name:                cookbook-custom-errors
 version:             0.1
 synopsis:            Return custom error messages from combinators
 homepage:            http://docs.servant.dev
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/db-mysql-basics/mysql-basics.cabal
+++ b/doc/cookbook/db-mysql-basics/mysql-basics.cabal
@@ -2,7 +2,7 @@ name:                mysql-basics
 version:             0.1.0.0
 synopsis:            Simple MySQL API cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -2,7 +2,7 @@ name:                cookbook-db-postgres-pool
 version:             0.1
 synopsis:            Simple PostgreSQL connection pool cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -2,7 +2,7 @@ name:                cookbook-db-sqlite-simple
 version:             0.1
 synopsis:            Simple SQLite DB cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/file-upload/file-upload.cabal
+++ b/doc/cookbook/file-upload/file-upload.cabal
@@ -2,7 +2,7 @@ name:                cookbook-file-upload
 version:             0.1
 synopsis:            File upload cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/generic/generic.cabal
+++ b/doc/cookbook/generic/generic.cabal
@@ -2,7 +2,7 @@ name:                cookbook-generic
 version:             0.1
 synopsis:            Using custom monad to pass a state between handlers
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
+++ b/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
@@ -4,7 +4,7 @@ synopsis:            JWT and basic access authentication with a Custom Monad coo
 description:         Using servant-auth to support both JWT-based and basic
                      authentication.
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/https/https.cabal
+++ b/doc/cookbook/https/https.cabal
@@ -2,7 +2,7 @@ name:                cookbook-https
 version:             0.1
 synopsis:            HTTPS cookbook example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -4,7 +4,7 @@ synopsis:            JWT and basic access authentication cookbook example
 description:         Using servant-auth to support both JWT-based and basic
                      authentication.
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/open-id-connect/OpenIdConnect.cabal
+++ b/doc/cookbook/open-id-connect/OpenIdConnect.cabal
@@ -2,7 +2,7 @@ name:           open-id-connect
 version:        0.1
 synopsis:       OpenId Connect with Servant example
 homepage:       http://haskell-servant.readthedocs.org/
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   ../../../servant/LICENSE
 author:         Servant Contributors
 maintainer:     haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/pagination/pagination.cabal
+++ b/doc/cookbook/pagination/pagination.cabal
@@ -2,7 +2,7 @@ name:                cookbook-pagination
 version:             2.1
 synopsis:            Pagination with Servant example
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/sentry/sentry.cabal
+++ b/doc/cookbook/sentry/sentry.cabal
@@ -2,7 +2,7 @@ name:                cookbook-sentry
 version:             0.1
 synopsis:            Collecting runtime exceptions using Sentry
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/structuring-apis/structuring-apis.cabal
+++ b/doc/cookbook/structuring-apis/structuring-apis.cabal
@@ -2,7 +2,7 @@ name:                cookbook-structuring-apis
 version:             0.1
 synopsis:            Example that shows how APIs can be structured
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/testing/testing.cabal
+++ b/doc/cookbook/testing/testing.cabal
@@ -3,7 +3,7 @@ version:             0.0.1
 synopsis:            Common testing patterns in Servant apps
 description:         This recipe includes various strategies for writing tests for Servant.
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/using-custom-monad/using-custom-monad.cabal
+++ b/doc/cookbook/using-custom-monad/using-custom-monad.cabal
@@ -2,7 +2,7 @@ name:                cookbook-using-custom-monad
 version:             0.1
 synopsis:            Using custom monad to pass a state between handlers
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/using-free-client/using-free-client.cabal
+++ b/doc/cookbook/using-free-client/using-free-client.cabal
@@ -2,7 +2,7 @@ name:                cookbook-using-free-client
 version:             0.1
 synopsis:            Using Free client
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/cookbook/uverb/uverb.cabal
+++ b/doc/cookbook/uverb/uverb.cabal
@@ -3,7 +3,7 @@ version:             0.0.1
 synopsis:            How to use the 'UVerb' type.
 description:         Listing alternative responses and exceptions in your API types.
 homepage:            http://docs.servant.dev/
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        ../../../servant/LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -6,7 +6,7 @@ description:
   <http://docs.servant.dev/>
 homepage:            http://docs.servant.dev/
 category:            Servant, Documentation
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -13,7 +13,7 @@ bug-reports:    https://github.com/haskell-servant/servant/issues
 author:         Julian K. Arni
 maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 tested-with:    GHC ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 build-type:     Simple

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -13,7 +13,7 @@ bug-reports:    https://github.com/haskell-servant/servant/issues
 author:         Julian K. Arni
 maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 tested-with:    GHC ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 build-type:     Custom

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -13,7 +13,7 @@ bug-reports:    https://github.com/haskell-servant/servant/issues
 author:         Julian K. Arni
 maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 tested-with:    GHC ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 build-type:     Simple

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -13,7 +13,7 @@ bug-reports:    https://github.com/haskell-servant/servant/issues
 author:         Julian K. Arni
 maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 tested-with:    GHC ==8.6.5 || ==8.8.4 || ==8.10.4
 build-type:     Simple

--- a/servant-auth/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth/servant-auth.cabal
@@ -15,7 +15,7 @@ bug-reports:    https://github.com/haskell-servant/servant/issues
 author:         Julian K. Arni
 maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 tested-with:    GHC ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 build-type:     Simple

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -10,7 +10,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -15,7 +15,7 @@ description:
 
 homepage:           http://docs.servant.dev/
 bug-reports:        http://github.com/haskell-servant/servant/issues
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Servant Contributors
 maintainer:         haskell-servant-maintainers@googlegroups.com

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -14,7 +14,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -10,7 +10,7 @@ description:         Servant Stream support for conduit.
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -13,7 +13,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -15,7 +15,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -14,7 +14,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -10,7 +10,7 @@ description:         Servant Stream support for machines.
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -10,7 +10,7 @@ description:         Servant Stream support for pipes.
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -17,7 +17,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -13,7 +13,7 @@ description:
 
 homepage:            http://docs.servant.dev/
 bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com


### PR DESCRIPTION
With cabal 3.0, `license` values need to be valid SPDX identifiers. This PR replaces all occurrences of BSD3 in cabal files with `BSD-3-Clause`. 