### PR TITLE
Allow newer hspec, free

### DIFF
--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -50,7 +50,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.12
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -62,7 +62,7 @@ test-suite spec
  
   -- test dependencies
   build-depends:
-      hspec                >= 2.5.5    && < 2.11
+      hspec                >= 2.5.5    && < 2.12
     , QuickCheck           >= 2.11.3   && < 2.15
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.10.6.0 && < 0.12

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -64,7 +64,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.12
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -78,7 +78,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-docs
-    , hspec             >= 2.5.5  && < 2.11
+    , hspec             >= 2.5.5  && < 2.12
     , QuickCheck        >= 2.11.3 && < 2.15
 
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -44,7 +44,7 @@ library
     , jose                    >= 0.10     && < 0.11
     , lens                    >= 4.16.1   && < 5.3
     , memory                  >= 0.14.16  && < 0.19
-    , monad-time              >= 0.3.1.0  && < 0.4
+    , monad-time              >= 0.3.1.0  && < 0.5
     , mtl                     ^>= 2.2.2   || ^>= 2.3.1
     , servant                 >= 0.13     && < 0.21
     , servant-auth            == 0.4.*
@@ -102,7 +102,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.11
+  build-tool-depends: hspec-discover:hspec-discover >=2.5.5 && <2.12
 
   -- dependencies with bounds inherited from the library stanza
   build-depends:
@@ -123,7 +123,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-server
-    , hspec       >= 2.5.5     && < 2.11
+    , hspec       >= 2.5.5     && < 2.12
     , QuickCheck  >= 2.11.3    && < 2.15
     , http-client >= 0.5.13.1  && < 0.8
     , lens-aeson  >= 1.0.2     && < 1.3

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -49,7 +49,7 @@ test-suite spec
       test
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
-  build-tool-depends: hspec-discover:hspec-discover >= 2.5.5 && <2.11
+  build-tool-depends: hspec-discover:hspec-discover >= 2.5.5 && <2.12
   -- dependencies with bounds inherited from the library stanza
   build-depends:
       base
@@ -63,7 +63,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-swagger
-    , hspec      >= 2.5.5  && < 2.11
+    , hspec      >= 2.5.5  && < 2.12
     , QuickCheck >= 2.11.3 && < 2.15
   other-modules:
       Servant.Auth.SwaggerSpec

--- a/servant-auth/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth/servant-auth.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
       base                    >= 4.10     && < 4.19
     , containers              >= 0.6      && < 0.7
-    , aeson                   >= 1.3.1.1  && < 3
+    , aeson                   >= 2.0      && < 3
     , jose                    >= 0.10     && < 0.11
     , lens                    >= 4.16.1   && < 5.3
     , servant                 >= 0.15     && < 0.21

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -74,7 +74,7 @@ library
     , base-compat           >= 0.10.5   && < 0.14
     , base64-bytestring     >= 1.0.0.1  && < 1.3
     , exceptions            >= 0.10.0   && < 0.11
-    , free                  >= 5.1      && < 5.2
+    , free                  >= 5.1      && < 5.3
     , http-media            >= 0.7.1.3  && < 0.9
     , http-types            >= 0.12.2   && < 0.13
     , network-uri           >= 2.6.1.0  && < 2.7
@@ -104,8 +104,8 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       deepseq    >= 1.4.2.0  && < 1.5
-    , hspec      >= 2.6.0    && < 2.11
+    , hspec      >= 2.6.0    && < 2.12
     , QuickCheck >= 2.12.6.1 && < 2.15
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.11
+    hspec-discover:hspec-discover >= 2.6.0 && <2.12

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -51,13 +51,13 @@ library
     , mtl                 ^>=2.2.2  || ^>=2.3.1
     , semigroupoids       >=5.3     && <6.1
     , string-conversions  >=0.3     && <0.5
-    , transformers        >=0.3     && <0.6
+    , transformers        >=0.3     && <0.7
     , transformers-base   >=0.4.4   && <0.5
 
   -- strict, as we re-export stuff
   build-depends:
-      servant              >=0.16 && <0.20
-    , servant-client-core  >=0.16 && <0.20
+      servant              >=0.20 && <0.21
+    , servant-client-core  >=0.20 && <0.21
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -124,7 +124,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.11
+    , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.2
     , QuickCheck        >= 2.12.6.1 && < 2.15
@@ -132,7 +132,7 @@ test-suite spec
     , servant-server    >= 0.20     && < 0.21
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
 
 test-suite readme
   type:           exitcode-stdio-1.0

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -74,7 +74,7 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    hspec >= 2.6.0 && <2.11
+    hspec >= 2.6.0 && <2.12
   build-tool-depends:
-    hspec-discover:hspec-discover >=2.6.0 && <2.11
+    hspec-discover:hspec-discover >=2.6.0 && <2.12
   default-language:  Haskell2010

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -112,7 +112,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.11
+    , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.2
     , QuickCheck        >= 2.12.6.1 && < 2.15
@@ -120,7 +120,7 @@ test-suite spec
     , servant           >= 0.20 && < 0.21
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
 
 test-suite readme
   type:           exitcode-stdio-1.0

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -159,7 +159,7 @@ test-suite spec
   build-depends:
       aeson                >= 1.4.1.0  && < 3
     , directory            >= 1.3.0.0  && < 1.4
-    , hspec                >= 2.6.0    && < 2.11
+    , hspec                >= 2.6.0    && < 2.12
     , hspec-wai            >= 0.10.1   && < 0.12
     , QuickCheck           >= 2.12.6.1 && < 2.15
     , should-not-typecheck >= 2.1.0    && < 2.2
@@ -167,4 +167,4 @@ test-suite spec
     , wai-extra            >= 3.0.24.3 && < 3.2
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.11
+    hspec-discover:hspec-discover >= 2.6.0 && <2.12

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -106,11 +106,11 @@ test-suite spec
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.11
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
   build-depends:    base
                   , base-compat
                   , aeson >=1.4.2.0 && <3
-                  , hspec >=2.6.0 && <2.11
+                  , hspec >=2.6.0 && <2.12
                   , QuickCheck
                   , lens
                   , lens-aeson >=1.0.2    && <1.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -167,9 +167,9 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-      hspec                >= 2.6.0    && < 2.11
+      hspec                >= 2.6.0    && < 2.12
     , QuickCheck           >= 2.12.6.1 && < 2.15
     , quickcheck-instances >= 0.3.19   && < 0.4
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.12


### PR DESCRIPTION
Especially the free bound is important for inclusion into Stackage Nightly.

I have also bumped the min bound for servant-auth, since jose-0.10 requires aeson-2, we might as well.

Also included is a bump for monad-time.
