### PR TITLE
[servant-docs] Export renderCurlBasePath lens

### DIFF
--- a/changelog.d/1706
+++ b/changelog.d/1706
@@ -1,0 +1,2 @@
+synopsis: Add public re-export of renderCurlBasePath lens
+prs: #1706

--- a/servant-docs/src/Servant/Docs.hs
+++ b/servant-docs/src/Servant/Docs.hs
@@ -26,7 +26,8 @@ module Servant.Docs
     HasDocs(..), docs, pretty, markdown
     -- ** Customising generated documentation
   , markdownWith, RenderingOptions(..), defRenderingOptions
-  , requestExamples, responseExamples, ShowContentTypes(..), notesHeading
+  , requestExamples, responseExamples, ShowContentTypes(..)
+  , notesHeading, renderCurlBasePath
     -- * Generating docs with extra information
   , docsWith, docsWithIntros, docsWithOptions
   , ExtraInfo(..), extraInfo


### PR DESCRIPTION
Add missing `renderCurlBasePath` lens re-export.

A workaround is to use:
```Haskell
import Servant.Docs.Internal qualified as SD (renderCurlBasePath)
```