### PR TITLE
Add missing IsElem instance for NamedRoutes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,6 +58,10 @@ optimization: False
 constraints: crypton < 0, crypton-connection < 0, crypton-x509 < 0, crypton-x509-store < 0, crypton-x509-system < 0, crypton-x509-validation < 0
 constraints: warp < 3.3.26
 
+-- wreq-0.5.4.1 doesn't seem to work with ghc-8.6.5
+if (impl(ghc < 8.8))
+  constraints: wreq == 0.5.4.0
+
 allow-newer: servant-js:base
 
 -- Print ticks so that doctest type querying is consistent across GHC versions.

--- a/changelog.d/1699
+++ b/changelog.d/1699
@@ -1,0 +1,7 @@
+synopsis: Add NamedRoutes instance to IsElem
+prs: #1699
+issues: #1674
+description: {
+Add missing IsElem instance for NamedRoutes, this allows links to be checked
+with `safeLink`.
+}

--- a/servant/src/Servant/API/TypeLevel.hs
+++ b/servant/src/Servant/API/TypeLevel.hs
@@ -64,6 +64,10 @@ import           Servant.API.QueryParam
                  (QueryFlag, QueryParam, QueryParams)
 import           Servant.API.ReqBody
                  (ReqBody)
+import           Servant.API.NamedRoutes
+                 (NamedRoutes)
+import           Servant.API.Generic
+                 (ToServantApi)
 import           Servant.API.Sub
                  (type (:>))
 import           Servant.API.Verbs
@@ -142,6 +146,7 @@ type family IsElem endpoint api :: Constraint where
   IsElem (Verb m s ct typ) (Verb m s ct' typ)
                                           = IsSubList ct ct'
   IsElem e e                              = ()
+  IsElem e (NamedRoutes rs)               = IsElem e (ToServantApi rs)
   IsElem e a                              = IsElem' e a
 
 -- | Check whether @sub@ is a sub-API of @api@.


### PR DESCRIPTION
Added various tests for NamedRoutes too.

In writing the tests I realised that the client combinators `//` and `/:` can be used to create links in the same natural way.
I've added the combinators to the test suite for now, but it probably makes sense to put them somewhere in the `servant` package, though I wasn't sure where. Maybe just in the root `API` module, and then ensure that `HasClient` and `Reexport` in `servant-client-core` reexport them for any backwards compatibility?

Fixes #1674.