### PR TITLE
bump GHC fix version and Cabal minor version in Github Action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.6"]
+        cabal: ["3.8.1.0"]
         ghc:
           - "8.6.5"
           - "8.8.4"
           - "8.10.7"
           - "9.0.2"
-          - "9.2.2"
+          - "9.2.4"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Cabal 3.8.1.0 and GHC 9.2.4

I tried `cabal: ["3.8"]` and `cabal: ["3.8.1"]` and these failed, so it is `cabal: ["3.8.1.0"]`