### PR TITLE
Enable curl-mock for GHC 9.2

### DIFF
--- a/doc/cookbook/curl-mock/curl-mock.cabal
+++ b/doc/cookbook/curl-mock/curl-mock.cabal
@@ -11,9 +11,6 @@ build-type:          Simple
 tested-with:         GHC==8.6.5, GHC==8.8.3, GHC ==8.10.7
 
 executable cookbock-curl-mock
-  if impl(ghc >= 9.2)
-    -- generic-arbitrary is incompatible
-    buildable: False
   main-is:             CurlMock.lhs
   build-depends:       base == 4.*
                      , aeson


### PR DESCRIPTION
Version 0.2.1 of generic-arbitrary adds the needed compatibility, see the [changelog](https://hackage.haskell.org/package/generic-arbitrary-0.2.1/changelog).

CI failure must be unrelated since this cabal.project change doesn't affect dependency resolution.