### PR TITLE
Fix servant-client-ghcjs for servant 0.19

### DIFF
--- a/changelog.d/1529
+++ b/changelog.d/1529
@@ -1,0 +1,10 @@
+synopsis: Fix performRequest in servant-client-ghcjs
+prs: #1529
+
+description: {
+
+performRequest function in servant-client-ghcjs was not compatible with the
+latest RunClient typeclass. Added the acceptStatus parameter and fixed the
+functionality to match what servant-client provides.
+
+}

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -38,7 +38,7 @@ library
     Servant.Client.Internal.XhrClient
 
   build-depends:
-      base                >=4.11    && <4.12
+      base                >=4.11    && <5
     , bytestring          >=0.10    && <0.12
     , case-insensitive    >=1.2.0.0 && <1.3.0.0
     , containers          >=0.5     && <0.7


### PR DESCRIPTION
I fixed servant-client-ghcjs to be compatible with servant-client-core version 0.19, also bumped max-bound on base to be able to use base 4.14