### PR TITLE
[servant-server] Add error 429 Too Many Requests. Fix build of examples/greet.hs

### DIFF
--- a/servant-server/example/greet.hs
+++ b/servant-server/example/greet.hs
@@ -18,6 +18,7 @@ import           Network.Wai.Handler.Warp
 
 import           Servant
 import           Servant.Server.Generic ()
+import           Servant.API.Generic ((:-))
 
 -- * Example
 

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -84,6 +84,7 @@ module Servant.Server
   , err417
   , err418
   , err422
+  , err429
    -- ** 5XX
   , err500
   , err501

--- a/servant-server/src/Servant/Server/Internal/ServerError.hs
+++ b/servant-server/src/Servant/Server/Internal/ServerError.hs
@@ -392,6 +392,20 @@ err422 = ServerError { errHTTPCode = 422
                     , errHeaders = []
                     }
 
+-- | 'err429' Too Many Requests
+--
+-- Example:
+--
+-- > failingHandler :: Handler ()
+-- > failingHandler = throwError $ err429 { errBody = "You have sent too many requests in a short period of time." }
+--
+err429 :: ServerError
+err429 = ServerError { errHTTPCode = 429
+                    , errReasonPhrase = "Too Many Requests"
+                    , errBody = ""
+                    , errHeaders = []
+                    }
+
 -- | 'err500' Internal Server Error
 --
 -- Example:


### PR DESCRIPTION
When I forked the repository, I did

```
$ cd servant-server
$ stack init
$ stack build
```

and `examples/greet.hs` failed to compile. So I fixed the compilation error there and then added the "429 Too Many Requests" error that I needed.