### PR TITLE
Add HeadNoContent to Servant.API.Verbs

### DIFF
--- a/servant/src/Servant/API/Verbs.hs
+++ b/servant/src/Servant/API/Verbs.hs
@@ -128,7 +128,8 @@ type DeleteNoContent = NoContentVerb 'DELETE
 type PatchNoContent  = NoContentVerb 'PATCH
 -- | 'PUT' with 204 status code.
 type PutNoContent    = NoContentVerb 'PUT
-
+-- | 'HEAD' with 204 status code.
+type HeadNoContent   = NoContentVerb 'HEAD
 
 -- ** 205 Reset Content
 --


### PR DESCRIPTION
As the head method isn't allowed to contain any response body, no
general Head Verb is added. (This may easily lead to wrong usages...)

(https://httpwg.org/specs/rfc7231.html#HEAD)