### PR TITLE
Fix NamedRoutes example in 0.19 changelog

### DIFF
--- a/servant/CHANGELOG.md
+++ b/servant/CHANGELOG.md
@@ -48,11 +48,11 @@ Package versions follow the [Package Versioning Policy](https://pvp.haskell.org/
   rootClient :: RootApi (AsClientT ClientM)
   rootClient = client (Proxy @API)
 
-  hello :: String -> ClientM String
-  hello name = rootClient // hello /: name
+  helloClient :: String -> ClientM String
+  helloClient name = rootClient // hello /: name
 
   endpointClient :: ClientM Person
-  endpointClient = client // subApi /: "foobar123" // endpoint
+  endpointClient = rootClient // subApi /: "foobar123" // endpoint
 
   type Api = NamedRoutes RootApi
 


### PR DESCRIPTION
There are small errors in the example showcasing 0.19's NamedRoutes