### PR TITLE
feat: Polymorphic `Elem` for `Union`

### DIFF
--- a/servant/src/Servant/API/UVerb/Union.hs
+++ b/servant/src/Servant/API/UVerb/Union.hs
@@ -128,9 +128,9 @@ type DuplicateElementError (rs :: [k]) =
     ':$$: 'Text "    " ':<>: 'ShowType rs
 
 type family Elem (x :: k) (xs :: [k]) :: Bool where
+  Elem x (x ': _) = 'True
+  Elem x (_ ': xs) = Elem x xs
   Elem _ '[] = 'False
-  Elem x (x' ': xs) =
-    If (x == x') 'True (Elem x xs)
 
 type family Unique xs :: Constraint where
   Unique xs = If (Nubbed xs == 'True) (() :: Constraint) (TypeError (DuplicateElementError xs))


### PR DESCRIPTION
The `Elem` call was not possible to resolve with polymophic type. For example, the following `forall a. Elem (Maybe a) '[Maybe a, Int]` cannot be resolved.

I don't really understand the reasons why, looks like the former implementation with `If (a == b)` does not work with polymophic types.

The new implementation uses pattern matching in closed type families.

Close #1590 and #1381.