### PR TITLE
Escape special chars in QueryParams

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Request.hs
@@ -51,9 +51,9 @@ import           Network.HTTP.Media
                  (MediaType)
 import           Network.HTTP.Types
                  (Header, HeaderName, HttpVersion (..), Method, QueryItem,
-                 http11, methodGet)
+                 http11, methodGet, urlEncodeBuilder)
 import           Servant.API
-                 (ToHttpApiData, toEncodedUrlPiece, toHeader, SourceIO)
+                 (ToHttpApiData, toEncodedUrlPiece, toQueryParam, toHeader, SourceIO)
 
 import Servant.Client.Core.Internal (mediaTypeRnf)
 
@@ -165,7 +165,8 @@ appendToQueryString pname pvalue req
 -- | Encode a query parameter value.
 --
 encodeQueryParamValue :: ToHttpApiData a => a  -> BS.ByteString
-encodeQueryParamValue = LBS.toStrict . Builder.toLazyByteString . toEncodedUrlPiece
+encodeQueryParamValue = LBS.toStrict . Builder.toLazyByteString
+  . urlEncodeBuilder True . encodeUtf8 . toQueryParam
 
 -- | Add header to the request being constructed.
 --


### PR DESCRIPTION
closes #1584

I was investigating a bug in our application and it turned out it was caused by servant-client not escaping plus signs in query params. After some digging down the code in servant-client I noticed servant-client uses `toEncodedUrlPiece` to encode the values of QueryParams, which is wrong because it should be used for path pieces only and it does not escape characters `:@&=+$,`. Later I found https://github.com/haskell-servant/servant/issues/1584 and https://github.com/haskell-servant/servant/pull/1586. Here I'm suggesting a workaround — using `urlEncodeBuilder True` directly instead of `toEncodedUrlPiece`.

At first I thought the `toEncodedUrlPiece` is itself the source of the problem and created a PR to https://github.com/fizruk/http-api-data/pull/119. The conclusion there was that it is wrong to encode query params with `toEncodedUrlPiece` and that this should be changed in servant-client, even though it's weird that ToHttpAPIData only has method for encoding path pieces