### PR TITLE
Only add a ? when query string is nonempty

### DIFF
--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -289,7 +289,8 @@ defaultMakeClientRequest burl r = Client.defaultRequest
         Https -> True
 
     -- Query string builder which does not do any encoding
-    buildQueryString = ("?" <>) . foldl' addQueryParam mempty
+    buildQueryString [] = mempty
+    buildQueryString qps = "?" <> foldl' addQueryParam mempty qps
 
     addQueryParam qs (k, v) =
           qs <> (if BS.null qs then mempty else "&") <> urlEncode True k <> foldMap ("=" <>) v


### PR DESCRIPTION
In #1432 we changed the way that servant composes query strings.  Among other problems, the new scheme always adds a `?` even when the query parameter set is empty.  This fixes the scheme so that when there are no query parameters, the resulting query string is empty.