### PR TITLE
Add details about AddHeaders instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/venv
 doc/tutorial/static/api.js
 doc/tutorial/static/jq.js
 shell.nix
+.hspec-failures
 
 # nix
 result*

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -112,7 +112,7 @@ instance {-# OVERLAPPABLE #-} ( FromHttpApiData v, BuildHeadersTo xs, KnownSymbo
              `HCons` buildHeadersTo headers
           Right h   -> Header h `HCons` buildHeadersTo headers
 
--- * Getting
+-- * Getting headers
 
 class GetHeaders ls where
     getHeaders :: ls -> [HTTP.Header]
@@ -153,7 +153,7 @@ instance (KnownSymbol h, GetHeadersFromHList rest, ToHttpApiData v)
   where
     getHeaders' hs = getHeadersFromHList $ getHeadersHList hs
 
--- * Adding headers to a response
+-- * Adding headers
 
 -- We need all these fundeps to save type inference
 class AddHeader h v orig new


### PR DESCRIPTION
This PR describes the behaviour of the two `AddHeader` instances. These comments are implementation-specific and should not be needed by users.