### PR TITLE
Fix build warnings for using * instead of Data.Kind.Type

### DIFF
--- a/servant-auth/servant-auth-docs/src/Servant/Auth/Docs.hs
+++ b/servant-auth/servant-auth-docs/src/Servant/Auth/Docs.hs
@@ -33,7 +33,7 @@ module Servant.Auth.Docs
   ) where
 
 import Control.Lens          ((%~), (&), (|>))
-import Data.Kind
+import Data.Kind             (Type)
 import Data.List             (intercalate)
 import Data.Monoid
 import Data.Proxy            (Proxy (Proxy))

--- a/servant-auth/servant-auth-docs/src/Servant/Auth/Docs.hs
+++ b/servant-auth/servant-auth-docs/src/Servant/Auth/Docs.hs
@@ -33,6 +33,7 @@ module Servant.Auth.Docs
   ) where
 
 import Control.Lens          ((%~), (&), (|>))
+import Data.Kind
 import Data.List             (intercalate)
 import Data.Monoid
 import Data.Proxy            (Proxy (Proxy))
@@ -63,7 +64,7 @@ pretty rs =
   )
 
 
-class AllDocs (x :: [*]) where
+class AllDocs (x :: [Type]) where
   allDocs :: proxy x
               -- intro, req
           -> [(String, String)]

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
@@ -7,6 +7,7 @@ module Servant.Auth.Server.Internal.AddSetCookie where
 
 import           Blaze.ByteString.Builder (toByteString)
 import qualified Data.ByteString          as BS
+import           Data.Kind
 import qualified Network.HTTP.Types       as HTTP
 import           Network.Wai              (mapResponseHeaders)
 import           Servant
@@ -33,12 +34,12 @@ type family AddSetCookieApiVerb a where
   AddSetCookieApiVerb a = Headers '[Header "Set-Cookie" SetCookie] a
 
 #if MIN_VERSION_servant_server(0,18,1)
-type family MapAddSetCookieApiVerb (as :: [*]) where
+type family MapAddSetCookieApiVerb (as :: [Type]) where
   MapAddSetCookieApiVerb '[] = '[]
   MapAddSetCookieApiVerb (a ': as) = (AddSetCookieApiVerb a ': MapAddSetCookieApiVerb as)
 #endif
 
-type family AddSetCookieApi a :: *
+type family AddSetCookieApi a :: Type
 type instance AddSetCookieApi (a :> b) = a :> AddSetCookieApi b
 type instance AddSetCookieApi (a :<|> b) = AddSetCookieApi a :<|> AddSetCookieApi b
 #if MIN_VERSION_servant_server(0,19,0)
@@ -57,7 +58,7 @@ type instance AddSetCookieApi (Stream method stat framing ctyps a)
 #endif
 type instance AddSetCookieApi (Headers hs a) = AddSetCookieApiVerb (Headers hs a)
 
-data SetCookieList (n :: Nat) :: * where
+data SetCookieList (n :: Nat) :: Type where
   SetCookieNil :: SetCookieList 'Z
   SetCookieCons :: Maybe SetCookie -> SetCookieList n -> SetCookieList ('S n)
 

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
@@ -7,7 +7,7 @@ module Servant.Auth.Server.Internal.AddSetCookie where
 
 import           Blaze.ByteString.Builder (toByteString)
 import qualified Data.ByteString          as BS
-import           Data.Kind
+import           Data.Kind                (Type)
 import qualified Network.HTTP.Types       as HTTP
 import           Network.Wai              (mapResponseHeaders)
 import           Servant

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
@@ -2,7 +2,7 @@
 module Servant.Auth.Server.Internal.Class where
 
 import Servant.Auth
-import Data.Kind
+import Data.Kind      (Type)
 import Data.Monoid
 import Servant hiding (BasicAuth)
 

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
@@ -2,6 +2,7 @@
 module Servant.Auth.Server.Internal.Class where
 
 import Servant.Auth
+import Data.Kind
 import Data.Monoid
 import Servant hiding (BasicAuth)
 
@@ -16,7 +17,7 @@ import Servant.Auth.Server.Internal.JWT (jwtAuthCheck)
 -- elements of @ctx@ to be the in the Context and whose authentication check
 -- returns an @AuthCheck v@.
 class IsAuth a v  where
-  type family AuthArgs a :: [*]
+  type family AuthArgs a :: [Type]
   runAuth :: proxy a -> proxy v -> Unapp (AuthArgs a) (AuthCheck v)
 
 instance FromJWT usr => IsAuth Cookie usr where
@@ -33,7 +34,7 @@ instance FromBasicAuthData usr => IsAuth BasicAuth usr where
 
 -- * Helper
 
-class AreAuths (as :: [*]) (ctxs :: [*]) v where
+class AreAuths (as :: [Type]) (ctxs :: [Type]) v where
   runAuths :: proxy as -> Context ctxs -> AuthCheck v
 
 instance  AreAuths '[] ctxs v where

--- a/servant-auth/servant-auth-swagger/src/Servant/Auth/Swagger.hs
+++ b/servant-auth/servant-auth-swagger/src/Servant/Auth/Swagger.hs
@@ -17,6 +17,7 @@ module Servant.Auth.Swagger
   ) where
 
 import Control.Lens    ((&), (<>~))
