### PR TITLE
Fix GHC 9.2 build

### DIFF
--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -649,7 +649,7 @@ simpleToLink _ toA _ = toLink toA (Proxy :: Proxy sub)
 -- Erroring instance for 'HasLink' when a combinator is not fully applied
 instance TypeError (PartialApplication HasLink arr) => HasLink ((arr :: a -> b) :> sub)
   where
-    type MkLink (arr :> sub) _ = TypeError (PartialApplication HasLink arr)
+    type MkLink (arr :> sub) _ = TypeError (PartialApplication (HasLink :: * -> Constraint) arr)
     toLink = error "unreachable"
 
 -- Erroring instances for 'HasLink' for unknown API combinators


### PR DESCRIPTION
Close #1513.

GHC 9.2 needs explicit kind signature here, I don't really understand
why.

This kind signature is correct and not too restritive, because `HasLink`
is technically defined `class HasLink endpoint` which means that it is
infered as `k -> Constraint`. In the instance signature, we have
`HasLink ((arr :: a -> b) :> sub)`, so here the `k` is the same kind as
the one of `:>` which is not polykinded.

Note: build tested with GHC 9.2 and the following workflow:

```
$ nix-shell ./ --argstr compiler 'ghc921' --arg pkgs 'import <nixpkgs> {}' -A servant

[nix-shell:~/srcs/servant]$ nix-shell -p cabal-install

[nix-shell:~/srcs/servant]$ cabal build servant
Up to date
```

I had to bump a few bounds:

```diff
diff --git a/cabal.project b/cabal.project
index ac4a4e3b..e2573fa9 100644
--- a/cabal.project
+++ b/cabal.project
@@ -57,7 +57,7 @@ constraints:
   foundation >=0.0.14,
   memory <0.14.12 || >0.14.12
 
-constraints: base-compat ^>=0.11
+constraints: base-compat ^>=0.12
 constraints: semigroups ^>=0.19
 
 -- allow-newer: sqlite-simple-0.4.16.0:semigroups
@@ -74,3 +74,5 @@ allow-newer: servant-js:servant
 
 -- ghc 9
 allow-newer: tdigest:base
+
+allow-newer: *
diff --git a/servant/servant.cabal b/servant/servant.cabal
index f5f973bb..14193e18 100644
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -80,7 +80,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                   >= 4.9      && < 4.16
+      base                   >= 4.9      && < 4.17
     , bytestring             >= 0.10.8.1 && < 0.12
     , constraints            >= 0.2
     , mtl                    >= 2.2.2    && < 2.3
@@ -98,7 +98,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat            >= 0.10.5   && < 0.12
+      base-compat            >= 0.12   && < 0.13
     , aeson                  >= 1.4.1.0  && < 3
     , attoparsec             >= 0.13.2.2 && < 0.15
     , bifunctors             >= 5.5.3    && < 5.6
```

(I have no idea what I'm doing there).

This patchs works in production and should be relatively safe considering that it only changes error messages, it should have no impact on running programs.