### PR TITLE
tree-wide: bump hspec bound to < 2.11

### DIFF
--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -50,7 +50,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.10
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -62,7 +62,7 @@ test-suite spec
  
   -- test dependencies
   build-depends:
-      hspec                >= 2.5.5    && < 2.10
+      hspec                >= 2.5.5    && < 2.11
     , QuickCheck           >= 2.11.3   && < 2.15
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.10.6.0 && < 0.12

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -64,7 +64,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.10
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -78,7 +78,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-docs
-    , hspec             >= 2.5.5  && < 2.10
+    , hspec             >= 2.5.5  && < 2.11
     , QuickCheck        >= 2.11.3 && < 2.15
 
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -102,7 +102,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.10
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -123,7 +123,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-server
-    , hspec       >= 2.5.5     && < 2.10
+    , hspec       >= 2.5.5     && < 2.11
     , QuickCheck  >= 2.11.3    && < 2.15
     , http-client >= 0.5.13.1  && < 0.8
     , lens-aeson  >= 1.0.2     && < 1.3

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -49,7 +49,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >= 2.5.5 && <2.10
+  build-tool-depends: hspec-discover:hspec-discover >= 2.5.5 && <2.11
   -- dependencies with bounds inherited from the library stanza
   build-depends:
       base
@@ -63,7 +63,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-swagger
-    , hspec      >= 2.5.5  && < 2.10
+    , hspec      >= 2.5.5  && < 2.11
     , QuickCheck >= 2.11.3 && < 2.15
   other-modules:
       Servant.Auth.SwaggerSpec

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:
@@ -104,8 +104,8 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       deepseq    >= 1.4.2.0  && < 1.5
-    , hspec      >= 2.6.0    && < 2.10
+    , hspec      >= 2.6.0    && < 2.11
     , QuickCheck >= 2.12.6.1 && < 2.15
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.10
+    hspec-discover:hspec-discover >= 2.6.0 && <2.11

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -20,7 +20,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:
@@ -124,7 +124,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.10
+    , hspec             >= 2.6.0    && < 2.11
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.2
     , QuickCheck        >= 2.12.6.1 && < 2.15
@@ -133,7 +133,7 @@ test-suite spec
     , tdigest           >= 0.2     && < 0.3
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.10
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
 
 test-suite readme
   type:           exitcode-stdio-1.0

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -19,7 +19,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -74,7 +74,7 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    hspec >= 2.6.0 && <2.10
+    hspec >= 2.6.0 && <2.11
   build-tool-depends:
-    hspec-discover:hspec-discover >=2.6.0 && <2.10
+    hspec-discover:hspec-discover >=2.6.0 && <2.11
   default-language:  Haskell2010

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -20,7 +20,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md
@@ -112,7 +112,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.10
+    , hspec             >= 2.6.0    && < 2.11
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.2
     , QuickCheck        >= 2.12.6.1 && < 2.15
@@ -121,7 +121,7 @@ test-suite spec
     , tdigest           >= 0.2     && < 0.3
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.10
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
 
 test-suite readme
   type:           exitcode-stdio-1.0

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -23,7 +23,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md
@@ -159,7 +159,7 @@ test-suite spec
   build-depends:
       aeson                >= 1.4.1.0  && < 3
     , directory            >= 1.3.0.0  && < 1.4
-    , hspec                >= 2.6.0    && < 2.10
+    , hspec                >= 2.6.0    && < 2.11
     , hspec-wai            >= 0.10.1   && < 0.12
     , QuickCheck           >= 2.12.6.1 && < 2.15
     , should-not-typecheck >= 2.1.0    && < 2.2
@@ -167,4 +167,4 @@ test-suite spec
     , wai-extra            >= 3.0.24.3 && < 3.2
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.10
+    hspec-discover:hspec-discover >= 2.6.0 && <2.11

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -28,7 +28,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           (c) 2015-2018, Servant contributors
 category:            Web, Servant, Swagger
 build-type:          Custom
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.4.2
 
 extra-source-files:
     README.md
@@ -92,7 +92,7 @@ test-suite doctests
   build-depends:
     base,
     directory >= 1.0,
-    doctest >= 0.17 && <0.21,
+    doctest >= 0.17 && <0.22,
     servant,
     QuickCheck,
     filepath

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -20,7 +20,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
 
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1 || ==9.4.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:
@@ -166,9 +166,9 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-      hspec                >= 2.6.0    && < 2.10
+      hspec                >= 2.6.0    && < 2.11
     , QuickCheck           >= 2.12.6.1 && < 2.15
     , quickcheck-instances >= 0.3.19   && < 0.4
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.10
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.11


### PR DESCRIPTION
This is required to work on the GHC 9.4.3 Nix package set.

Built and tested on GHC 9.4.3 (from Nix) on macOS/aarch64.