### PR TITLE
Disable hspec colored output in servant-swagger doctests

### DIFF
--- a/servant-swagger/src/Servant/Swagger.hs
+++ b/servant-swagger/src/Servant/Swagger.hs
@@ -55,6 +55,7 @@ import           Servant.Swagger.Internal.Orphans ()
 -- >>> import Data.Typeable
 -- >>> import GHC.Generics
 -- >>> import Servant.API
+-- >>> import System.Environment
 -- >>> import Test.Hspec
 -- >>> import Test.QuickCheck
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSL8
@@ -64,6 +65,7 @@ import           Servant.Swagger.Internal.Orphans ()
 -- >>> :set -XGeneralizedNewtypeDeriving
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XTypeOperators
+-- >>> setEnv "HSPEC_COLOR" "no"
 -- >>> data User = User { name :: String, age :: Int } deriving (Show, Generic, Typeable)
 -- >>> newtype UserId = UserId Integer deriving (Show, Generic, Typeable, ToJSON)
 -- >>> instance ToJSON User

--- a/servant-swagger/src/Servant/Swagger/Internal/Test.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/Test.hs
@@ -29,10 +29,12 @@ import           Servant.Swagger.Internal.TypeLevel
 -- >>> import Control.Applicative
 -- >>> import GHC.Generics
 -- >>> import Test.QuickCheck
+-- >>> import System.Environment (setEnv)
 -- >>> :set -XDeriveGeneric
 -- >>> :set -XGeneralizedNewtypeDeriving
 -- >>> :set -XDataKinds
 -- >>> :set -XTypeOperators
+-- >>> setEnv "HSPEC_COLOR" "no"
 
 -- | Verify that every type used with @'JSON'@ content type in a servant API
 -- has compatible @'ToJSON'@ and @'ToSchema'@ instances using @'validateToJSON'@.


### PR DESCRIPTION
Colored output is the default since hspec 2.9.5.

> **Changes in 2.9.5**
>
>    Assume --color by default when running on GitHub Actions. Use HSPEC_COLOR=no or --no-color to opt out of this behavior.

This causes CI failures due to terminal escaping characters when running
the doctests on GitHub Actions.