### PR TITLE
[servant] Generalize type of Servant.Types.SourceT.source to any foldable

### DIFF
--- a/changelog.d/1593
+++ b/changelog.d/1593
@@ -1,0 +1,2 @@
+synopsis: Generalize type of Servant.Types.SourceT.source to any foldable.
+prs: 1593

--- a/servant/src/Servant/Types/SourceT.hs
+++ b/servant/src/Servant/Types/SourceT.hs
@@ -269,7 +269,7 @@ mapMaybeStep p = go where
 
 -- | Run action for each value in the 'SourceT'.
 --
--- >>> foreach fail print (source "abc")
+-- >>> foreach fail print $ source ("abc" :: String)
 -- 'a'
 -- 'b'
 -- 'c'

--- a/servant/src/Servant/Types/SourceT.hs
+++ b/servant/src/Servant/Types/SourceT.hs
@@ -212,7 +212,7 @@ instance (QC.Arbitrary a, Monad m) => QC.Arbitrary (StepT m a) where
 -- >>> source "foo" :: SourceT Identity Char
 -- fromStepT (Effect (Identity (Yield 'f' (Yield 'o' (Yield 'o' Stop)))))
 --
-source :: [a] -> SourceT m a
+source :: Foldable f => f a -> SourceT m a
 source = fromStepT . foldr Yield Stop
 
 -- | Get the answers.


### PR DESCRIPTION
I didn't see any reason to restrict this function to only work on lists, so I changed the type signature from

```haskell
source :: [a] -> SourceT m a
```

to

```haskell
source :: Foldable f => f a -> SourceT m a
```