### PR TITLE
servant-auth-server: Support NamedRoutes

### DIFF
--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ThrowAll.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ThrowAll.hs
@@ -8,7 +8,10 @@ module Servant.Auth.Server.Internal.ThrowAll where
 
 import Control.Monad.Error.Class
 import Data.Tagged               (Tagged (..))
-import Servant                   ((:<|>) (..), ServerError(..))
+import Servant                   ((:<|>) (..), ServerError(..), NamedRoutes(..))
+import Servant.API.Generic
+import Servant.Server.Generic
+import Servant.Server
 import Network.HTTP.Types
 import Network.Wai
 
@@ -25,6 +28,12 @@ class ThrowAll a where
 
 instance (ThrowAll a, ThrowAll b) => ThrowAll (a :<|> b) where
   throwAll e = throwAll e :<|> throwAll e
+
+instance
+  ( ThrowAll (ToServant api (AsServerT m)) , GenericServant api (AsServerT m)) =>
+  ThrowAll (api (AsServerT m)) where
+
+  throwAll = fromServant . throwAll
 
 -- Really this shouldn't be necessary - ((->) a) should be an instance of
 -- MonadError, no?


### PR DESCRIPTION
Trying to use `NamedRoutes` with `servant-auth-server` currently results
in hideous error messages such as:

```
app/Main.hs:50:7: error:
    • No instance for (Servant.Auth.Server.Internal.AddSetCookie.AddSetCookies
                         ('Servant.Auth.Server.Internal.AddSetCookie.S
                            ('Servant.Auth.Server.Internal.AddSetCookie.S
                               'Servant.Auth.Server.Internal.AddSetCookie.Z))
                         (AdminRoutes (Servant.Server.Internal.AsServerT Handler))
                         (ServerT
                            (Servant.Auth.Server.Internal.AddSetCookie.AddSetCookieApi
                               (Servant.Auth.Server.Internal.AddSetCookie.AddSetCookieApi
                                  (NamedRoutes AdminRoutes)))
                            Handler))
        arising from a use of 'serveWithContext'
    • In the expression: serveWithContext (Proxy @API) ctx RootAPI {..}
```

This is because we didn't teach it how to recurse along `NamedRoutes`
trees and sprinkle headers at the tip of each branch.

This commit adds a test case and fixes the issue. In the process, it
also implements `ThrowAll` for `NamedRoutes`, which was necessary for
the test to run, and should also prove convenient for users.

