### PR TITLE
Fix haddock documentation for (//) and (/:)

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -874,7 +874,7 @@ infixl 2 /:
 --
 -- Example:
 --
--- @@
+-- @
 -- type Api = NamedRoutes RootApi
 --
 -- data RootApi mode = RootApi
@@ -895,7 +895,7 @@ infixl 2 /:
 --
 -- endpointClient :: ClientM Person
 -- endpointClient = client // subApi // endpoint
--- @@
+-- @
 (//) :: a -> (a -> b) -> b
 x // f = f x
 
@@ -906,7 +906,7 @@ x // f = f x
 --
 -- Example:
 --
--- @@
+-- @
 -- type Api = NamedRoutes RootApi
 --
 -- data RootApi mode = RootApi
@@ -931,7 +931,7 @@ x // f = f x
 --
 -- endpointClient :: ClientM Person
 -- endpointClient = client // subApi /: "foobar123" // endpoint
--- @@
+-- @
 (/:) :: (a -> b -> c) -> b -> a -> c
 (/:) = flip
 


### PR DESCRIPTION
The examples for these two operators weren't displayed properly due to invalid Haddock markup (see [here](https://hackage.haskell.org/package/servant-client-core-0.19/docs/Servant-Client-Core-Reexport.html#v:-47-:) for example).