### PR TITLE
Add `IsIn` instance for `NamedRoutes`

### DIFF
--- a/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
@@ -43,6 +43,7 @@ type family IsIn sub api :: Constraint where
   IsIn e (a :<|> b) = Or (IsIn e a) (IsIn e b)
   IsIn (e :> a) (e :> b) = IsIn a b
   IsIn e e = ()
+  IsIn e (NamedRoutes record) = IsIn e (ToServantApi record)
 
 -- | Check whether a type is a member of a list of types.
 -- This is a type-level analogue of @'elem'@.

--- a/servant/src/Servant/API/TypeLevel.hs
+++ b/servant/src/Servant/API/TypeLevel.hs
@@ -185,6 +185,7 @@ type family AllIsElem xs api :: Constraint where
 type family IsIn (endpoint :: *) (api :: *) :: Constraint where
   IsIn e (sa :<|> sb)                = Or (IsIn e sa) (IsIn e sb)
   IsIn (e :> sa) (e :> sb)           = IsIn sa sb
+  IsIn e (NamedRoutes record)        = IsIn e (ToServantApi record)
   IsIn e e                           = ()
 
 -- | Check whether @sub@ is a sub API of @api@.

--- a/servant/src/Servant/API/TypeLevel.hs
+++ b/servant/src/Servant/API/TypeLevel.hs
@@ -185,8 +185,8 @@ type family AllIsElem xs api :: Constraint where
 type family IsIn (endpoint :: *) (api :: *) :: Constraint where
   IsIn e (sa :<|> sb)                = Or (IsIn e sa) (IsIn e sb)
   IsIn (e :> sa) (e :> sb)           = IsIn sa sb
-  IsIn e (NamedRoutes record)        = IsIn e (ToServantApi record)
   IsIn e e                           = ()
+  IsIn e (NamedRoutes record)        = IsIn e (ToServantApi record)
 
 -- | Check whether @sub@ is a sub API of @api@.
 --


### PR DESCRIPTION
This was needed for adding custom tags using the [subOperations](https://hackage.haskell.org/package/servant-swagger-1.2/docs/Servant-Swagger.html#v:subOperations) combinator. `IsSubAPI` constraint could not resolve for APIs using the new `NamedRoutes`.