### PR TITLE
Allow http-api-data-0.5.1

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -73,7 +73,7 @@ library
   -- strict dependency as we re-export 'servant' things.
   build-depends:
       servant             >= 0.19     && < 0.20
-    , http-api-data       >= 0.4.1    && < 0.5.1
+    , http-api-data       >= 0.4.1    && < 0.6
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -93,8 +93,8 @@ library
   -- We depend (heavily) on the API of these packages:
   -- i.e. re-export, or allow using without direct dependency
   build-depends:
-      http-api-data          >= 0.4.1    && < 0.5.1
-    , singleton-bool         >= 0.1.4    && < 0.1.7
+      http-api-data          >= 0.4.1    && < 0.6
+    , singleton-bool         >= 0.1.4    && < 0.2
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.


### PR DESCRIPTION
v0.5.1 is the first version of http-api-data that supports base-4.18 (which is what GHC 9.6) uses. So this is necessary to fix #1659.

I also relaxed the bounds of singleton-bool, since if the library follows PVP conventions, any other 0.1 series release should also be compatible.