### PR TITLE
Support UVerb in servant-auth-server

### DIFF
--- a/changelog.d/1571
+++ b/changelog.d/1571
@@ -1,0 +1,8 @@
+synopsis: Support UVerb in servant-auth-server
+prs: #1571
+issues: #1570
+description: {
+UVerb endpoints are now supported by servant-auth-server and can used under the
+Auth combinator when writing servers. It is still unsupported by
+servant-auth-client.
+}

--- a/changelog.d/1571
+++ b/changelog.d/1571
@@ -2,7 +2,7 @@ synopsis: Support UVerb in servant-auth-server
 prs: #1571
 issues: #1570
 description: {
-UVerb endpoints are now supported by servant-auth-server and can used under the
+UVerb endpoints are now supported by servant-auth-server and can be used under the
 Auth combinator when writing servers. It is still unsupported by
 servant-auth-client.
 }

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -129,6 +129,7 @@ test-suite spec
     , lens-aeson  >= 1.0.2     && < 1.2
     , warp        >= 3.2.25    && < 3.4
     , wreq        >= 0.5.2.1   && < 0.6
+    , text        >= 1.2.3.0   && < 2.1
   other-modules:
       Servant.Auth.ServerSpec
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/test/Servant/Auth/ServerSpec.hs
+++ b/servant-auth/servant-auth-server/test/Servant/Auth/ServerSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
 module Servant.Auth.ServerSpec (spec) where
 
 #if !MIN_VERSION_servant_server(0,16,0)
@@ -25,6 +26,7 @@ import           Data.Aeson                          (FromJSON, ToJSON, Value,
 import           Data.Aeson.Lens                     (_JSON)
 import qualified Data.ByteString                     as BS
 import qualified Data.ByteString.Lazy                as BSL
+import           Data.Text                           (Text)
 import           Data.CaseInsensitive                (mk)
 import           Data.Foldable                       (find)
 import           Data.Monoid
@@ -407,6 +409,7 @@ type API auths
         ( Get '[JSON] Int
        :<|> ReqBody '[JSON] Int :> Post '[JSON] Int
        :<|> NamedRoutes DummyRoutes
+       :<|> UVerb 'GET '[JSON] '[WithStatus 200 Int, WithStatus 500 Text]
        :<|> "header" :> Get '[JSON] (Headers '[Header "Blah" Int] Int)
 #if MIN_VERSION_servant_server(0,15,0)
        :<|> "stream" :> StreamGet NoFraming OctetStream (SourceIO BS.ByteString)
@@ -483,6 +486,7 @@ server ccfg =
         Authenticated usr -> getInt usr
                         :<|> postInt usr
                         :<|> DummyRoutes { dummyInt = getInt usr }
+                        :<|> respond (WithStatus @200 (42 :: Int))
                         :<|> getHeaderInt
 #if MIN_VERSION_servant_server(0,15,0)
                         :<|> return (S.source ["bytestring"])

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE PolyKinds              #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
 {-# OPTIONS_HADDOCK not-home        #-}
@@ -51,6 +52,9 @@ import           Prelude ()
 import           Prelude.Compat
 import           Servant.API.Header
                  (Header)
+import           Servant.API.UVerb.Union
+import qualified Data.SOP.BasicFunctors as SOP
+import qualified Data.SOP.NS as SOP
 
 -- | Response Header objects. You should never need to construct one directly.
 -- Instead, use 'addOptionalHeader'.
@@ -169,6 +173,21 @@ instance {-# OVERLAPPING #-} ( KnownSymbol h, ToHttpApiData v )
 instance {-# OVERLAPPABLE #-} ( KnownSymbol h, ToHttpApiData v , new ~ Headers '[Header h v] a)
          => AddHeader h v a new where
     addOptionalHeader hdr resp = Headers resp (HCons hdr HNil)
+
+-- Instances to decorate all responses in a 'Union' with headers. The functional
+-- dependencies force us to consider singleton lists as the base case in the
+-- recursion (it is impossible to determine h and v otherwise from old / new
+-- responses if the list is empty).
+instance (AddHeader h v old new) => AddHeader h v (Union '[old]) (Union '[new]) where
+  addOptionalHeader hdr resp =
+    SOP.Z $ SOP.I $ addOptionalHeader hdr $ SOP.unI $ SOP.unZ $ resp
+
+instance
+  (AddHeader h v old new, AddHeader h v (Union oldrest) (Union newrest), oldrest ~ (a ': as), newrest ~ (b ': bs))
+  => AddHeader h v (Union (old ': (a ': as))) (Union (new ': (b ': bs))) where
+  addOptionalHeader hdr resp = case resp of
+    SOP.Z (SOP.I rHead) -> SOP.Z $ SOP.I $ addOptionalHeader hdr rHead
+    SOP.S rOthers -> SOP.S $ addOptionalHeader hdr rOthers
 
 -- | @addHeader@ adds a header to a response. Note that it changes the type of
 -- the value in the following ways:

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -183,7 +183,11 @@ instance (AddHeader h v old new) => AddHeader h v (Union '[old]) (Union '[new]) 
     SOP.Z $ SOP.I $ addOptionalHeader hdr $ SOP.unI $ SOP.unZ $ resp
 
 instance
-  (AddHeader h v old new, AddHeader h v (Union oldrest) (Union newrest), oldrest ~ (a ': as), newrest ~ (b ': bs))
+  ( AddHeader h v old new, AddHeader h v (Union oldrest) (Union newrest)
+  -- This ensures that the remainder of the response list is _not_ empty
+  -- It is necessary to prevent the two instances for union types from
+  -- overlapping.
+  , oldrest ~ (a ': as), newrest ~ (b ': bs))
   => AddHeader h v (Union (old ': (a ': as))) (Union (new ': (b ': bs))) where
   addOptionalHeader hdr resp = case resp of
     SOP.Z (SOP.I rHead) -> SOP.Z $ SOP.I $ addOptionalHeader hdr rHead

--- a/servant/src/Servant/API/UVerb.hs
+++ b/servant/src/Servant/API/UVerb.hs
@@ -38,6 +38,7 @@ import GHC.TypeLits (Nat)
 import Network.HTTP.Types (Status, StdMethod)
 import Servant.API.ContentTypes (JSON, PlainText, FormUrlEncoded, OctetStream, NoContent, MimeRender(mimeRender), MimeUnrender(mimeUnrender))
 import Servant.API.Status (KnownStatus, statusVal)
+import Servant.API.ResponseHeaders (Headers)
 import Servant.API.UVerb.Union
 
 class KnownStatus (StatusOf a) => HasStatus (a :: *) where
@@ -86,6 +87,8 @@ newtype WithStatus (k :: Nat) a = WithStatus a
 instance KnownStatus n => HasStatus (WithStatus n a) where
   type StatusOf (WithStatus n a) = n
 
+instance HasStatus a => HasStatus (Headers ls a) where
+  type StatusOf (Headers ls a) = StatusOf a
 
 -- | A variant of 'Verb' that can have any of a number of response values and status codes.
 --


### PR DESCRIPTION
Closes #1570 

~Caveat: returning a 401 response with UVerb is _not_ equivalent to using `throwAll err401`: `XSRF-TOKEN` will be set anyway, because the handler then doesn't fail (it successfully returns an error :upside_down_face:). I can't see a satisfying solution to this problem, so external input is much welcome on this issue (I for one consider this limitation semi-reasonable).~ This should be fixed.