### PR TITLE
Export encoding function for a query parameter value

### DIFF
--- a/servant-client-core/src/Servant/Client/Core.hs
+++ b/servant-client-core/src/Servant/Client/Core.hs
@@ -59,6 +59,7 @@ module Servant.Client.Core
   , appendToPath
   , setRequestBodyLBS
   , setRequestBody
+  , encodeQueryParamValue
   ) where
 import           Servant.Client.Core.Auth
 import           Servant.Client.Core.BaseUrl

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -33,9 +33,7 @@ import           Control.Arrow
 import           Control.Monad
                  (unless)
 import qualified Data.ByteString as BS
-import           Data.ByteString.Builder
-                 (toLazyByteString)
-import qualified Data.ByteString.Lazy                     as BL
+import qualified Data.ByteString.Lazy as BL
 import           Data.Either
                  (partitionEithers)
 import           Data.Constraint (Dict(..))
@@ -571,16 +569,13 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient m api, SBoolI (FoldRequire
       (Proxy :: Proxy mods) add (maybe req add) mparam
     where
       add :: a -> Request
-      add param = appendToQueryString pname (Just $ encodeQueryParam param) req
+      add param = appendToQueryString pname (Just $ encodeQueryParamValue param) req
 
       pname :: Text
       pname  = pack $ symbolVal (Proxy :: Proxy sym)
 
   hoistClientMonad pm _ f cl = \arg ->
     hoistClientMonad pm (Proxy :: Proxy api) f (cl arg)
-
-encodeQueryParam :: ToHttpApiData a => a  -> BS.ByteString
-encodeQueryParam = BL.toStrict . toLazyByteString . toEncodedUrlPiece
 
 -- | If you use a 'QueryParams' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take
@@ -623,7 +618,7 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient m api)
                     )
 
     where pname = pack $ symbolVal (Proxy :: Proxy sym)
-          paramlist' = map (Just . encodeQueryParam) paramlist
+          paramlist' = map (Just . encodeQueryParamValue) paramlist
 
   hoistClientMonad pm _ f cl = \as ->
     hoistClientMonad pm (Proxy :: Proxy api) f (cl as)

--- a/servant-client-core/src/Servant/Client/Core/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Request.hs
@@ -17,6 +17,7 @@ module Servant.Client.Core.Request (
     addHeader,
     appendToPath,
     appendToQueryString,
+    encodeQueryParamValue,
     setRequestBody,
     setRequestBodyLBS,
     ) where
@@ -142,18 +143,29 @@ defaultRequest = Request
   , requestMethod = methodGet
   }
 
+-- | Append extra path to the request being constructed.
+--
 appendToPath :: Text -> Request -> Request
 appendToPath p req
   = req { requestPath = requestPath req <> "/" <> toEncodedUrlPiece p }
 
-appendToQueryString :: Text             -- ^ param name
-                    -> Maybe BS.ByteString -- ^ param value
+-- | Append a query parameter to the request being constructed.
+--
+appendToQueryString :: Text                -- ^ query param name
+                    -> Maybe BS.ByteString -- ^ query param value
                     -> Request
                     -> Request
 appendToQueryString pname pvalue req
   = req { requestQueryString = requestQueryString req
                         Seq.|> (encodeUtf8 pname, pvalue)}
 
+-- | Encode a query parameter value.
+--
+encodeQueryParamValue :: ToHttpApiData a => a  -> BS.ByteString
+encodeQueryParamValue = LBS.toStrict . Builder.toLazyByteString . toEncodedUrlPiece
+
+-- | Add header to the request being constructed.
+--
 addHeader :: ToHttpApiData a => HeaderName -> a -> Request -> Request
 addHeader name val req
   = req { requestHeaders = requestHeaders req Seq.|> (name, toHeader val)}


### PR DESCRIPTION
After the refactoring of URL encoding (https://github.com/haskell-servant/servant/pull/1432), the type of the `appendToQueryString` function has changed.
It might be helpful to export the function `encodeQueryParamValue` (it was `encodeQueryParam`) that could be used to obtain the proper value to pass to `appendToQueryString`, when this function is used outside of `servant`.

This PR proposes to:
- move `encodeQueryParam` from `Servant.Client.Core.HasClient` to `Servant.Client.Core.Request`
- rename `encodeQueryParam` into `encodeQueryParamValue`, just to be more explicit
- re-export `encodeQueryParamValue` from `Servant.Client.Core`
- add short descriptions to some of the exported functions of the `Servant.Client.Core.Request` module