### PR TITLE
Evaluate NoContent before (not) rendering it.

### DIFF
--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -295,7 +295,7 @@ instance {-# OVERLAPPABLE #-}
 -- then this would be taken care of. However there is no more specific instance
 -- between that and 'MimeRender JSON a', so we do this instead
 instance {-# OVERLAPPING #-} ( Accept ctyp ) => AllMimeRender '[ctyp] NoContent where
-    allMimeRender _ _ = map (, "") $ NE.toList $ contentTypes pctyp
+    allMimeRender _ NoContent = map (, "") $ NE.toList $ contentTypes pctyp
       where
         pctyp = Proxy :: Proxy ctyp
 

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -83,6 +83,9 @@ spec = describe "Servant.API.ContentTypes" $ do
     describe "The NoContent Content-Type type" $ do
         let p = Proxy :: Proxy '[JSON]
 
+        it "does not render any content" $
+          allMimeRender p NoContent `shouldSatisfy` (all (BSL8.null . snd))
+
         it "evaluates the NoContent value" $
           evaluate (allMimeRender p (undefined :: NoContent)) `shouldThrow` anyErrorCall
 

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -33,6 +33,8 @@ import           Data.String.Conversions
 import qualified Data.Text                                        as TextS
 import qualified Data.Text.Encoding                               as TextSE
 import qualified Data.Text.Lazy                                   as TextL
+import           Control.Exception
+                 (evaluate)
 import           GHC.Generics
 import           Test.Hspec
 import           Test.QuickCheck
@@ -77,6 +79,12 @@ spec = describe "Servant.API.ContentTypes" $ do
 
         it "has mimeUnrender reverse mimeRender for valid top-level json " $ do
             property $ \x -> mimeUnrender p (mimeRender p x) == Right (x::SomeData)
+
+    describe "The NoContent Content-Type type" $ do
+        let p = Proxy :: Proxy '[JSON]
+
+        it "evaluates the NoContent value" $
+          evaluate (allMimeRender p (undefined :: NoContent)) `shouldThrow` anyErrorCall
 
     describe "The PlainText Content-Type type" $ do
         let p = Proxy :: Proxy PlainText


### PR DESCRIPTION
This way it shows up as covered in coverage reports,
 
Currently any `return NoContent` is marked at "not covered" in coverage reports because it is not evaluated.