### PR TITLE
Avoid clock-0.8.4 which breaks ghcjs

### DIFF
--- a/cabal.ghcjs.project
+++ b/cabal.ghcjs.project
@@ -13,3 +13,5 @@ tests: True
 constraints: attoparsec == 0.13.2.2
 constraints: hashable == 1.3.0.0
 constraints: hspec < 2.10
+
+constraints: clock < 0.8.4


### PR DESCRIPTION
See test failure on main branch.
