### PR TITLE
Allow bifunctors <6

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -61,7 +61,7 @@ library
 
   if !impl(ghc >= 8.2)
     build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+      bifunctors >= 5.5.3 && < 6
 
   -- Servant dependencies
   build-depends:

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -53,7 +53,7 @@ library
 
   if !impl(ghc >= 8.2)
     build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+      bifunctors >= 5.5.3 && < 6
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -49,7 +49,7 @@ library
 
   if !impl(ghc >= 8.2)
     build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+      bifunctors >= 5.5.3 && < 6
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -102,7 +102,7 @@ library
       base-compat            >= 0.10.5   && < 0.14
     , aeson                  >= 1.4.1.0  && < 3
     , attoparsec             >= 0.13.2.2 && < 0.15
-    , bifunctors             >= 5.5.3    && < 5.7
+    , bifunctors             >= 5.5.3    && < 6
     , case-insensitive       >= 1.2.0.11 && < 1.3
     , deepseq                >= 1.4.2.0  && < 1.5
     , http-media             >= 0.7.1.3  && < 0.9


### PR DESCRIPTION
Matches version upper bounds for `bifunctors` in the `semigroupoids` package