### PR TITLE
Fix Request's Show instance

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Request.hs
@@ -78,12 +78,13 @@ instance (Show a, Show b) =>
         . showString ", requestAccept = "
         . showsPrec 0 (requestAccept req)
         . showString ", requestHeaders = "
-        . showsPrec 0 (redactSensitiveHeader <$> requestHeaders req))
+        . showsPrec 0 (redactSensitiveHeader <$> requestHeaders req)
         . showString ", requestHttpVersion = "
         . showsPrec 0 (requestHttpVersion req)
         . showString ", requestMethod = "
         . showsPrec 0 (requestMethod req)
         . showString "}"
+        )
        where
         redactSensitiveHeader :: Header -> Header
         redactSensitiveHeader ("Authorization", _) = ("Authorization", "<REDACTED>")

--- a/servant-client-core/test/Servant/Client/Core/RequestSpec.hs
+++ b/servant-client-core/test/Servant/Client/Core/RequestSpec.hs
@@ -10,10 +10,22 @@ import           Data.List (isInfixOf)
 import           Servant.Client.Core.Request
 import           Test.Hspec
 
+newtype DataWithRequest = DataWithRequest (RequestF RequestBody ())
+  deriving Show
+
 spec :: Spec
 spec = do
   describe "Request" $ do
     describe "show" $ do
+      it "has parenthesis correctly positioned" $ do
+        let d = DataWithRequest (void defaultRequest)
+        show d `shouldBe` "DataWithRequest (Request {requestPath = ()\
+                                                  \, requestQueryString = fromList []\
+                                                  \, requestBody = Nothing\
+                                                  \, requestAccept = fromList []\
+                                                  \, requestHeaders = fromList []\
+                                                  \, requestHttpVersion = HTTP/1.1\
+                                                  \, requestMethod = \"GET\"})"
       it "redacts the authorization header" $ do
         let request = void $ defaultRequest { requestHeaders = pure ("authorization", "secret") }
         isInfixOf "secret" (show request) `shouldBe` False


### PR DESCRIPTION
A parenthesis was misplaced in the manually written `Show` instance of `RequestF` which had the consequence of misplacing the parenthesis if the `RequestF` was embedded in another type.

Here is the test failure with the original code:
```
expected: "DataWithRequest (Request {requestPath = (), requestQueryString = fromList [], requestBody = Nothing, requestAccept = fromList [], requestHeaders = fromList [], requestHttpVersion = HTTP/1.1, requestMethod = \"GET\"})"
 but got: "DataWithRequest (Request {requestPath = (), requestQueryString = fromList [], requestBody = Nothing, requestAccept = fromList [], requestHeaders = fromList []), requestHttpVersion = HTTP/1.1, requestMethod = \"GET\"}"
```
Notice how the `)` got moved from the finish to after `requestHeaders`.