### PR TITLE
Rename proof to g{Client,Server,Link}Proof

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -828,10 +828,10 @@ type GClientConstraints api m =
   )
 
 class GClient (api :: * -> *) m where
-  proof :: Dict (GClientConstraints api m)
+  gClientProof :: Dict (GClientConstraints api m)
 
 instance GClientConstraints api m => GClient api m where
-  proof = Dict
+  gClientProof = Dict
 
 instance
   ( forall n. GClient api n
@@ -843,7 +843,7 @@ instance
 
   clientWithRoute :: Proxy m -> Proxy (NamedRoutes api) -> Request -> Client m (NamedRoutes api)
   clientWithRoute pm _ request =
-    case proof @api @m of
+    case gClientProof @api @m of
       Dict -> fromServant $ clientWithRoute  pm (Proxy @(ToServantApi api)) request
 
   hoistClientMonad
@@ -854,7 +854,7 @@ instance
     -> Client ma (NamedRoutes api)
     -> Client mb (NamedRoutes api)
   hoistClientMonad _ _ nat clientA =
-    case (proof @api @ma, proof @api @mb) of
+    case (gClientProof @api @ma, gClientProof @api @mb) of
       (Dict, Dict) ->
         fromServant @api @(AsClientT mb) $
         hoistClientMonad @m @(ToServantApi api) @ma @mb Proxy Proxy nat $

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -928,13 +928,13 @@ type GServerConstraints api m =
 -- is provided in this module for all record APIs.
 
 class GServer (api :: * -> *) (m :: * -> *) where
-  proof :: Dict (GServerConstraints api m)
+  gServerProof :: Dict (GServerConstraints api m)
 
 instance
   ( ToServant api (AsServerT m) ~ ServerT (ToServantApi api) m
   , GServantProduct (Rep (api (AsServerT m)))
   ) => GServer api m where
-  proof = Dict
+  gServerProof = Dict
 
 instance
   ( HasServer (ToServantApi api) context
@@ -950,7 +950,7 @@ instance
     -> Delayed env (api (AsServerT Handler))
     -> Router env
   route _ ctx delayed =
-    case proof @api @Handler of
+    case gServerProof @api @Handler of
       Dict -> route (Proxy @(ToServantApi api)) ctx (toServant <$> delayed)
 
   hoistServerWithContext
@@ -960,7 +960,7 @@ instance
     -> api (AsServerT m)
     -> api (AsServerT n)
   hoistServerWithContext _ pctx nat server =
-    case (proof @api @m, proof @api @n) of
+    case (gServerProof @api @m, gServerProof @api @n) of
       (Dict, Dict) ->
         fromServant servantSrvN
         where

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -595,10 +595,10 @@ type GLinkConstraints routes a =
   )
 
 class GLink (routes :: * -> *) (a :: *) where
-  proof :: Dict (GLinkConstraints routes a)
+  gLinkProof :: Dict (GLinkConstraints routes a)
 
 instance GLinkConstraints routes a => GLink routes a where
-  proof = Dict
+  gLinkProof = Dict
 
 instance
   ( HasLink (ToServantApi routes)
@@ -613,7 +613,7 @@ instance
     -> Link
     -> routes (AsLink a)
 
-  toLink toA _ l = case proof @routes @a of
+  toLink toA _ l = case gLinkProof @routes @a of
     Dict -> fromServant $ toLink toA (Proxy @(ToServantApi routes)) l
 
 -- AuthProtext instances


### PR DESCRIPTION
Renaming cleanup for #1388 .