### PR TITLE
Allow semigroupoids < 6.1

### DIFF
--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -49,7 +49,7 @@ library
     , http-types          >=0.12    && <0.13
     , monad-control       >=1.0.0.4 && <1.1
     , mtl                 ^>=2.2.2  || ^>=2.3.1
-    , semigroupoids       >=5.3     && <5.4
+    , semigroupoids       >=5.3     && <6.1
     , string-conversions  >=0.3     && <0.5
     , transformers        >=0.3     && <0.6
     , transformers-base   >=0.4.4   && <0.5

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -71,7 +71,7 @@ library
     , exceptions            >= 0.10.0   && < 0.11
     , kan-extensions        >= 5.2      && < 5.3
     , monad-control         >= 1.0.2.3  && < 1.1
-    , semigroupoids         >= 5.3.1    && < 5.4
+    , semigroupoids         >= 5.3.1    && < 6.1
     , transformers-base     >= 0.4.5.2  && < 0.5
     , transformers-compat   >= 0.6.2    && < 0.8
 

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -70,7 +70,7 @@ library
     , exceptions            >= 0.10.0   && < 0.11
     , kan-extensions        >= 5.2      && < 5.3
     , monad-control         >= 1.0.2.3  && < 1.1
-    , semigroupoids         >= 5.3.1    && < 5.4
+    , semigroupoids         >= 5.3.1    && < 6.1
     , transformers-base     >= 0.4.5.2  && < 0.5
     , transformers-compat   >= 0.6.2    && < 0.8
 


### PR DESCRIPTION
Relaxes bounds on `semigroupoids` for `servant-client` and `servant-http-streams`