### PR TITLE
Allow IO in JWTSettings' validationKeys

### DIFF
--- a/changelog.d/1580
+++ b/changelog.d/1580
@@ -1,0 +1,10 @@
+synopsis: Allow IO in validationKeys
+prs: #1580
+issues: #1579
+
+description: {
+
+Currently validationKeys are a fixed JWKSet. This does not work for setups such
+as AWS Cognito or Okta, where there is a regular key rotation. This change
+alters the type of validationKeys from JWKSet to IO JWKSet.
+}

--- a/changelog.d/1580
+++ b/changelog.d/1580
@@ -4,7 +4,9 @@ issues: #1579
 
 description: {
 
-Currently validationKeys are a fixed JWKSet. This does not work for setups such
-as AWS Cognito or Okta, where there is a regular key rotation. This change
-alters the type of validationKeys from JWKSet to IO JWKSet.
+Currently validationKeys are a fixed JWKSet. This does not work with OIDC
+providers such as AWS Cognito or Okta, which regularly fetching jwks_uri to
+discover new and expired keys.
+
+This change alters the type of validationKeys from JWKSet to IO JWKSet.
 }

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -33,7 +33,7 @@ data JWTSettings = JWTSettings
   -- | Algorithm used to sign JWT.
   , jwtAlg          :: Maybe Jose.Alg
   -- | Keys used to validate JWT.
-  , validationKeys  :: Jose.JWKSet
+  , validationKeys  :: IO Jose.JWKSet
   -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
   -- intended recipient of the JWT.
   , audienceMatches :: Jose.StringOrURI -> IsMatch
@@ -44,7 +44,7 @@ defaultJWTSettings :: Jose.JWK -> JWTSettings
 defaultJWTSettings k = JWTSettings
    { signingKey = k
    , jwtAlg = Nothing
-   , validationKeys = Jose.JWKSet [k]
+   , validationKeys = pure $ Jose.JWKSet [k]
    , audienceMatches = const Matches }
 
 -- | The policies to use when generating cookies.

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
@@ -58,11 +58,12 @@ makeJWT v cfg expiry = runExceptT $ do
 
 verifyJWT :: FromJWT a => JWTSettings -> BS.ByteString -> IO (Maybe a)
 verifyJWT jwtCfg input = do
-  verifiedJWT <- liftIO $ runExceptT $ do
+  keys <- validationKeys jwtCfg
+  verifiedJWT <- runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact (BSL.fromStrict input)
     Jose.verifyClaims
       (jwtSettingsToJwtValidationSettings jwtCfg)
-      (validationKeys jwtCfg)
+      keys
       unverifiedJWT
   return $ case verifiedJWT of
     Left (_ :: Jose.JWTError) -> Nothing


### PR DESCRIPTION
Fixes #1579 

There have been two PRs in the old servant-auth repo doing similar things. [This one](https://github.com/haskell-servant/servant-auth/pull/193/files) by [dnikolovv](https://github.com/dnikolovv) which uses IORefs, and [this one](https://github.com/haskell-servant/servant-auth/pull/169/files) by me which allows IO as here (but that PR also does a lot of other things).

I personally prefer `IO` rather than `IORef` since it's a bit more general (and works with libraries that either don't use or don't expose the `IORef` - e.g. [cached-io](https://hackage.haskell.org/package/cached-io)).

This is a breaking change. 