### PR TITLE
Update documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@if [ ! -d venv ]; then echo "WARNING: There is no venv directory, did you forget to 'virtualenv venv'. Check building-the-docs file."; fi
+	@if [ ! -d venv ]; then echo "WARNING: There is no venv directory, did you forget to 'virtualenv venv'. Check README.md."; fi
 	@if [ ! "z$$(which $(SPHINXBUILD))" = "z$$(pwd)/venv/bin/sphinx-build" ]; then echo "WARNING: Did you forgot to 'source venv/bin/activate'"; fi
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Servant'
-copyright = u'2018, Servant Contributors'
+copyright = u'2022, Servant Contributors'
 author = u'Servant Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -169,4 +169,3 @@ texinfo_documents = [
 source_parsers = {
     '.lhs': CommonMarkParser,
 }
-

--- a/doc/tutorial/install.rst
+++ b/doc/tutorial/install.rst
@@ -40,3 +40,29 @@ nix
 `Nix <https://nixos.org/nix/>`_ users should feel free to take a look at
 the `nix/shell.nix` file in the repository and use it to provision a suitable
 environment to build and run the examples.
+
+Note for Ubuntu users
+--------
+
+Ubuntu's packages for `ghc`, `cabal`, and `stack` are years out of date.
+If the instructions above fail for you,
+try replacing the Ubuntu packages with up-to-date versions.
+First remove the installed versions:
+
+.. code-block:: bash
+
+   # remove the obsolete versions
+   $ sudo apt remove ghc haskell-stack cabal-install
+
+Then install fresh versions of the Haskell toolchain
+using the `ghcup <https://www.haskell.org/ghcup/install/>`_ installer.
+
+As of February 2022, one easy way to do this is by running a bootstrap script:
+
+.. code-block:: bash
+
+   $ curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+
+The script is interactive and will prompt you for details about what
+you want installed and where.  To install manually,
+see `the detailed instructions <https://www.haskell.org/ghcup/install/#manual-install>`_.


### PR DESCRIPTION
1. Add a note to the tutorial install doc that addresses problems caused by the ancient toolchain on Ubuntu (resolves issue #1540)
2. Update error message in `doc/Makefile`
3. Update copyright date from 2018 to 2022

