### PR TITLE
Adjust bounds for http-api-data and aeson

### DIFF
--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -73,7 +73,7 @@ library
   -- strict dependency as we re-export 'servant' things.
   build-depends:
       servant             >= 0.20     && < 0.21
-    , http-api-data       >= 0.4.1    && < 0.6
+    , http-api-data       >= 0.4.1    && < 0.7
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -93,14 +93,14 @@ library
   -- We depend (heavily) on the API of these packages:
   -- i.e. re-export, or allow using without direct dependency
   build-depends:
-      http-api-data          >= 0.4.1    && < 0.6
+      http-api-data          >= 0.4.1    && < 0.7
     , singleton-bool         >= 0.1.4    && < 0.2
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
       base-compat            >= 0.10.5   && < 0.14
-    , aeson                  >= 1.4.1.0  && < 3
+    , aeson                  >= 1.4.1.0  && < 2.2
     , attoparsec             >= 0.13.2.2 && < 0.15
     , bifunctors             >= 5.5.3    && < 5.7
     , case-insensitive       >= 1.2.0.11 && < 1.3


### PR DESCRIPTION
Fixes #1691. When all dependencies for all packages support aeson-2.2, we should adjust our code to be compatible.
