### PR TITLE
Add RawM combinator

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -76,7 +76,7 @@ import           Servant.API
                  FromSourceIO (..), Header', Headers (..), HttpVersion,
                  IsSecure, MimeRender (mimeRender),
                  MimeUnrender (mimeUnrender), NoContent (NoContent),
-                 NoContentVerb, QueryFlag, QueryParam', QueryParams, Raw,
+                 NoContentVerb, QueryFlag, QueryParam', QueryParams, Raw, RawM,
                  ReflectMethod (..), RemoteHost, ReqBody', SBoolI, Stream,
                  StreamBody', Summary, ToHttpApiData, ToSourceIO (..), Vault,
                  Verb, WithNamedContext, WithStatus (..), contentType, getHeadersHList,
@@ -674,6 +674,16 @@ instance RunClient m => HasClient m Raw where
     = H.Method ->  m Response
 
   clientWithRoute :: Proxy m -> Proxy Raw -> Request -> Client m Raw
+  clientWithRoute _pm Proxy req httpMethod = do
+    runRequest req { requestMethod = httpMethod }
+
+  hoistClientMonad _ _ f cl = \meth -> f (cl meth)
+
+instance RunClient m => HasClient m RawM where
+  type Client m RawM
+    = H.Method ->  m Response
+
+  clientWithRoute :: Proxy m -> Proxy RawM -> Request -> Client m RawM
   clientWithRoute _pm Proxy req httpMethod = do
     runRequest req { requestMethod = httpMethod }
 

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -111,7 +111,7 @@ import           Servant.API.Modifiers
 import           Servant.API.QueryParam
                  (QueryFlag, QueryParam, QueryParam', QueryParams)
 import           Servant.API.Raw
-                 (Raw)
+                 (Raw, RawM)
 import           Servant.API.RemoteHost
                  (RemoteHost)
 import           Servant.API.ReqBody

--- a/servant/src/Servant/API/Raw.hs
+++ b/servant/src/Servant/API/Raw.hs
@@ -15,3 +15,6 @@ import           Data.Typeable
 -- <https://hackage.haskell.org/package/servant-server/docs/Servant-Server-StaticFiles.html Servant.Server.StaticFiles>
 -- to serve static files stored in a particular directory on your filesystem
 data Raw deriving Typeable
+
+-- | Variant of 'Raw' that lets you access the underlying monadic context to process the request.
+data RawM deriving Typeable

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -174,7 +174,7 @@ import           Servant.API.NamedRoutes
 import           Servant.API.QueryParam
                  (QueryFlag, QueryParam', QueryParams)
 import           Servant.API.Raw
-                 (Raw)
+                 (Raw, RawM)
 import           Servant.API.RemoteHost
                  (RemoteHost)
 import           Servant.API.ReqBody
@@ -578,6 +578,10 @@ instance HasLink (NoContentVerb m) where
 
 instance HasLink Raw where
     type MkLink Raw a = a
+    toLink toA _ = toA
+
+instance HasLink RawM where
+    type MkLink RawM a = a
     toLink toA _ = toA
 
 instance HasLink (Stream m status fr ct a) where


### PR DESCRIPTION
The 'RawM' combinator is a variant of 'Raw' that lets users access the monadic context of the server.

The handler must produce a WAI Response, like Raw.

Closes #1544 .

@hasufell may I have your input on this PR ?