### PR TITLE
Add JWT token expiration at JWTSettings level - NominalDiffTime

### DIFF
--- a/servant-auth/servant-auth-server/README.lhs
+++ b/servant-auth/servant-auth-server/README.lhs
@@ -134,7 +134,7 @@ mainWithJWT = do
      xs <- words <$> getLine
      case xs of
        [name', email'] -> do
-         etoken <- makeJWT (User name' email') jwtCfg Nothing
+         etoken <- makeJWT (User name' email') jwtCfg
          case etoken of
            Left e -> putStrLn $ "Error generating token:t" ++ show e
            Right v -> putStrLn $ "New token:\t" ++ show v

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -37,6 +37,10 @@ data JWTSettings = JWTSettings
   -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
   -- intended recipient of the JWT.
   , audienceMatches :: Jose.StringOrURI -> IsMatch
+
+  -- | How long from now until the jwt expires. Default: @Nothing@.
+  , expiresIn      :: Maybe NominalDiffTime
+
   } deriving (Generic)
 
 -- | A @JWTSettings@ where the audience always matches.
@@ -45,7 +49,9 @@ defaultJWTSettings k = JWTSettings
    { signingKey = k
    , jwtAlg = Nothing
    , validationKeys = pure $ Jose.JWKSet [k]
-   , audienceMatches = const Matches }
+   , audienceMatches = const Matches
+   , expiresIn = Nothing
+   }
 
 -- | The policies to use when generating cookies.
 --

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -4,8 +4,6 @@ module Servant.Auth.Server.Internal.Cookie where
 import           Blaze.ByteString.Builder (toByteString)
 import           Control.Monad.Except
 import           Control.Monad.Reader
-import qualified Crypto.JOSE              as Jose
-import qualified Crypto.JWT               as Jose
 import           Data.ByteArray           (constEq)
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Base64   as BS64
@@ -21,7 +19,7 @@ import           Servant                  (AddHeader, addHeader)
 import           System.Entropy           (getEntropy)
 import           Web.Cookie
 
-import Servant.Auth.JWT                          (FromJWT (decodeJWT), ToJWT)
+import Servant.Auth.JWT                          (FromJWT, ToJWT)
 import Servant.Auth.Server.Internal.ConfigTypes
 import Servant.Auth.Server.Internal.JWT          (makeJWT, verifyJWT)
 import Servant.Auth.Server.Internal.Types
@@ -80,7 +78,7 @@ makeCsrfCookie = makeXsrfCookie
 -- | Makes a cookie with session information.
 makeSessionCookie :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe SetCookie)
 makeSessionCookie cookieSettings jwtSettings v = do
-  ejwt <- makeJWT v jwtSettings (cookieExpires cookieSettings)
+  ejwt <- makeJWT v jwtSettings
   case ejwt of
     Left _ -> return Nothing
     Right jwt -> return


### PR DESCRIPTION
## Introduction

The ability to set expiration to the `JWT Token` in `servant-auth-server` library, rests on the `CookieSettings`  data type configuration and in particular in the field `cookieExpires`  as we can appreciate it [here](https://github.com/haskell-servant/servant/blob/f0e2316895ee5fda52ba9d5b2b7e10f8a80a9019/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs#L66).

## Discussion

The problems regarding using this field for setting `JWT Token` expiration time are the following:
1. `CookieSettings` are usually created at application startup time and it keeps with the same values during the whole application life cycle. Since `cookieExpires` is an absolute and deterministic point in time, futures `JWT Tokens` will contain precisely the same expiration time leading to an undesired behavior and expiring the token upon creation. 
2. `CookieSettings` is a particular Data Type for all the cookies and `JWT Token` should not be coupled to the rest of the cookies. 
3. With the current setup and using the automatic authentication schema like the one described [here](https://docs.servant.dev/en/stable/cookbook/jwt-and-basic-auth/JWTAndBasicAuth.html), it is not possible to configure the application to create `JWT Tokens` with specific `DiffTime` expirations, like for example configure the authentication context to create a JWT that expires in 2 hours, even using `CookieSettings.cookieExpires`.
4. The only possible way to do this is using the `acceptLogin` function and the creation of the `CookieSettings` value every time the entity authenticates successfully, but this authentication setup is manual and cannot be done with `BasicAuthentication` combinator. 

## Proposal
The proposal is implemented in this PR and includes the following changes:

1. Add `expiresIn :: Maybe NominalDiffTime` in `JWTSettings` 
2. Remove `Maybe UTCTime` parameter from `makeJWT` function.
3. Calculate expiration on `makeJWT` function using `getCurrentTime + expiresIn` if it is present.  

## Solution

- The implemented solution will allow to create once `JWTSettings` and `CookieSettings` but allow the user to set an optional  `NominalDiffTime` to calculate the expiration of the `JWT Token` upon token creation if the value is present.
- This removes the need of calling explicitly `acceptLogin` and allowing `BasicAuthentication` context to handle the creation of the token by itself.



