### PR TITLE
Full query string helpers

### DIFF
--- a/changelog.d/1604
+++ b/changelog.d/1604
@@ -1,0 +1,10 @@
+synopsis: Full query string helpers
+prs: #1604
+
+description: {
+  This PR introduces `DeepQuery`, a route combinator that implements a pattern commonly known as deep objects.
+  It builds upon the convention of using `[]` for a list of parameters: 
+  `books?filter[search]=value&filter[author][name]=value`.
+  The corresponding type would be `DeepQuery "filter" BookQuery :> Get '[JSON] [Book]`.
+
+}

--- a/servant-client-core/src/Servant/Client/Core/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Request.hs
@@ -18,6 +18,7 @@ module Servant.Client.Core.Request (
     appendToPath,
     appendToQueryString,
     encodeQueryParamValue,
+    setQueryString,
     setRequestBody,
     setRequestBodyLBS,
     ) where
@@ -50,7 +51,7 @@ import           GHC.Generics
 import           Network.HTTP.Media
                  (MediaType)
 import           Network.HTTP.Types
-                 (Header, HeaderName, HttpVersion (..), Method, QueryItem,
+                 (Header, HeaderName, HttpVersion (..), Method, Query, QueryItem,
                  http11, methodGet, urlEncodeBuilder)
 import           Servant.API
                  (ToHttpApiData, toEncodedUrlPiece, toQueryParam, toHeader, SourceIO)
@@ -161,6 +162,12 @@ appendToQueryString :: Text                -- ^ query param name
 appendToQueryString pname pvalue req
   = req { requestQueryString = requestQueryString req
                         Seq.|> (encodeUtf8 pname, pvalue)}
+
+setQueryString :: Query
+               -> Request
+               -> Request
+setQueryString query req
+  = req { requestQueryString = Seq.fromList query }
 
 -- | Encode a query parameter value.
 --

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -110,6 +110,13 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
       forM_ [False, True] $ \ flag -> it (show flag) $ \(_, baseUrl) -> do
         left show <$> runClient (getQueryFlag flag) baseUrl `shouldReturn` Right flag
 
+    it "Servant.API.QueryParam.QueryString" $ \(_, baseUrl) -> do
+      let qs = [("name", Just "bob"), ("age", Just "1")]
+      left show <$> runClient (getQueryString qs) baseUrl `shouldReturn` (Right (Person "bob" 1))
+
+    it "Servant.API.QueryParam.DeepQuery" $ \(_, baseUrl) -> do
+       left show <$> runClient (getDeepQuery $ Filter 1 "bob") baseUrl `shouldReturn` (Right (Person "bob" 1))
+
     it "Servant.API.Fragment" $ \(_, baseUrl) -> do
       left id <$> runClient getFragment baseUrl `shouldReturn` Right alice
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -47,6 +47,7 @@ library
     Servant.API.Modifiers
     Servant.API.NamedRoutes
     Servant.API.QueryParam
+    Servant.API.QueryString
     Servant.API.Raw
     Servant.API.RemoteHost
     Servant.API.ReqBody
@@ -83,6 +84,7 @@ library
       base                   >= 4.9      && < 4.20
     , bytestring             >= 0.10.8.1 && < 0.13
     , constraints            >= 0.2
+    , containers             >= 0.6      && < 0.7
     , mtl                    ^>= 2.2.2   || ^>= 2.3.1
     , sop-core               >= 0.4.0.0  && < 0.6
     , transformers           >= 0.5.2.0  && < 0.7

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -19,6 +19,8 @@ module Servant.API (
   -- | Retrieving the HTTP version of the request
   module Servant.API.QueryParam,
   -- | Retrieving parameters from the query string of the 'URI': @'QueryParam'@
+  module Servant.API.QueryString,
+  -- | Retrieving the complete query string of the 'URI': @'QueryString'@
   module Servant.API.Fragment,
   -- | Documenting the fragment of the 'URI': @'Fragment'@
   module Servant.API.ReqBody,
@@ -118,6 +120,8 @@ import           Servant.API.NamedRoutes
                  (NamedRoutes)
 import           Servant.API.QueryParam
                  (QueryFlag, QueryParam, QueryParam', QueryParams)
+import           Servant.API.QueryString
+                 (QueryString, DeepQuery)
 import           Servant.API.Raw
                  (Raw, RawM)
 import           Servant.API.RemoteHost

--- a/servant/src/Servant/API/QueryString.hs
+++ b/servant/src/Servant/API/QueryString.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+module Servant.API.QueryString (QueryString, DeepQuery, FromDeepQuery (..), ToDeepQuery (..), generateDeepParam) where
+
+import Data.Bifunctor (Bifunctor (first))
+#if MIN_VERSION_base(4,9,0)
+import Data.Kind (Type)
+#endif
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Typeable
+  ( Typeable,
+  )
+import GHC.TypeLits
+  ( Symbol,
+  )
+import Web.HttpApiData (FromHttpApiData)
+import Web.Internal.HttpApiData (FromHttpApiData (..))
+
+-- | Extract the whole query string from a request. This is useful for query strings
+-- containing dynamic parameter names. For query strings with static parameter names,
+-- 'QueryParam' is more suited.
+--
+-- Example:
+--
+-- >>> -- /books?author=<author name>&year=<book year>
+-- >>> type MyApi = "books" :> QueryString :> Get '[JSON] [Book]
+data QueryString
+  deriving (Typeable)
+
+-- | Extract an deep object from a query string.
+--
+-- Example:
+--
+-- >>> -- /books?filter[author][name]=<author name>&filter[year]=<book year>
+-- >>> type MyApi = "books" :> DeepQuery "filter" BookQuery :> Get '[JSON] [Book]
+data DeepQuery (sym :: Symbol) (a :: Type)
+  deriving (Typeable)
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Servant.API
+-- >>> import Data.Aeson
+-- >>> import Data.Text
+-- >>> data Book
+-- >>> data BookQuery
+-- >>> instance ToJSON Book where { toJSON = undefined }
+
+-- | Extract a deep object from (possibly nested) query parameters.
+-- a param like @filter[a][b][c]=d@ will be represented as
+-- @'(["a", "b", "c"], Just "d")'@. Note that a parameter with no
+-- nested field is possible: @filter=a@ will be represented as
+-- @'([], Just "a")'@
+class FromDeepQuery a where
+  fromDeepQuery :: [([Text], Maybe Text)] -> Either String a
+
+instance (FromHttpApiData a) => FromDeepQuery (Map Text a) where
+  fromDeepQuery params =
+    let parseParam ([k], Just rawV) = (k,) <$> first T.unpack (parseQueryParam rawV)
+        parseParam (_, Nothing) = Left "Empty map value"
+        parseParam ([], _) = Left "Empty map parameter"
+        parseParam (_, Just _) = Left "Nested map values"
+     in Map.fromList <$> traverse parseParam params
+
+-- | Generate query parameters from an object, using the deep object syntax.
+-- A result of @'(["a", "b", "c"], Just "d")'@ attributed to the @filter@
+-- parameter name will result in the following query parameter:
+-- @filter[a][b][c]=d@
+class ToDeepQuery a where
+  toDeepQuery :: a -> [([Text], Maybe Text)]
+
+-- | Turn a nested path into a deep object query param
+--
+-- >>> generateDeepParam "filter" (["a", "b", "c"], Just "d")
+-- ("filter[a][b][c]",Just "d")
+generateDeepParam :: Text -> ([Text], Maybe Text) -> (Text, Maybe Text)
+generateDeepParam name (keys, value) =
+  let makeKeySegment key = "[" <> key <> "]"
+   in (name <> foldMap makeKeySegment keys, value)


### PR DESCRIPTION
The goal of this PR is to adress a use-case that is not currently covered by servant: query strings with dynamic parameter names.

`QueryParam` and its friends are super useful, but extract the parameter name from a type-level string, so while this is useful in many cases, it cannot cover every use-case. A typical use-case would be implementing a search filter where filters are not static and can't be enumerated ahead of time.

I'll propose two helpers, directly derived from a use case that came up at work:

- one is an escape hatch that extracts the whole query string as a `[(ByteString, Maybe ByteString)]` value. It cannot fail and provides raw access to the query string: `QueryString :> Get '[JSON] [Book]`.  
  This was the first version that i implemented for my concrete use-case at work, to get things going.
- the other one is a bit more constrained and implements a pattern commonly known as [_deep objects_](https://swagger.io/docs/specification/serialization/). It builds upon the convention of using `[]` for a list of parameters: `books?filter[search]=value&filter[author][name]=value`. The corresponding type would be `DeepQuery "filter" BookQuery :> Get '[JSON] [Book]`.  
 This is based on what's currently used for my use-case at work.
 

## Raw query string capture

- [x] Servant.API
- [x] Servant.Server
- [x] Servant.Server Specs
- [x] Servant.Server Docs
- [x] Servant.Client
- [x] Servant.Client Specs
- [x] Servant.Client Docs

## Deep object query parsing

- [x] Servant.API
- [x] Servant.Server
- [x] Servant.Server Specs
- [x] Servant.Server Docs
- [x] Servant.Client
- [x] Servant.Client Specs
- [x] Servant.Client Docs
