### PR TITLE
Add (basic) docs for ServerT

### DIFF
--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -112,6 +112,10 @@ import           Servant.API.TypeLevel
                  (AtLeastOneFragment, FragmentUnique)
 
 class HasServer api context where
+  -- | The type of a server for this API, given a monad to run effects in.
+  --
+  -- Note that the result kind is @*@, so it is /not/ a monad transformer, unlike
+  -- what the @T@ in the name might suggest.
   type ServerT api (m :: * -> *) :: *
 
   route ::


### PR DESCRIPTION
While reading the docs I was a bit surprised that `ServerT api` isn't a monad transformer, while I was assuming that it was due to the name. I saw #340, but since there seems to be no consensus on what it should be renamed to, I figured some clarification in a doc comment would help in the meantime. 