### PR TITLE
Remove allow-newer for postgresql-simple

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,8 +51,3 @@ packages:
 tests: True
 optimization: False
 -- reorder-goals: True
-
-allow-newer:
--- see https://github.com/haskellari/postgresql-simple/issues/104
-    postgresql-simple:base
-  , postgresql-simple:template-haskell


### PR DESCRIPTION
Upstream has released updated versions.