### PR TITLE
Remove allow-newer for swagger2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -61,5 +61,3 @@ if(impl(ghc >= 9.6.1))
 
   package servant-server
     ghc-options: -fprint-redundant-promotion-ticks
-
-allow-newer: swagger2:aeson, swagger2:base, swagger2:template-haskell, swagger2:bytestring, swagger2:text


### PR DESCRIPTION
[v2.8.8 released with GHC 9.8 support](https://hackage.haskell.org/package/swagger2-2.8.8/changelog)