### PR TITLE
Remove unnecessary servant-multipart{,-api} allow-newers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,6 +62,4 @@ if(impl(ghc >= 9.6.1))
   package servant-server
     ghc-options: -fprint-redundant-promotion-ticks
 
-allow-newer: servant-multipart:bytestring,     servant-multipart:text
-allow-newer: servant-multipart-api:bytestring, servant-multipart-api:text
 allow-newer: swagger2:aeson, swagger2:base, swagger2:template-haskell, swagger2:bytestring, swagger2:text


### PR DESCRIPTION
These revisions were just made today, so we should no longer need this.