### PR TITLE
Remove commented code and unused dependency (tdigest)

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -130,7 +130,6 @@ test-suite spec
     , QuickCheck        >= 2.12.6.1 && < 2.15
     , servant           == 0.19.*
     , servant-server    == 0.19.*
-    , tdigest           >= 0.2     && < 0.3
 
   build-tool-depends:
     hspec-discover:hspec-discover >= 2.6.0 && < 2.10

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -118,7 +118,6 @@ test-suite spec
     , QuickCheck        >= 2.12.6.1 && < 2.15
     , servant           == 0.19.*
     , servant-server    == 0.19.*
-    , tdigest           >= 0.2     && < 0.3
 
   build-tool-depends:
     hspec-discover:hspec-discover >= 2.6.0 && < 2.10


### PR DESCRIPTION
Instead of having commented code around and an unused dependency, let's remove
both. This will improve compatibilty with GHC 9.6 since tdigest is not yet
compatible with semigroupoids-6, which is the first release of semigroupoids
that supports GHC 9.6.
