### PR TITLE
Require wai >= 3.2.2.1

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -91,7 +91,7 @@ library
     , resourcet           >= 1.2.2    && < 1.4
     , tagged              >= 0.8.6    && < 0.9
     , transformers-base   >= 0.4.5.2  && < 0.5
-    , wai                 >= 3.2.1.2  && < 3.3
+    , wai                 >= 3.2.2.1  && < 3.3
     , wai-app-static      >= 3.1.6.2  && < 3.2
     , word8               >= 0.1.3    && < 0.2
 


### PR DESCRIPTION
`Network.Wai.getRequestBodyChunk` is not available earlier than `wai-3.2.2.1`.

As a Hackage trustee I revised `servant-server-0.19.{1,2}`.