### PR TITLE
Avoid crypton dependency for now

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -52,3 +52,8 @@ packages:
 tests: True
 optimization: False
 -- reorder-goals: True
+
+-- The switch to crypton breaks the build, so let's avoid it for now
+-- https://github.com/snoyberg/http-client/issues/508
+constraints: crypton < 0, crypton-connection < 0, crypton-x509 < 0, crypton-x509-store < 0, crypton-x509-system < 0, crypton-x509-validation < 0
+constraints: warp < 3.3.26


### PR DESCRIPTION
The crypton fork of cryptonite seems to have broken its use in servant (CI for master is currently broken). So for now, let's avoid crypton. Since this is in `cabal.project`, it won't affect users of the libraries, only developers.

* https://github.com/yesodweb/wai/issues/932
* https://github.com/yesodweb/wai/issues/934
* https://github.com/snoyberg/http-client/issues/508