+import Data.Kind
 import Data.Proxy      (Proxy (Proxy))
 import Data.Swagger    (ApiKeyLocation (..), ApiKeyParams (..),
                         SecurityRequirement (..), SecurityScheme (..), 
@@ -66,7 +67,7 @@ instance HasSecurity JWT where
       type_ = SecuritySchemeApiKey (ApiKeyParams "Authorization" ApiKeyHeader)
       desc  = "JSON Web Token-based API key"
 
-class AllHasSecurity (x :: [*]) where
+class AllHasSecurity (x :: [Type]) where
   securities :: Proxy x -> [(T.Text,SecurityScheme)]
 
 instance {-# OVERLAPPABLE #-} (HasSecurity x, AllHasSecurity xs) => AllHasSecurity (x ': xs) where

--- a/servant-auth/servant-auth-swagger/src/Servant/Auth/Swagger.hs
+++ b/servant-auth/servant-auth-swagger/src/Servant/Auth/Swagger.hs
@@ -17,7 +17,7 @@ module Servant.Auth.Swagger
   ) where
 
 import Control.Lens    ((&), (<>~))
-import Data.Kind
+import Data.Kind       (Type)
 import Data.Proxy      (Proxy (Proxy))
 import Data.Swagger    (ApiKeyLocation (..), ApiKeyParams (..),
                         SecurityRequirement (..), SecurityScheme (..), 

--- a/servant-auth/servant-auth/src/Servant/Auth.hs
+++ b/servant-auth/servant-auth/src/Servant/Auth.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeOperators              #-}
 module Servant.Auth where
 
+import           Data.Kind
 import           Data.Proxy          (Proxy(..))
 import           Servant.API         ((:>))
 import           Servant.Links       (HasLink (..))
@@ -13,15 +14,15 @@ import           Servant.Links       (HasLink (..))
 
 -- | @Auth [auth1, auth2] val :> api@ represents an API protected *either* by
 -- @auth1@ or @auth2@
-data Auth (auths :: [*]) val
+data Auth (auths :: [Type]) val
 
 -- | A @HasLink@ instance for @Auth@
-instance HasLink sub => HasLink (Auth (tag :: [*]) value :> sub) where
+instance HasLink sub => HasLink (Auth (tag :: [Type]) value :> sub) where
 #if MIN_VERSION_servant(0,14,0)
-  type MkLink (Auth (tag :: [*]) value :> sub) a = MkLink sub a
+  type MkLink (Auth (tag :: [Type]) value :> sub) a = MkLink sub a
   toLink toA _ = toLink toA (Proxy :: Proxy sub)
 #else
-  type MkLink (Auth (tag :: [*]) value :> sub) = MkLink sub
+  type MkLink (Auth (tag :: [Type]) value :> sub) = MkLink sub
   toLink _ = toLink (Proxy :: Proxy sub)
 #endif
 

--- a/servant-auth/servant-auth/src/Servant/Auth.hs
+++ b/servant-auth/servant-auth/src/Servant/Auth.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators              #-}
 module Servant.Auth where
 
-import           Data.Kind
+import           Data.Kind           (Type)
 import           Data.Proxy          (Proxy(..))
 import           Servant.API         ((:>))
 import           Servant.Links       (HasLink (..))

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -39,6 +39,7 @@ import           Data.Either
 import           Data.Constraint (Dict(..))
 import           Data.Foldable
                  (toList)
+import           Data.Kind
 import           Data.List
                  (foldl')
 import           Data.Sequence
@@ -128,7 +129,7 @@ clientIn p pm = clientWithRoute pm p defaultRequest
 -- combinators that you want to support client-generation, you can ignore this
 -- class.
 class RunClient m => HasClient m api where
-  type Client (m :: * -> *) (api :: *) :: *
+  type Client (m :: Type -> Type) (api :: Type) :: Type
   clientWithRoute :: Proxy m -> Proxy api -> Request -> Client m api
   hoistClientMonad
     :: Proxy m
@@ -333,7 +334,7 @@ instance {-# OVERLAPPING #-}
 data ClientParseError = ClientParseError MediaType String | ClientStatusMismatch | ClientNoMatchingStatus
   deriving (Eq, Show)
 
-class UnrenderResponse (cts :: [*]) (a :: *) where
+class UnrenderResponse (cts :: [Type]) (a :: Type) where
   unrenderResponse :: Seq.Seq H.Header -> BL.ByteString -> Proxy cts
                    -> [Either (MediaType, String) a]
 
@@ -840,7 +841,7 @@ instance HasClient m api => HasClient m (BasicAuth realm usr :> api) where
     hoistClientMonad pm (Proxy :: Proxy api) f (cl bauth)
 
 -- | A type that specifies that an API record contains a client implementation.
-data AsClientT (m :: * -> *)
+data AsClientT (m :: Type -> Type)
 instance GenericMode (AsClientT m) where
     type AsClientT m :- api = Client m api
 
@@ -850,7 +851,7 @@ type GClientConstraints api m =
   , Client m (ToServantApi api) ~ ToServant api (AsClientT m)
   )
 
-class GClient (api :: * -> *) m where
+class GClient (api :: Type -> Type) m where
   gClientProof :: Dict (GClientConstraints api m)
 
 instance GClientConstraints api m => GClient api m where

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -40,6 +40,7 @@ import           Data.Constraint (Dict(..))
 import           Data.Foldable
                  (toList)
 import           Data.Kind
+                 (Type)
 import           Data.List
                  (foldl')
 import           Data.Sequence

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -23,6 +23,7 @@ import           Control.Lens
 import           Data.Data
                  (Data)
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
 import           Data.String
 import           Data.Text

--- a/servant-foreign/src/Servant/Foreign/Internal.hs
+++ b/servant-foreign/src/Servant/Foreign/Internal.hs
@@ -22,6 +22,7 @@ import           Control.Lens
                  (Getter, makeLenses, makePrisms, (%~), (&), (.~), (<>~))
 import           Data.Data
                  (Data)
+import           Data.Kind
 import           Data.Proxy
 import           Data.String
 import           Data.Text
@@ -274,8 +275,8 @@ instance HasForeignType NoTypes NoContent a where
 -- | Implementation of the Servant framework types.
 --
 -- Relevant instances: Everything containing 'HasForeignType'.
-class HasForeign lang ftype (api :: *) where
-  type Foreign ftype api :: *
+class HasForeign lang ftype (api :: Type) where
+  type Foreign ftype api :: Type
   foreignFor :: Proxy lang -> Proxy ftype -> Proxy api -> Req ftype -> Foreign ftype api
 
 instance (HasForeign lang ftype a, HasForeign lang ftype b)

--- a/servant-server/src/Servant/Server/Experimental/Auth.hs
+++ b/servant-server/src/Servant/Server/Experimental/Auth.hs
@@ -16,6 +16,7 @@ module Servant.Server.Experimental.Auth where
 import           Control.Monad.Trans
                  (liftIO)
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy (Proxy))
 import           Data.Typeable

--- a/servant-server/src/Servant/Server/Experimental/Auth.hs
+++ b/servant-server/src/Servant/Server/Experimental/Auth.hs
@@ -15,6 +15,7 @@ module Servant.Server.Experimental.Auth where
 
 import           Control.Monad.Trans
                  (liftIO)
+import           Data.Kind
 import           Data.Proxy
                  (Proxy (Proxy))
 import           Data.Typeable
@@ -38,7 +39,7 @@ import           Servant.Server.Internal
 -- quite often this is some `User` datatype.
 --
 -- NOTE: THIS API IS EXPERIMENTAL AND SUBJECT TO CHANGE
-type family AuthServerData a :: *
+type family AuthServerData a :: Type
 
 -- | Handlers for AuthProtected resources
 --

--- a/servant-server/src/Servant/Server/Generic.hs
+++ b/servant-server/src/Servant/Server/Generic.hs
@@ -17,6 +17,7 @@ module Servant.Server.Generic (
   ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy (..))
 

--- a/servant-server/src/Servant/Server/Generic.hs
+++ b/servant-server/src/Servant/Server/Generic.hs
@@ -16,6 +16,7 @@ module Servant.Server.Generic (
     genericServerT
   ) where
 
+import           Data.Kind
 import           Data.Proxy
                  (Proxy (..))
 
@@ -37,7 +38,7 @@ genericServe = serve (Proxy :: Proxy (ToServantApi routes))  . genericServer
 --   by providing a transformation to bring each handler back in the 'Handler'
 --   monad.
 genericServeT
-  :: forall (routes :: * -> *) (m :: * -> *).
+  :: forall (routes :: Type -> Type) (m :: Type -> Type).
      ( GenericServant routes (AsServerT m)
      , GenericServant routes AsApi
      , HasServer (ToServantApi routes) '[]
@@ -55,7 +56,7 @@ genericServeT f server = serve p $ hoistServer p f (genericServerT server)
 --   used by auth-related combinators in servant, e.g to hold auth checks) and the given
 --   transformation to map all the handlers back to the 'Handler' monad.
 genericServeTWithContext
-  :: forall (routes :: * -> *) (m :: * -> *) (ctx :: [*]).
+  :: forall (routes :: Type -> Type) (m :: Type -> Type) (ctx :: [Type]).
      ( GenericServant routes (AsServerT m)
      , GenericServant routes AsApi
      , HasServer (ToServantApi routes) ctx

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -47,6 +47,7 @@ import qualified Data.ByteString.Lazy                       as BL
 import           Data.Constraint (Constraint, Dict(..))
 import           Data.Either
                  (partitionEithers)
+import           Data.Kind
 import           Data.Maybe
                  (fromMaybe, isNothing, mapMaybe, maybeToList)
 import           Data.String
@@ -121,7 +122,7 @@ class HasServer api context where
   --
   -- Note that the result kind is @*@, so it is /not/ a monad transformer, unlike
   -- what the @T@ in the name might suggest.
-  type ServerT api (m :: * -> *) :: *
+  type ServerT api (m :: Type -> Type) :: Type
 
   route ::
        Proxy api
@@ -900,7 +901,7 @@ instance TypeError (PartialApplication
 #endif
                     HasServer arr) => HasServer ((arr :: a -> b) :> sub) context
   where
-    type ServerT (arr :> sub) _ = TypeError (PartialApplication (HasServer :: * -> [*] -> Constraint) arr)
+    type ServerT (arr :> sub) _ = TypeError (PartialApplication (HasServer :: Type -> [Type] -> Constraint) arr)
     route = error "unreachable"
     hoistServerWithContext _ _ _ _ = error "unreachable"
 
@@ -973,7 +974,7 @@ instance (AtLeastOneFragment api, FragmentUnique (Fragment a1 :> api), HasServer
 -- >>> import Servant
 
 -- | A type that specifies that an API record contains a server implementation.
-data AsServerT (m :: * -> *)
+data AsServerT (m :: Type -> Type)
 instance GenericMode (AsServerT m) where
     type AsServerT m :- api = ServerT api m
 
@@ -999,7 +1000,7 @@ type GServerConstraints api m =
 -- Users shouldn't have to worry about this class, as the only possible instance
 -- is provided in this module for all record APIs.
 
-class GServer (api :: * -> *) (m :: * -> *) where
+class GServer (api :: Type -> Type) (m :: Type -> Type) where
   gServerProof :: Dict (GServerConstraints api m)
 
 instance

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -48,6 +48,7 @@ import           Data.Constraint (Constraint, Dict(..))
 import           Data.Either
                  (partitionEithers)
 import           Data.Kind
+                 (Type)
 import           Data.Maybe
                  (fromMaybe, isNothing, mapMaybe, maybeToList)
 import           Data.String
@@ -98,8 +99,6 @@ import           Servant.API.TypeErrors
 import           Web.HttpApiData
                  (FromHttpApiData, parseHeader, parseQueryParam, parseUrlPiece,
                  parseUrlPieces)
-import           Data.Kind
-                 (Type)
 
 import           Servant.Server.Internal.BasicAuth
 import           Servant.Server.Internal.Context

--- a/servant-server/src/Servant/Server/Internal/Context.hs
+++ b/servant-server/src/Servant/Server/Internal/Context.hs
@@ -10,6 +10,7 @@
 
 module Servant.Server.Internal.Context where
 
+import           Data.Kind
 import           Data.Proxy
 import           GHC.TypeLits
 
@@ -51,7 +52,7 @@ instance (Eq a, Eq (Context as)) => Eq (Context (a ': as)) where
 -- Hint: import it as
 --
 -- > import Servant.Server (type (.++))
-type family (.++) (l1 :: [*]) (l2 :: [*]) where
+type family (.++) (l1 :: [Type]) (l2 :: [Type]) where
   '[] .++ a = a
   (a ': as) .++ b = a ': (as .++ b)
 
@@ -73,7 +74,7 @@ EmptyContext .++ a = a
 -- ...
 -- ...No instance for ...HasContextEntry '[] [Char]...
 -- ...
-class HasContextEntry (context :: [*]) (val :: *) where
+class HasContextEntry (context :: [Type]) (val :: Type) where
     getContextEntry :: Context context -> val
 
 instance {-# OVERLAPPABLE #-}
@@ -90,7 +91,7 @@ instance {-# OVERLAPPING #-}
 -- to have multiple values of the same type in your 'Context' and need to access
 -- them, we provide 'NamedContext'. You can think of it as sub-namespaces for
 -- 'Context's.
-data NamedContext (name :: Symbol) (subContext :: [*])
+data NamedContext (name :: Symbol) (subContext :: [Type])
   = NamedContext (Context subContext)
 
 -- | 'descendIntoNamedContext' allows you to access `NamedContext's. Usually you

--- a/servant-server/src/Servant/Server/Internal/Context.hs
+++ b/servant-server/src/Servant/Server/Internal/Context.hs
@@ -11,6 +11,7 @@
 module Servant.Server.Internal.Context where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
 import           GHC.TypeLits
 

--- a/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
+++ b/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
@@ -16,6 +16,7 @@ module Servant.Server.Internal.ErrorFormatter
   ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.String.Conversions
                  (cs)
 import           Data.Typeable

--- a/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
+++ b/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
@@ -15,6 +15,7 @@ module Servant.Server.Internal.ErrorFormatter
   , mkContextWithErrorFormatter
   ) where
 
+import           Data.Kind
 import           Data.String.Conversions
                  (cs)
 import           Data.Typeable
@@ -67,9 +68,9 @@ type ErrorFormatter = TypeRep -> Request -> String -> ServerError
 -- | This formatter does not get neither 'TypeRep' nor error message.
 type NotFoundErrorFormatter = Request -> ServerError
 
-type MkContextWithErrorFormatter (ctx :: [*]) = ctx .++ DefaultErrorFormatters
+type MkContextWithErrorFormatter (ctx :: [Type]) = ctx .++ DefaultErrorFormatters
 
-mkContextWithErrorFormatter :: forall (ctx :: [*]). Context ctx -> Context (MkContextWithErrorFormatter ctx)
+mkContextWithErrorFormatter :: forall (ctx :: [Type]). Context ctx -> Context (MkContextWithErrorFormatter ctx)
 mkContextWithErrorFormatter ctx = ctx .++ (defaultErrorFormatters :. EmptyContext)
 
 -- Internal

--- a/servant-server/src/Servant/Server/UVerb.hs
+++ b/servant-server/src/Servant/Server/UVerb.hs
@@ -23,6 +23,7 @@ module Servant.Server.UVerb
 where
 
 import qualified Data.ByteString as B
+import Data.Kind
 import Data.Proxy (Proxy (Proxy))
 import Data.SOP (I (I))
 import Data.SOP.Constraint (All, And)
@@ -39,13 +40,13 @@ import Servant.Server.Internal (Context, Delayed, Handler, HasServer (..), Route
 -- | 'return' for 'UVerb' handlers.  Takes a value of any of the members of the open union,
 -- and will construct a union value in an 'Applicative' (eg. 'Server').
 respond ::
-  forall (x :: *) (xs :: [*]) (f :: * -> *).
+  forall (x :: Type) (xs :: [Type]) (f :: Type -> Type).
   (Applicative f, HasStatus x, IsMember x xs) =>
   x ->
   f (Union xs)
 respond = pure . inject . I
 
-class IsServerResource (cts :: [*]) a where
+class IsServerResource (cts :: [Type]) a where
   resourceResponse :: Request -> Proxy cts -> a -> Maybe (LBS, LBS)
   resourceHeaders :: Proxy cts -> a -> [(HeaderName, B.ByteString)]
 

--- a/servant-server/src/Servant/Server/UVerb.hs
+++ b/servant-server/src/Servant/Server/UVerb.hs
@@ -23,7 +23,7 @@ module Servant.Server.UVerb
 where
 
 import qualified Data.ByteString as B
-import Data.Kind
+import Data.Kind (Type)
 import Data.Proxy (Proxy (Proxy))
 import Data.SOP (I (I))
 import Data.SOP.Constraint (All, And)

--- a/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
@@ -8,7 +8,7 @@
 module Servant.Swagger.Internal.TypeLevel.API where
 
 import           GHC.Exts       (Constraint)
-import           Data.Kind
+import           Data.Kind      (Type)
 import           Servant.API
 
 -- | Build a list of endpoints from an API.

--- a/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/API.hs
@@ -8,6 +8,7 @@
 module Servant.Swagger.Internal.TypeLevel.API where
 
 import           GHC.Exts       (Constraint)
+import           Data.Kind
 import           Servant.API
 
 -- | Build a list of endpoints from an API.
@@ -75,7 +76,7 @@ type AddBodyType c cs a as = If (Elem c cs) (a ': as) as
 -- @'NoContent'@ is removed from the list and not tested.  (This allows for leaving the body
 -- completely empty on responses to requests that only accept 'application/json', while
 -- setting the content-type in the response accordingly.)
-type family BodyTypes' c api :: [*] where
+type family BodyTypes' c api :: [Type] where
   BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
   BodyTypes' c (Verb verb b cs NoContent) = '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]

--- a/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/Every.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/Every.hs
@@ -18,6 +18,7 @@
 #endif
 module Servant.Swagger.Internal.TypeLevel.Every where
 
+import           Data.Kind
 import           Data.Proxy
 import           GHC.Exts                                (Constraint)
 
@@ -48,7 +49,7 @@ type family EveryTF cs x :: Constraint where
 -- | Apply multiple constraint constructors to a type as a class.
 --
 -- This is different from @'EveryTF'@ in that it allows partial application.
-class EveryTF cs x => Every (cs :: [* -> Constraint]) (x :: *) where
+class EveryTF cs x => Every (cs :: [Type -> Constraint]) (x :: Type) where
 
 instance Every '[] x where
 instance (c x, Every cs x) => Every (c ': cs) x where

--- a/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/Every.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal/TypeLevel/Every.hs
@@ -19,6 +19,7 @@
 module Servant.Swagger.Internal.TypeLevel.Every where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
 import           GHC.Exts                                (Constraint)
 

--- a/servant/src/Servant/API/BasicAuth.hs
+++ b/servant/src/Servant/API/BasicAuth.hs
@@ -7,6 +7,7 @@ module Servant.API.BasicAuth where
 
 import           Data.ByteString
                  (ByteString)
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits
@@ -24,7 +25,7 @@ import           GHC.TypeLits
 -- In Basic Auth, username and password are base64-encoded and transmitted via
 -- the @Authorization@ header. Handshakes are not required, making it
 -- relatively efficient.
-data BasicAuth (realm :: Symbol) (userData :: *)
+data BasicAuth (realm :: Symbol) (userData :: Type)
   deriving (Typeable)
 
 -- | A simple datatype to hold data required to decorate a request

--- a/servant/src/Servant/API/BasicAuth.hs
+++ b/servant/src/Servant/API/BasicAuth.hs
@@ -8,6 +8,7 @@ module Servant.API.BasicAuth where
 import           Data.ByteString
                  (ByteString)
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits

--- a/servant/src/Servant/API/Capture.hs
+++ b/servant/src/Servant/API/Capture.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Capture (Capture, Capture', CaptureAll) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits
@@ -17,7 +18,7 @@ import           GHC.TypeLits
 type Capture = Capture' '[] -- todo
 
 -- | 'Capture' which can be modified. For example with 'Description'.
-data Capture' (mods :: [*]) (sym :: Symbol) (a :: *)
+data Capture' (mods :: [Type]) (sym :: Symbol) (a :: Type)
     deriving (Typeable)
 
 -- | Capture all remaining values from the request path under a certain type
@@ -27,7 +28,7 @@ data Capture' (mods :: [*]) (sym :: Symbol) (a :: *)
 --
 -- >>>            -- GET /src/*
 -- >>> type MyAPI = "src" :> CaptureAll "segments" Text :> Get '[JSON] SourceFile
-data CaptureAll (sym :: Symbol) (a :: *)
+data CaptureAll (sym :: Symbol) (a :: Type)
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/Capture.hs
+++ b/servant/src/Servant/API/Capture.hs
@@ -5,6 +5,7 @@
 module Servant.API.Capture (Capture, Capture', CaptureAll) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -82,6 +82,7 @@ import qualified Data.ByteString                  as BS
 import           Data.ByteString.Lazy
                  (ByteString, fromStrict, toStrict)
 import           Data.Kind
+                 (Type)
 import qualified Data.List.NonEmpty               as NE
 import           Data.Maybe
                  (isJust)

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -81,6 +81,7 @@ import           Data.Bifunctor
 import qualified Data.ByteString                  as BS
 import           Data.ByteString.Lazy
                  (ByteString, fromStrict, toStrict)
+import           Data.Kind
 import qualified Data.List.NonEmpty               as NE
 import           Data.Maybe
                  (isJust)
@@ -171,7 +172,7 @@ newtype AcceptHeader = AcceptHeader BS.ByteString
 class Accept ctype => MimeRender ctype a where
     mimeRender  :: Proxy ctype -> a -> ByteString
 
-class (AllMime list) => AllCTRender (list :: [*]) a where
+class (AllMime list) => AllCTRender (list :: [Type]) a where
     -- If the Accept header can be matched, returns (Just) a tuple of the
     -- Content-Type and response (serialization of @a@ into the appropriate
     -- mimetype).
@@ -225,7 +226,7 @@ class Accept ctype => MimeUnrender ctype a where
 
     {-# MINIMAL mimeUnrender | mimeUnrenderWithType #-}
 
-class AllCTUnrender (list :: [*]) a where
+class AllCTUnrender (list :: [Type]) a where
     canHandleCTypeH
         :: Proxy list
         -> ByteString  -- Content-Type header
@@ -244,7 +245,7 @@ instance ( AllMimeUnrender ctyps a ) => AllCTUnrender ctyps a where
 --------------------------------------------------------------------------
 -- * Utils (Internal)
 
-class AllMime (list :: [*]) where
+class AllMime (list :: [Type]) where
     allMime :: Proxy list -> [M.MediaType]
 
 instance AllMime '[] where
@@ -262,7 +263,7 @@ canHandleAcceptH p (AcceptHeader h ) = isJust $ M.matchAccept (allMime p) h
 --------------------------------------------------------------------------
 -- Check that all elements of list are instances of MimeRender
 --------------------------------------------------------------------------
-class (AllMime list) => AllMimeRender (list :: [*]) a where
+class (AllMime list) => AllMimeRender (list :: [Type]) a where
     allMimeRender :: Proxy list
                   -> a                              -- value to serialize
                   -> [(M.MediaType, ByteString)]    -- content-types/response pairs
@@ -302,7 +303,7 @@ instance {-# OVERLAPPING #-}
 --------------------------------------------------------------------------
 -- Check that all elements of list are instances of MimeUnrender
 --------------------------------------------------------------------------
-class (AllMime list) => AllMimeUnrender (list :: [*]) a where
+class (AllMime list) => AllMimeUnrender (list :: [Type]) a where
     allMimeUnrender :: Proxy list
                     -> [(M.MediaType, ByteString -> Either String a)]
 

--- a/servant/src/Servant/API/Description.hs
+++ b/servant/src/Servant/API/Description.hs
@@ -17,6 +17,7 @@ module Servant.API.Description (
     ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy (..))
 import           Data.Typeable

--- a/servant/src/Servant/API/Description.hs
+++ b/servant/src/Servant/API/Description.hs
@@ -16,6 +16,7 @@ module Servant.API.Description (
     reflectDescription,
     ) where
 
+import           Data.Kind
 import           Data.Proxy
                  (Proxy (..))
 import           Data.Typeable
@@ -59,7 +60,7 @@ data Description (sym :: Symbol)
 type FoldDescription mods = FoldDescription' "" mods
 
 -- | Implementation of 'FoldDescription'.
-type family FoldDescription' (acc :: Symbol) (mods ::  [*]) :: Symbol where
+type family FoldDescription' (acc :: Symbol) (mods ::  [Type]) :: Symbol where
     FoldDescription' acc '[]                        = acc
     FoldDescription' acc (Description desc ': mods) = FoldDescription' desc mods
     FoldDescription' acc (mod     ': mods)          = FoldDescription' acc mods

--- a/servant/src/Servant/API/Fragment.hs
+++ b/servant/src/Servant/API/Fragment.hs
@@ -5,6 +5,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Fragment (Fragment) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 
@@ -14,7 +15,7 @@ import           Data.Typeable
 --
 -- >>> -- /post#TRACKING
 -- >>> type MyApi = "post" :> Fragment Text :> Get '[JSON] Tracking
-data Fragment (a :: *)
+data Fragment (a :: Type)
     deriving Typeable
 
 -- $setup

--- a/servant/src/Servant/API/Fragment.hs
+++ b/servant/src/Servant/API/Fragment.hs
@@ -6,6 +6,7 @@
 module Servant.API.Fragment (Fragment) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 

--- a/servant/src/Servant/API/Generic.hs
+++ b/servant/src/Servant/API/Generic.hs
@@ -70,6 +70,7 @@ module Servant.API.Generic (
 -- SOFTWARE.
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy (..))
 import           GHC.Generics

--- a/servant/src/Servant/API/Generic.hs
+++ b/servant/src/Servant/API/Generic.hs
@@ -69,6 +69,7 @@ module Servant.API.Generic (
 -- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 -- SOFTWARE.
 
+import           Data.Kind
 import           Data.Proxy
                  (Proxy (..))
 import           GHC.Generics
@@ -83,7 +84,7 @@ type GenericServant routes mode = (GenericMode mode, Generic (routes mode), GSer
 -- parameter.  For example, 'AsApi' will leave @api@ untouched, while
 -- @'AsServerT' m@ will produce @'ServerT' api m@.
 class GenericMode mode where
-    type mode :- api :: *
+    type mode :- api :: Type
 
 infixl 0 :-
 

--- a/servant/src/Servant/API/Header.hs
+++ b/servant/src/Servant/API/Header.hs
@@ -7,6 +7,7 @@ module Servant.API.Header (
     ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits

--- a/servant/src/Servant/API/Header.hs
+++ b/servant/src/Servant/API/Header.hs
@@ -6,6 +6,7 @@ module Servant.API.Header (
     Header, Header',
     ) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits
@@ -23,7 +24,7 @@ import           Servant.API.Modifiers
 -- >>> type MyApi = "view-my-referer" :> Header "from" Referer :> Get '[JSON] Referer
 type Header = Header' '[Optional, Strict]
 
-data Header' (mods :: [*]) (sym :: Symbol) (a :: *)
+data Header' (mods :: [Type]) (sym :: Symbol) (a :: Type)
     deriving Typeable
 
 -- $setup

--- a/servant/src/Servant/API/Modifiers.hs
+++ b/servant/src/Servant/API/Modifiers.hs
@@ -19,6 +19,7 @@ module Servant.API.Modifiers (
     unfoldRequestArgument,
     ) where
 
+import           Data.Kind
 import           Data.Proxy
                  (Proxy (..))
 import           Data.Singletons.Bool
@@ -51,7 +52,7 @@ data Optional
 type FoldRequired mods = FoldRequired' 'False mods
 
 -- | Implementation of 'FoldRequired'.
-type family FoldRequired' (acc :: Bool) (mods :: [*]) :: Bool where
+type family FoldRequired' (acc :: Bool) (mods :: [Type]) :: Bool where
     FoldRequired' acc '[]                = acc
     FoldRequired' acc (Required ': mods) = FoldRequired' 'True mods
     FoldRequired' acc (Optional ': mods) = FoldRequired' 'False mods
@@ -72,7 +73,7 @@ data Strict
 type FoldLenient mods = FoldLenient' 'False mods
 
 -- | Implementation of 'FoldLenient'.
-type family FoldLenient' (acc :: Bool) (mods ::  [*]) :: Bool where
+type family FoldLenient' (acc :: Bool) (mods ::  [Type]) :: Bool where
     FoldLenient' acc '[]               = acc
     FoldLenient' acc (Lenient ': mods) = FoldLenient' 'True mods
     FoldLenient' acc (Strict  ': mods) = FoldLenient' 'False mods

--- a/servant/src/Servant/API/Modifiers.hs
+++ b/servant/src/Servant/API/Modifiers.hs
@@ -20,6 +20,7 @@ module Servant.API.Modifiers (
     ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy (..))
 import           Data.Singletons.Bool

--- a/servant/src/Servant/API/NamedRoutes.hs
+++ b/servant/src/Servant/API/NamedRoutes.hs
@@ -6,7 +6,7 @@ module Servant.API.NamedRoutes (
     NamedRoutes
   ) where
 
-import Data.Kind
+import Data.Kind (Type)
 
 -- | Combinator for embedding a record of named routes into a Servant API type.
 data NamedRoutes (api :: Type -> Type)

--- a/servant/src/Servant/API/NamedRoutes.hs
+++ b/servant/src/Servant/API/NamedRoutes.hs
@@ -6,5 +6,7 @@ module Servant.API.NamedRoutes (
     NamedRoutes
   ) where
 
+import Data.Kind
+
 -- | Combinator for embedding a record of named routes into a Servant API type.
-data NamedRoutes (api :: * -> *)
+data NamedRoutes (api :: Type -> Type)

--- a/servant/src/Servant/API/QueryParam.hs
+++ b/servant/src/Servant/API/QueryParam.hs
@@ -6,6 +6,7 @@
 module Servant.API.QueryParam (QueryFlag, QueryParam, QueryParam', QueryParams) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits

--- a/servant/src/Servant/API/QueryParam.hs
+++ b/servant/src/Servant/API/QueryParam.hs
@@ -5,6 +5,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.QueryParam (QueryFlag, QueryParam, QueryParam', QueryParams) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 import           GHC.TypeLits
@@ -21,7 +22,7 @@ import           Servant.API.Modifiers
 type QueryParam = QueryParam' '[Optional, Strict]
 
 -- | 'QueryParam' which can be 'Required', 'Lenient', or modified otherwise.
-data QueryParam' (mods :: [*]) (sym :: Symbol) (a :: *)
+data QueryParam' (mods :: [Type]) (sym :: Symbol) (a :: Type)
     deriving Typeable
 
 -- | Lookup the values associated to the @sym@ query string parameter
@@ -35,7 +36,7 @@ data QueryParam' (mods :: [*]) (sym :: Symbol) (a :: *)
 --
 -- >>> -- /books?authors[]=<author1>&authors[]=<author2>&...
 -- >>> type MyApi = "books" :> QueryParams "authors" Text :> Get '[JSON] [Book]
-data QueryParams (sym :: Symbol) (a :: *)
+data QueryParams (sym :: Symbol) (a :: Type)
     deriving Typeable
 
 -- | Lookup a potentially value-less query string parameter

--- a/servant/src/Servant/API/ReqBody.hs
+++ b/servant/src/Servant/API/ReqBody.hs
@@ -7,6 +7,7 @@ module Servant.API.ReqBody (
     ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 import           Servant.API.Modifiers

--- a/servant/src/Servant/API/ReqBody.hs
+++ b/servant/src/Servant/API/ReqBody.hs
@@ -6,6 +6,7 @@ module Servant.API.ReqBody (
     ReqBody, ReqBody',
     ) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 import           Servant.API.Modifiers
@@ -21,7 +22,7 @@ type ReqBody = ReqBody' '[Required, Strict]
 -- |
 --
 -- /Note:/ 'ReqBody'' is always 'Required'.
-data ReqBody' (mods :: [*]) (contentTypes :: [*]) (a :: *)
+data ReqBody' (mods :: [Type]) (contentTypes :: [Type]) (a :: Type)
     deriving (Typeable)
 
 -- $setup

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -41,6 +41,7 @@ import           Control.DeepSeq
 import           Data.ByteString.Char8     as BS
                  (ByteString, pack)
 import qualified Data.CaseInsensitive      as CI
+import           Data.Kind
 import qualified Data.List                 as L
 import           Data.Proxy
 import           Data.Typeable
@@ -95,7 +96,7 @@ instance (y ~ Header' mods h x, NFData x, NFDataHList xs) => NFDataHList (y ': x
 instance NFDataHList xs => NFData (HList xs) where
     rnf = rnfHList
 
-type family HeaderValMap (f :: * -> *) (xs :: [*]) where
+type family HeaderValMap (f :: Type -> Type) (xs :: [Type]) where
     HeaderValMap f '[]                = '[]
     HeaderValMap f (Header' mods h x ': xs) = Header' mods h (f x) ': HeaderValMap f xs
 
@@ -162,7 +163,7 @@ instance (KnownSymbol h, GetHeadersFromHList rest, ToHttpApiData v)
 -- * Adding headers
 
 -- We need all these fundeps to save type inference
-class AddHeader (mods :: [*]) h v orig new
+class AddHeader (mods :: [Type]) h v orig new
     | mods h v orig -> new, new -> mods, new -> h, new -> v, new -> orig where
   addOptionalHeader :: ResponseHeader h v -> orig -> new  -- ^ N.B.: The same header can't be added multiple times
 

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -42,6 +42,7 @@ import           Data.ByteString.Char8     as BS
                  (ByteString, pack)
 import qualified Data.CaseInsensitive      as CI
 import           Data.Kind
+                 (Type)
 import qualified Data.List                 as L
 import           Data.Proxy
 import           Data.Typeable

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -46,6 +46,7 @@ import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as LBS
 import qualified Data.ByteString.Lazy.Char8       as LBS8
 import           Data.Kind
+                 (Type)
 import           Data.List.NonEmpty
                  (NonEmpty (..))
 import           Data.Proxy

--- a/servant/src/Servant/API/Stream.hs
+++ b/servant/src/Servant/API/Stream.hs
@@ -45,6 +45,7 @@ import qualified Data.Attoparsec.ByteString.Char8 as A8
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Lazy             as LBS
 import qualified Data.ByteString.Lazy.Char8       as LBS8
+import           Data.Kind
 import           Data.List.NonEmpty
                  (NonEmpty (..))
 import           Data.Proxy
@@ -63,7 +64,7 @@ import           Servant.Types.SourceT
 -- given @Content-Type@, delimited by a @framing@ strategy.
 -- Type synonyms are provided for standard methods.
 --
-data Stream (method :: k1) (status :: Nat) (framing :: *) (contentType :: *) (a :: *)
+data Stream (method :: k1) (status :: Nat) (framing :: Type) (contentType :: Type) (a :: Type)
   deriving (Typeable, Generic)
 
 type StreamGet  = Stream 'GET 200
@@ -72,7 +73,7 @@ type StreamPost = Stream 'POST 200
 -- | A stream request body.
 type StreamBody = StreamBody' '[]
 
-data StreamBody' (mods :: [*]) (framing :: *) (contentType :: *) (a :: *)
+data StreamBody' (mods :: [Type]) (framing :: Type) (contentType :: Type) (a :: Type)
   deriving (Typeable, Generic)
 
 -------------------------------------------------------------------------------

--- a/servant/src/Servant/API/Sub.hs
+++ b/servant/src/Servant/API/Sub.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Sub ((:>)) where
 
+import           Data.Kind
 import           Data.Typeable
                  (Typeable)
 
@@ -15,7 +16,7 @@ import           Data.Typeable
 -- >>> -- GET /hello/world
 -- >>> -- returning a JSON encoded World value
 -- >>> type MyApi = "hello" :> "world" :> Get '[JSON] World
-data (path :: k) :> (a :: *)
+data (path :: k) :> (a :: Type)
     deriving (Typeable)
 infixr 4 :>
 

--- a/servant/src/Servant/API/Sub.hs
+++ b/servant/src/Servant/API/Sub.hs
@@ -5,6 +5,7 @@
 module Servant.API.Sub ((:>)) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Typeable
                  (Typeable)
 

--- a/servant/src/Servant/API/TypeErrors.hs
+++ b/servant/src/Servant/API/TypeErrors.hs
@@ -16,7 +16,7 @@ module Servant.API.TypeErrors (
   ErrorIfNoGeneric,
 ) where
 
-import Data.Kind
+import Data.Kind (Type, Constraint)
 import GHC.Generics (Generic(..))
 import GHC.TypeLits
 

--- a/servant/src/Servant/API/TypeLevel.hs
+++ b/servant/src/Servant/API/TypeLevel.hs
@@ -53,6 +53,7 @@ module Servant.API.TypeLevel (
 
 import           GHC.Exts
                  (Constraint)
+import           Data.Kind
 import           Servant.API.Alternative
                  (type (:<|>))
 import           Servant.API.Capture
@@ -182,7 +183,7 @@ type family AllIsElem xs api :: Constraint where
 -- ...
 -- ... Could not ...
 -- ...
-type family IsIn (endpoint :: *) (api :: *) :: Constraint where
+type family IsIn (endpoint :: Type) (api :: Type) :: Constraint where
   IsIn e (sa :<|> sb)                = Or (IsIn e sa) (IsIn e sb)
   IsIn (e :> sa) (e :> sb)           = IsIn sa sb
   IsIn e e                           = ()

--- a/servant/src/Servant/API/TypeLevel.hs
+++ b/servant/src/Servant/API/TypeLevel.hs
@@ -54,6 +54,7 @@ module Servant.API.TypeLevel (
 import           GHC.Exts
                  (Constraint)
 import           Data.Kind
+                 (Type)
 import           Servant.API.Alternative
                  (type (:<|>))
 import           Servant.API.Capture

--- a/servant/src/Servant/API/UVerb.hs
+++ b/servant/src/Servant/API/UVerb.hs
@@ -33,6 +33,7 @@ module Servant.API.UVerb
   )
 where
 
+import Data.Kind
 import Data.Proxy (Proxy (Proxy))
 import GHC.TypeLits (Nat)
 import Network.HTTP.Types (Status, StdMethod)
@@ -41,8 +42,8 @@ import Servant.API.Status (KnownStatus, statusVal)
 import Servant.API.ResponseHeaders (Headers)
 import Servant.API.UVerb.Union
 
-class KnownStatus (StatusOf a) => HasStatus (a :: *) where
-  type StatusOf (a :: *) :: Nat
+class KnownStatus (StatusOf a) => HasStatus (a :: Type) where
+  type StatusOf (a :: Type) :: Nat
 
 statusOf :: forall a proxy. HasStatus a => proxy a -> Status
 statusOf = const (statusVal (Proxy :: Proxy (StatusOf a)))
@@ -53,8 +54,8 @@ statusOf = const (statusVal (Proxy :: Proxy (StatusOf a)))
 instance HasStatus NoContent where
   type StatusOf NoContent = 204
 
-class HasStatuses (as :: [*]) where
-  type Statuses (as :: [*]) :: [Nat]
+class HasStatuses (as :: [Type]) where
+  type Statuses (as :: [Type]) :: [Nat]
   statuses :: Proxy as -> [Status]
 
 instance HasStatuses '[] where
@@ -100,7 +101,7 @@ instance HasStatus a => HasStatus (Headers ls a) where
 --
 -- Backwards compatibility is tricky, though: this type alias would mean people would have to
 -- use 'respond' instead of 'pure' or 'return', so all old handlers would have to be rewritten.
-data UVerb (method :: StdMethod) (contentTypes :: [*]) (as :: [*])
+data UVerb (method :: StdMethod) (contentTypes :: [Type]) (as :: [Type])
 
 instance {-# OVERLAPPING #-} MimeRender JSON a => MimeRender JSON (WithStatus _status a) where
   mimeRender contentTypeProxy (WithStatus a) = mimeRender contentTypeProxy a

--- a/servant/src/Servant/API/UVerb.hs
+++ b/servant/src/Servant/API/UVerb.hs
@@ -33,7 +33,7 @@ module Servant.API.UVerb
   )
 where
 
-import Data.Kind
+import Data.Kind (Type)
 import Data.Proxy (Proxy (Proxy))
 import GHC.TypeLits (Nat)
 import Network.HTTP.Types (Status, StdMethod)

--- a/servant/src/Servant/API/UVerb/Union.hs
+++ b/servant/src/Servant/API/UVerb/Union.hs
@@ -59,7 +59,7 @@ module Servant.API.UVerb.Union
 )
 where
 
-import Data.Kind
+import Data.Kind (Type)
 import Data.Proxy (Proxy)
 import Data.SOP.BasicFunctors (I, unI)
 import Data.SOP.Constraint

--- a/servant/src/Servant/API/UVerb/Union.hs
+++ b/servant/src/Servant/API/UVerb/Union.hs
@@ -59,6 +59,7 @@ module Servant.API.UVerb.Union
 )
 where
 
+import Data.Kind
 import Data.Proxy (Proxy)
 import Data.SOP.BasicFunctors (I, unI)
 import Data.SOP.Constraint
@@ -75,7 +76,7 @@ type Union = NS I
 --
 -- See also: 'matchUnion'.
 foldMapUnion ::
-  forall (c :: * -> Constraint) (a :: *) (as :: [*]).
+  forall (c :: Type -> Constraint) (a :: Type) (as :: [Type]).
   All c as =>
   Proxy c ->
   (forall x. c x => x -> a) ->
@@ -88,7 +89,7 @@ foldMapUnion proxy go = cfoldMap_NS proxy (go . unI)
 -- otherwise.
 --
 -- See also: 'foldMapUnion'.
-matchUnion :: forall (a :: *) (as :: [*]). (IsMember a as) => Union as -> Maybe a
+matchUnion :: forall (a :: Type) (as :: [Type]). (IsMember a as) => Union as -> Maybe a
 matchUnion = fmap unI . eject
 
 -- * Stuff stolen from 'Data.WorldPeace" but for generics-sop

--- a/servant/src/Servant/API/Verbs.hs
+++ b/servant/src/Servant/API/Verbs.hs
@@ -9,6 +9,7 @@ module Servant.API.Verbs
   ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.Proxy
                  (Proxy)
 import           Data.Typeable

--- a/servant/src/Servant/API/Verbs.hs
+++ b/servant/src/Servant/API/Verbs.hs
@@ -8,6 +8,7 @@ module Servant.API.Verbs
   , StdMethod(GET, POST, HEAD, PUT, DELETE, TRACE, CONNECT, OPTIONS, PATCH)
   ) where
 
+import           Data.Kind
 import           Data.Proxy
                  (Proxy)
 import           Data.Typeable
@@ -26,7 +27,7 @@ import           Network.HTTP.Types.Method
 -- provided, but you are free to define your own:
 --
 -- >>> type Post204 contentTypes a = Verb 'POST 204 contentTypes a
-data Verb (method :: k1) (statusCode :: Nat) (contentTypes :: [*]) (a :: *)
+data Verb (method :: k1) (statusCode :: Nat) (contentTypes :: [Type]) (a :: Type)
   deriving (Typeable, Generic)
 
 -- | @NoContentVerb@ is a specific type to represent 'NoContent' responses.

--- a/servant/src/Servant/API/WithNamedContext.hs
+++ b/servant/src/Servant/API/WithNamedContext.hs
@@ -4,6 +4,7 @@
 module Servant.API.WithNamedContext where
 
 import           GHC.TypeLits
+import           Data.Kind
 
 -- | 'WithNamedContext' names a specific tagged context to use for the
 -- combinators in the API. (See also in @servant-server@,
@@ -18,4 +19,4 @@ import           GHC.TypeLits
 -- 'Context's are only relevant for @servant-server@.
 --
 -- For more information, see the tutorial.
-data WithNamedContext (name :: Symbol) (subContext :: [*]) subApi
+data WithNamedContext (name :: Symbol) (subContext :: [Type]) subApi

--- a/servant/src/Servant/API/WithNamedContext.hs
+++ b/servant/src/Servant/API/WithNamedContext.hs
@@ -5,6 +5,7 @@ module Servant.API.WithNamedContext where
 
 import           GHC.TypeLits
 import           Data.Kind
+                 (Type)
 
 -- | 'WithNamedContext' names a specific tagged context to use for the
 -- combinators in the API. (See also in @servant-server@,

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -131,6 +131,7 @@ module Servant.Links (
 ) where
 
 import           Data.Kind
+                 (Type)
 import           Data.List
 import           Data.Constraint
 import           Data.Proxy
@@ -197,8 +198,6 @@ import           Servant.API.WithNamedContext
 import           Servant.API.WithResource
                  (WithResource)
 import           Web.HttpApiData
-import           Data.Kind
-                 (Type)
 
 -- | A safe link datatype.
 -- The only way of constructing a 'Link' is using 'safeLink', which means any

--- a/servant/src/Servant/Links.hs
+++ b/servant/src/Servant/Links.hs
@@ -358,7 +358,7 @@ safeLink' toA _ endpoint = toLink toA endpoint (Link mempty mempty mempty)
 -- Note: nested APIs don't work well with this approach
 --
 -- >>> :kind! MkLink (Capture "nest" Char :> (Capture "x" Int :> Get '[JSON] Int :<|> Capture "y" Double :> Get '[JSON] Double)) Link
--- MkLink (Capture "nest" Char :> (Capture "x" Int :> Get '[JSON] Int :<|> Capture "y" Double :> Get '[JSON] Double)) Link :: Type
+-- MkLink (Capture "nest" Char :> (Capture "x" Int :> Get '[JSON] Int :<|> Capture "y" Double :> Get '[JSON] Double)) Link :: *
 -- = Char -> (Int -> Link) :<|> (Double -> Link)
 allLinks
     :: forall api. HasLink api


### PR DESCRIPTION
This PR fixes warning messages related to the deprecation of the `StarIsType` extension by changing `*`s to `Data.Kind.Type`.