### PR TITLE
servant-client: Run ClientEnv's makeClientRequest in IO

### DIFF
--- a/changelog.d/1595
+++ b/changelog.d/1595
@@ -1,0 +1,2 @@
+synopsis: Run ClientEnv's makeClientRequest in IO.
+prs: #1595

--- a/doc/cookbook/using-free-client/UsingFreeClient.lhs
+++ b/doc/cookbook/using-free-client/UsingFreeClient.lhs
@@ -119,7 +119,7 @@ Now we can use `servant-client`'s internals to convert servant's `Request`
 to http-client's `Request`, and we can inspect it:
 
 ```haskell
-        let req' = I.defaultMakeClientRequest burl req
+        req' <- I.defaultMakeClientRequest burl req
         putStrLn $ "Making request: " ++ show req'
 ```
 

--- a/servant-client/src/Servant/Client/Internal/HttpClient/Streaming.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient/Streaming.hs
@@ -140,7 +140,7 @@ performRequest :: Maybe [Status] -> Request -> ClientM Response
 performRequest acceptStatus req = do
     -- TODO: should use Client.withResponse here too
   ClientEnv m burl cookieJar' createClientRequest <- ask
-  let clientRequest = createClientRequest burl req
+  clientRequest <- liftIO $ createClientRequest burl req
   request <- case cookieJar' of
     Nothing -> pure clientRequest
     Just cj -> liftIO $ do
@@ -177,7 +177,7 @@ performWithStreamingRequest req k = do
   m <- asks manager
   burl <- asks baseUrl
   createClientRequest <- asks makeClientRequest
-  let request = createClientRequest burl req
+  request <- liftIO $ createClientRequest burl req
   ClientM $ lift $ lift $ Codensity $ \k1 ->
       Client.withResponse request m $ \res -> do
           let status = Client.responseStatus res

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -162,7 +162,8 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
       mgr <- C.newManager C.defaultManagerSettings
       -- In proper situation, extra headers should probably be visible in API type.
       -- However, testing for response timeout is difficult, so we test with something which is easy to observe
-      let createClientRequest url r = (defaultMakeClientRequest url r) { C.requestHeaders = [("X-Added-Header", "XXX")] }
+      let createClientRequest url r = fmap (\req -> req { C.requestHeaders = [("X-Added-Header", "XXX")] })
+                                           (defaultMakeClientRequest url r)
           clientEnv = (mkClientEnv mgr baseUrl) { makeClientRequest = createClientRequest }
       res <- runClientM (getRawSuccessPassHeaders HTTP.methodGet) clientEnv
       case res of


### PR DESCRIPTION
Use cases:
- [applyDigestAuth](https://hackage.haskell.org/package/http-client-tls-0.3.6.1/docs/Network-HTTP-Client-TLS.html#v:applyDigestAuth)
- Sign requests