### PR TITLE
Use cabal-install to invoke doctest

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,10 +47,7 @@ jobs:
 
     - name: Configure
       run: |
-        # Using separate store-dir because default one already has 'ghc-paths' package installed
-        # with hardcoded path to ghcup's GHC path (which it was built with). This leads to failure in
-        # doctest, as it tries to invoke that GHC, and it doesn't exist here.
-        cabal --store-dir /tmp/cabal-store install --ignore-project -j2 doctest --constraint='doctest ^>=0.18'
+        cabal install --ignore-project -j2 doctest --constraint='doctest ^>=0.20'
 
     - name: Build
       run: |
@@ -68,24 +65,17 @@ jobs:
         # Necessary for doctest to be found in $PATH
         export PATH="$HOME/.cabal/bin:$PATH"
 
-        # Filter out base-compat-batteries from .ghc.environment.*, as its modules
-        # conflict with those of base-compat.
-        #
-        # FIXME: This is an ugly hack. Ultimately, we'll want to use cabal-doctest
-        # (or cabal v2-doctest, if it ever lands) to provide a clean GHC environment.
-        # This might allow running doctests in GHCJS build as well.
-        perl -i -e 'while (<ARGV>) { print unless /package-id\s+(base-compat-batteries)-\d+(\.\d+)*/; }' .ghc.environment.*
-
-        (cd servant && doctest src)
-        (cd servant-client && doctest src)
-        (cd servant-client-core && doctest src)
-        (cd servant-http-streams && doctest src)
-        (cd servant-docs && doctest src)
-        (cd servant-foreign && doctest src)
-        (cd servant-server && doctest src)
-        (cd servant-machines && doctest src)
-        (cd servant-conduit && doctest src)
-        (cd servant-pipes && doctest src)
+        DOCTEST="cabal repl --with-ghc=doctest --ghc-options=-w"
+        (cd servant && eval $DOCTEST)
+        (cd servant-client && eval $DOCTEST)
+        (cd servant-client-core && eval $DOCTEST)
+        (cd servant-http-streams && eval $DOCTEST)
+        (cd servant-docs && eval $DOCTEST)
+        (cd servant-foreign && eval $DOCTEST)
+        (cd servant-server && eval $DOCTEST)
+        (cd servant-machines && eval $DOCTEST)
+        (cd servant-conduit && eval $DOCTEST)
+        (cd servant-pipes && eval $DOCTEST)
 
   stack:
     name: stack / ghc ${{ matrix.ghc }}

--- a/cabal.project
+++ b/cabal.project
@@ -52,9 +52,6 @@ tests: True
 optimization: False
 -- reorder-goals: True
 
--- needed for doctests
-write-ghc-environment-files: always
-
 -- https://github.com/chordify/haskell-servant-pagination/pull/12
 allow-newer: servant-pagination-2.2.2:servant
 allow-newer: servant-pagination-2.2.2:servant-server

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -246,7 +246,7 @@ defaultMakeClientRequest burl r = Client.defaultRequest
   where
     -- Content-Type and Accept are specified by requestBody and requestAccept
     headers = filter (\(h, _) -> h /= "Accept" && h /= "Content-Type") $
-        toList $requestHeaders r
+        toList $ requestHeaders r
 
     acceptHdr
         | null hs   = Nothing

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -92,7 +92,7 @@ test-suite doctests
   build-depends:
     base,
     directory >= 1.0,
-    doctest >= 0.17 && <0.19,
+    doctest >= 0.17 && <0.21,
     servant,
     QuickCheck,
     filepath


### PR DESCRIPTION
Doctests can be made more robust by making cabal-install invoke doctest with the right configuration. This is a new feature added in doctest 0.20. This makes the environment files unnecessary, and the CI configuration becomes simpler.

This also inserts a space such that `$requestHeaders` isn't mistaken for a TemplateHaskell splice.