### PR TITLE
Use Stack 2.7.5, cleanup allow-newer/CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,9 +58,6 @@ jobs:
         cabal test all
 
     - name: Run doctests
-      # doctests are broken on GHC 9 due to compiler bug:
-      # https://gitlab.haskell.org/ghc/ghc/-/issues/19460
-      continue-on-error: ${{ matrix.ghc == '9.0.1' }}
       run: |
         # Necessary for doctest to be found in $PATH
         export PATH="$HOME/.cabal/bin:$PATH"
@@ -82,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.7.3"]
+        stack: ["2.7.5"]
         ghc: ["8.10.7"]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -51,7 +51,3 @@ packages:
 tests: True
 optimization: False
 -- reorder-goals: True
-
--- https://github.com/chordify/haskell-servant-pagination/pull/12
-allow-newer: servant-pagination-2.2.2:servant
-allow-newer: servant-pagination-2.2.2:servant-server


### PR DESCRIPTION
servant-pagination 2.5.0 is out, and it allows servant 0.19. So we do not need this allow-newer any more. Stack 2.7.5 is out, and it only downloads extra-deps with multiple subdirs once, and also contains other bugfixes. A stale CI configuration line is removed, since GHC 9.0.1 is no longer run in CI, we use GHC 9.0.2.