### PR TITLE
Documentation: Update commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing Guidelines
 
-Contributions are very welcome! To hack on the github version, clone the
-repository. You can use `cabal`:
+Contributions are very welcome! To hack on the github version, clone the repository. You can use `cabal`:
 
 ```shell
 cabal build all  # Install dependencies and build packages
@@ -36,8 +35,7 @@ Some things we like:
 - Few dependencies
 - -Werror-compatible (7.8, 7.10 and 8.0)
 
-Though we aren't sticklers for style, the `.stylish-haskell.yaml` and `HLint.hs`
-files in the repository provide a good baseline for consistency.
+Though we aren't sticklers for style, the `.stylish-haskell.yaml` and `HLint.hs` files in the repository provide a good baseline for consistency.
 
 **Important**: please do not modify the versions of the servant packages you are sending patches for.
 
@@ -70,52 +68,27 @@ for prose.
 
 ## PR process
 
-We try to give timely reviews to PRs that pass CI. If CI for your PR fails, we
-may close the PR if it has been open for too long (though you should feel free
-to reopen when the issues have been fixed).
+We try to give timely reviews to PRs that pass CI. If CI for your PR fails, we may close the PR if it has been open for too long (though you should feel free to reopen when the issues have been fixed).
 
-We require two +1 from the maintainers of the repo. If you feel like there has
-not been a timely response to a PR, you can ping the Maintainers group (with
-`@haskell-servant/maintainers`).
+We require two +1 from the maintainers of the repo. If you feel like there has not been a timely response to a PR, you can ping the Maintainers group (with `@haskell-servant/maintainers`).
 
 ## New combinators
 
-We encourage people to experiment with new combinators and instances - it is
-one of the most powerful ways of using `servant`, and a wonderful way of
-getting to know it better. If you do write a new combinator, we would love to
-know about it! Either hop on
-[#haskell-servant on libera.chat](https://web.libera.chat/#haskell-servant) and
-let us know, or open an issue with the `news` tag (which we will close when we
-read it).
+We encourage people to experiment with new combinators and instances - it is one of the most powerful ways of using `servant`, and a wonderful way of getting to know it better. If you do write a new combinator, we would love to know about it! Either hop on [#haskell-servant on libera.chat](https://web.libera.chat/#haskell-servant) and let us know, or open an issue with the `news` tag (which we will close when we read it).
 
-As for adding them to the main repo: maintaining combinators can be expensive,
-since official combinators must have instances for all classes (and new classes
-come along fairly frequently). We therefore have to be quite selective about
-those that we accept. If you're considering writing a new combinator, open an
-issue to discuss it first!  Or contribute it to the
-[servant-contrib](https://github.com/haskell-servant/servant-contrib) repository.
+As for adding them to the main repo: maintaining combinators can be expensive, since official combinators must have instances for all classes (and new classes come along fairly frequently). We therefore have to be quite selective about those that we accept. If you're considering writing a new combinator, open an issue to discuss it first! Or contribute it to the [servant-contrib](https://github.com/haskell-servant/servant-contrib) repository.
 You could release your combinator as a separate package, of course.
-
 
 ## New classes
 
-The main benefit of having a new class and package in the main servant repo is
-that we get to see via CI whether changes to other packages break the build.
-Open an issue to discuss whether a package should be added to the main repo. If
-we decide that it can, you can still keep maintainership over it.
+The main benefit of having a new class and package in the main servant repo is that we get to see via CI whether changes to other packages break the build. Open an issue to discuss whether a package should be added to the main repo. If we decide that it can, you can still keep maintainership over it.
 
-Whether or not you want your package to be in the repo, create an issue with
-the `news` label if you make a new package so we can know about it!
+Whether or not you want your package to be in the repo, create an issue with the `news` label if you make a new package so we can know about it!
 
 ## Release policy
 
-We are currently moving to a more aggressive release policy, so that you can get
-what you contribute from Hackage fairly soon. However, note that prior to major
-releases it may take some time in between releases.
+We are currently moving to a more aggressive release policy, so that you can get what you contribute from Hackage fairly soon. However, note that prior to major releases it may take some time in between releases.
 
 ## Reporting security issues
 
-Please email haskell-servant-maintainers AT googlegroups DOT com. This group is
-private, and accessible only to known maintainers. We will then discuss how to
-proceed. Please do not make the issue public before we inform you that we have
-a patch ready.
+Please email haskell-servant-maintainers AT googlegroups DOT com. This group is private, and accessible only to known maintainers. We will then discuss how to proceed. Please do not make the issue public before we inform you that we have a patch ready.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,25 @@ Contributions are very welcome! To hack on the github version, clone the
 repository. You can use `cabal`:
 
 ```shell
-./scripts/start-sandbox.sh # Initialize the sandbox and add-source the packages
-./scripts/test-all.sh      # Run all the tests
+cabal build all  # Install dependencies and build packages
+cabal test all   # Run all the tests
 ```
 
 Or `stack`:
 
 ```shell
-stack setup                    # Downloads and installs a proper GHC version if necessary
-stack build --fast --pedantic  # Install dependencies and build packages
-stack test                     # Run all the tests
+stack setup         # Downloads and installs a proper GHC version if necessary
+stack build --fast  # Install dependencies and build packages
+stack test          # Run all the tests
 ```
 
 Or `nix`:
+
 ```shell
-./scripts/generate-nix-files.sh   # Get up-to-date shell.nix files
+nix-shell nix/shell.nix  # Enter a new development shell with Cabal and Stack
+
+# Alternatively, another version of GHC can be used. See nix/README.md for more info.
+nix-shell nix/shell.nix --argstr compiler ghc901
 ```
 
 To build the docs, see `doc/README.md`.


### PR DESCRIPTION
This PR updates the commands mentioned in CONTRIBUTING.md. It removes the no longer existing scripts in favor of up-to-date Cabal / Stack / Nix commands.

Should fix #1027.

This PR also uses consistent longer lines in the file, but it might be less desirable. The associated commit can be removed if it is.