### PR TITLE
Fix haddock code examples in HasClient

### DIFF
--- a/doc/cookbook/open-id-connect/OpenIdConnect.lhs
+++ b/doc/cookbook/open-id-connect/OpenIdConnect.lhs
@@ -330,7 +330,7 @@ data Customer = Customer {
 ```
 
 Here is the code that displays the homepage.
-It should contain a link to the the `/login` URL.
+It should contain a link to the `/login` URL.
 When the user clicks on this link it will be redirected to Google login page
 with some generated information.
 

--- a/doc/cookbook/uverb/UVerb.lhs
+++ b/doc/cookbook/uverb/UVerb.lhs
@@ -199,7 +199,7 @@ parsers in the hope that the ones that should will always error out so
 you can try until the right one returns a value.)
 
 [servant-exceptions](https://github.com/ch1bo/servant-exceptions) is
-another shot at at the problem.  It is inspired by
+another shot at the problem.  It is inspired by
 servant-checked-exceptions, so it may be worth taking a closer look.
 The README claims that
 [cardano-sl](https://github.com/input-output-hk/cardano-sl) also has

--- a/servant-auth/servant-auth/src/Servant/Auth.hs
+++ b/servant-auth/servant-auth/src/Servant/Auth.hs
@@ -27,7 +27,7 @@ instance HasLink sub => HasLink (Auth (tag :: [*]) value :> sub) where
 
 -- ** Combinators
 
--- | A JSON Web Token (JWT) in the the Authorization header:
+-- | A JSON Web Token (JWT) in the Authorization header:
 --
 --    @Authorization: Bearer \<token\>@
 --

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -902,7 +902,7 @@ infixl 2 /:
 -- rootClient = client api
 --
 -- endpointClient :: ClientM Person
--- endpointClient = client // subApi // endpoint
+-- endpointClient = client \/\/ subApi \/\/ endpoint
 -- @
 (//) :: a -> (a -> b) -> b
 x // f = f x
@@ -935,10 +935,10 @@ x // f = f x
 -- rootClient = client api
 --
 -- hello :: String -> ClientM String
--- hello name = rootClient // hello /: name
+-- hello name = rootClient \/\/ hello \/: name
 --
 -- endpointClient :: ClientM Person
--- endpointClient = client // subApi /: "foobar123" // endpoint
+-- endpointClient = client \/\/ subApi \/: "foobar123" \/\/ endpoint
 -- @
 (/:) :: (a -> b -> c) -> b -> a -> c
 (/:) = flip

--- a/servant-docs/src/Servant/Docs/Internal.hs
+++ b/servant-docs/src/Servant/Docs/Internal.hs
@@ -447,7 +447,7 @@ docsWith opts intros (ExtraInfo endpoints) p =
       & apiEndpoints %~ HM.unionWith (flip combineAction) endpoints
 
 
--- | Generate the docs for a given API that implements 'HasDocs' with with any
+-- | Generate the docs for a given API that implements 'HasDocs' with any
 -- number of introduction(s)
 docsWithIntros :: HasDocs api => [DocIntro] -> Proxy api -> API
 docsWithIntros intros = docsWith defaultDocOptions intros mempty


### PR DESCRIPTION
The code examples don't render properly, because '/' needs to be escaped when used in `@...@` code blocks.

### Before
![Screenshot from 2023-01-15 10-27-28](https://user-images.githubusercontent.com/2716069/212533285-17c05718-2bc7-4477-a1c1-5e3a8c25dff7.png)

### After

![Screenshot from 2023-01-15 10-22-31](https://user-images.githubusercontent.com/2716069/212533301-73db296c-4be5-449b-9f75-ded9b1aa9970.png)
