### PR TITLE
servant-auth 0.4.0.0 -> 0.4.1.0, servant-auth-server 0.4.6.0 -> 0.4.7.0

### DIFF
--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           servant-auth-server
-version: 0.4.6.0
+version: 0.4.7.0
 synopsis:       servant-server/servant-auth compatibility
 description:    This package provides the required instances for using the @Auth@ combinator
                 in your 'servant' server.

--- a/servant-auth/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth/servant-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           servant-auth
-version:        0.4.0.0
+version:        0.4.1.0
 synopsis:       Authentication combinators for servant
 description:    This package provides an @Auth@ combinator for 'servant'. This combinator
                 allows using different authentication schemes in a straightforward way,


### PR DESCRIPTION
`servant-auth` must be bumped because we changed dependencies.
`servant-auth-server` contains an important GHC9-related bound fix for `base64-bytestring`, so let's release it as well.