### PR TITLE
Add -XTypeOperators

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/RunClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/RunClient.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 -- | Types for possible backends to run client-side `Request` queries
 module Servant.Client.Core.RunClient (
     RunClient (..),

--- a/servant-client-core/src/Servant/Client/Generic.hs
+++ b/servant-client-core/src/Servant/Client/Generic.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 module  Servant.Client.Generic (
     AsClientT,

--- a/servant-conduit/src/Servant/Conduit.hs
+++ b/servant-conduit/src/Servant/Conduit.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | This module exports 'ToSourceIO' and 'FromSourceIO' for 'ConduitT' instances.

--- a/servant-pipes/src/Servant/Pipes.hs
+++ b/servant-pipes/src/Servant/Pipes.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | This module exports 'ToSourceIO' and 'FromSourceIO' for 'Proxy' and 'SafeT' instances.

--- a/servant/src/Servant/Types/SourceT.hs
+++ b/servant/src/Servant/Types/SourceT.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
 module Servant.Types.SourceT where
 
 import           Control.Monad.Except


### PR DESCRIPTION
See #1681. Adds `LANGUAGE TypeOperators` where warned that this will be needed, such as:

```
$ cabal build all --enable-tests --enable-benchmarks
Resolving dependencies...
Build profile: -w ghc-9.4.7 -O0
...
src/Servant/Types/SourceT.hs:73:19: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
   |
73 | instance Identity ~ m => Foldable (SourceT m) where
   |  
```

Can be tested by doing a rebuild from clean with this warning as an error:

```diff
$ git diff
diff --git a/cabal.project b/cabal.project
index 2239b77c..888f4689 100644
--- a/cabal.project
+++ b/cabal.project
@@ -77,3 +77,6 @@ if(impl(ghc >= 9.6.1))
 allow-newer: servant-multipart:servant, servant-multipart:servant-server, servant-multipart-api:servant
 allow-newer: servant-pagination:servant, servant-pagination:servant-server
 allow-newer: servant-js:servant, servant-js:servant-foreign
+
+program-options
+  ghc-options: -Werror=type-equality-requires-operators
\ No newline at end of file
```