### PR TITLE
Add attoparsec-aeson dependency

### DIFF
--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -102,6 +102,7 @@ library
       base-compat            >= 0.10.5   && < 0.14
     , aeson                  >= 1.4.1.0  && < 3
     , attoparsec             >= 0.13.2.2 && < 0.15
+    , attoparsec-aeson       >= 2.2      && < 3
     , bifunctors             >= 5.5.3    && < 5.7
     , case-insensitive       >= 1.2.0.11 && < 1.3
     , deepseq                >= 1.4.2.0  && < 1.5


### PR DESCRIPTION
This makes `servant` buildable with the upcoming aeson-2.2 release.