### PR TITLE
Fix typo in servant-conduit example

### DIFF
--- a/servant-conduit/example/Main.hs
+++ b/servant-conduit/example/Main.hs
@@ -58,7 +58,7 @@ server = fast :<|> slow :<|> readme :<|> proxy
         return $ slowConduit n
 
     readme = liftIO $ do
-        putStrLn "/proxy"
+        putStrLn "/readme"
         return (C.sourceFile "README.md")
 
     proxy c = liftIO $ do


### PR DESCRIPTION
Just a small benign typo