### PR TITLE
Fix haddocks for type families in Servant.API.UVerb.Union

### DIFF
--- a/servant/src/Servant/API/UVerb/Union.hs
+++ b/servant/src/Servant/API/UVerb/Union.hs
@@ -111,8 +111,8 @@ instance {-# OVERLAPPING #-} UElem x xs => UElem x (x' ': xs) where
   eject (Z _) = Nothing
   eject (S ns) = eject ns
 
--- | Check whether @a@ is in list.  This will throw nice errors if the element is not in the
--- list, or if there is a duplicate in the list.
+-- | Check whether @a@ is in given type-level list.
+-- This will throw a nice error if the element is not in the list.
 type family CheckElemIsMember (a :: k) (as :: [k]) :: Constraint where
     CheckElemIsMember a as =
       If (Elem a as) (() :: Constraint) (TypeError (NoElementError a as))
@@ -132,6 +132,8 @@ type family Elem (x :: k) (xs :: [k]) :: Bool where
   Elem x (_ ': xs) = Elem x xs
   Elem _ '[] = 'False
 
+-- | Check whether all values in a type-level list are distinct.
+-- This will throw a nice error if there are any duplicate elements in the list.
 type family Unique xs :: Constraint where
   Unique xs = If (Nubbed xs == 'True) (() :: Constraint) (TypeError (DuplicateElementError xs))
 


### PR DESCRIPTION
The comment says `CheckElemIsMember` can throw error which it cannot actually throw.
But that error can be thrown by *another* type family in this module - `Unique`