### PR TITLE
Update docs: #servant is now on libera.chat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,10 @@ not been a timely response to a PR, you can ping the Maintainers group (with
 We encourage people to experiment with new combinators and instances - it is
 one of the most powerful ways of using `servant`, and a wonderful way of
 getting to know it better. If you do write a new combinator, we would love to
-know about it! Either hop on #servant on freenode and let us know, or open an
-issue with the `news` tag (which we will close when we read it).
+know about it! Either hop on
+[#haskell-servant on libera.chat](https://web.libera.chat/#haskell-servant) and
+let us know, or open an issue with the `news` tag (which we will close when we
+read it).
 
 As for adding them to the main repo: maintaining combinators can be expensive,
 since official combinators must have instances for all classes (and new classes

--- a/doc/cookbook/index.rst
+++ b/doc/cookbook/index.rst
@@ -6,8 +6,8 @@ how to solve many common problems with servant. If you're
 interested in contributing examples of your own, feel free
 to open an issue or a pull request on
 `our github repository <https://github.com/haskell-servant/servant>`_
-or even to just get in touch with us on the **#servant** IRC channel
-on freenode or on
+or even to just get in touch with us on the `**#haskell-servant** IRC channel
+on libera.chat <https://web.libera.chat/#haskell-servant>_ or on
 `the mailing list <https://groups.google.com/forum/#!forum/haskell-servant>`_.
 
 The scope is very wide. Simple and fancy authentication schemes,

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -12,7 +12,7 @@ Helpful Links
   `https://github.com/haskell-servant/servant/issues <https://github.com/haskell-servant/servant/issues>`_
 
 - the irc channel:
-  ``#servant`` on freenode
+  `#haskell-servant on libera.chat <https://web.libera.chat/#haskell-servant>`_
 
 - the mailing list:
   `groups.google.com/forum/#!forum/haskell-servant <https://groups.google.com/forum/#!forum/haskell-servant>`_


### PR DESCRIPTION
Looks like `#servant` is now hosted on libera.