### PR TITLE
Handle Cookies correctly for RunStreamingClient

### DIFF
--- a/changelog.d/1606
+++ b/changelog.d/1606
@@ -1,0 +1,10 @@
+synopsis: Handle Cookies correctly for RunStreamingClient
+prs: #1606
+issues: #1605
+
+description: {
+
+Makes performWithStreamingRequest take into consideration the
+CookieJar, which it previously didn't.
+
+}


### PR DESCRIPTION
Makes `performWithStreamingRequest` take into consideration the
CookieJar, which it previously didn't.

It's now possible to e.g. use the servant-client generated functions to
access a streaming endpoint that depends on a cookie being set to
authenticate the user

Fixes #1605