### PR TITLE
Major version bound for servant-server's dependency on servant

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -72,7 +72,7 @@ library
   -- Servant dependencies
   -- strict dependency as we re-export 'servant' things.
   build-depends:
-      servant             >= 0.19
+      servant             >= 0.19     && < 0.20
     , http-api-data       >= 0.4.1    && < 0.4.4
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.


### PR DESCRIPTION
I made the revision on hackage, just reflecting it here.