### PR TITLE
Use pkg-config for HsOpenSSL

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup
+      run: |
+        sudo apt update -y
+        sudo apt install -y libssl-dev
+        sudo ldconfig
+
     - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -99,6 +99,12 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         stack-version: ${{ matrix.stack }}
 
+    - name: Setup
+      run: |
+        sudo apt update -y
+        sudo apt install -y libssl-dev
+        sudo ldconfig
+
     - uses: actions/cache@v2.1.3
       name: Cache ~/.stack
       with:

--- a/cabal.project
+++ b/cabal.project
@@ -48,6 +48,9 @@ packages:
   doc/cookbook/using-free-client
   -- doc/cookbook/open-id-connect
 
+package HsOpenSSL
+  flags: +use-pkg-config
+
 tests: True
 optimization: False
 -- reorder-goals: True

--- a/cabal.project
+++ b/cabal.project
@@ -48,8 +48,10 @@ packages:
   doc/cookbook/using-free-client
   -- doc/cookbook/open-id-connect
 
-package HsOpenSSL
-  flags: +use-pkg-config
+source-repository-package
+  type: git
+  location: https://github.com/haskell-cryptography/HsOpenSSL.git
+  tag: e18303a
 
 tests: True
 optimization: False

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -648,7 +648,6 @@ simpleToLink _ toA _ = toLink toA (Proxy :: Proxy sub)
 -- $setup
 -- >>> import Servant.API
 -- >>> import Data.Text (Text)
-
 -- Erroring instance for 'HasLink' when a combinator is not fully applied
 instance TypeError (PartialApplication 
 #if __GLASGOW_HASKELL__ >= 904

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20
+resolver: lts-18.5
 packages:
 - servant-client-core/
 - servant-client/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.5
+resolver: lts-20
 packages:
 - servant-client-core/
 - servant-client/


### PR DESCRIPTION
We're getting a bunch of these errors in CI:

```
/home/runner/.cabal/store/ghc-9.0.2/HsOpenSSL-0.11.7.2-2f50dead591dd0867b55c1e835363a3ed95d8c266c738c1cb1ae501e62b70c50/lib/libHSHsOpenSSL-0.11.7.2-2f50dead591dd0867b55c1e835363a3ed95d8c266c738c1cb1ae501e62b70c50.a(Session.o):ghc_453.c:function HsOpenSSLzm0zi11zi7zi2zm2f50dead591dd0867b55c1e835363a3ed95d8c266c738c1cb1ae501e62b70c50_OpenSSLziSession_zdwio_info: error: undefined reference to 'SSL_get_peer_certificate'
```

I'm exploring whether or not using pkg-config for HsOpenSSL would help.