### PR TITLE
servant-server: Fix build on GHC 9.2.1

### DIFF
--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -41,7 +41,7 @@ import qualified Data.ByteString                            as B
 import qualified Data.ByteString.Builder                    as BB
 import qualified Data.ByteString.Char8                      as BC8
 import qualified Data.ByteString.Lazy                       as BL
-import           Data.Constraint (Dict(..))
+import           Data.Constraint (Constraint, Dict(..))
 import           Data.Either
                  (partitionEithers)
 import           Data.Maybe
@@ -821,7 +821,7 @@ instance (HasContextEntry context (NamedContext name subContext), HasServer subA
 -- Erroring instance for 'HasServer' when a combinator is not fully applied
 instance TypeError (PartialApplication HasServer arr) => HasServer ((arr :: a -> b) :> sub) context
   where
-    type ServerT (arr :> sub) _ = TypeError (PartialApplication HasServer arr)
+    type ServerT (arr :> sub) _ = TypeError (PartialApplication (HasServer :: * -> [*] -> Constraint) arr)
     route = error "unreachable"
     hoistServerWithContext _ _ _ _ = error "unreachable"
 


### PR DESCRIPTION
The issue is similar to the one in #1513:

```
src/Servant/Server/Internal.hs:824:10: error:
    • Uninferrable type variable k0 in
      type family equation right-hand side: (TypeError ...)
    • In the type instance declaration for ‘ServerT’
      In the instance declaration for
        ‘HasServer ((arr :: a -> b) :> sub) context’
    |
824 |     type ServerT (arr :> sub) _ = TypeError (PartialApplication HasServer arr)
    |
```

This fix is similar to the one in #1514.