### PR TITLE
Use tested-with for CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,7 +47,7 @@ jobs:
         path: | 
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('./.plan.json') }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
         restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
 
     - name: Install doctest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   generate-matrix:
     name: "Generate matrix from cabal"
-    outputs: 
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v4.0.0
       with:
-        path: | 
+        path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
         key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
@@ -110,7 +110,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v4.0.0
       with:
-        path: | 
+        path: |
           ~/.cabal/store
           dist-newstyle
         key: ${{ runner.os }}-ghcjs8.6-cabal-${{ hashFiles('./.plan.json') }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,23 +7,25 @@ on:
       - master
 
 jobs:
-  cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: servant/servant.cabal
+          ubuntu: true
+          version: 0.1.6.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        cabal: ["3.10"]
-        ghc:
-          - "8.8.4"
-          - "8.10.7"
-          - "9.0.2"
-          - "9.2.8"
-          - "9.4.8"
-          - "9.6.3"
-          - "9.8.1"
-      fail-fast: false
-
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v2
 
@@ -32,22 +34,21 @@ jobs:
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+        cabal-version: 'latest'
 
     - name: Freeze
       run: |
         cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
         cabal freeze
 
-    - uses: actions/cache/restore@v3
-      name: Cache ~/.cabal/store and dist-newstyle
+    - name: Cache
+      uses: actions/cache@v4.0.0
       with:
-        path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        path: | 
+          ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('./.plan.json') }}
+        restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
 
     - name: Install doctest
       run: |
@@ -85,42 +86,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-
-  # stack:
-  #   name: stack / ghc ${{ matrix.ghc }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       stack: ["2.7.5"]
-  #       ghc: ["8.10.7"]
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - uses: haskell/actions/setup@v1
-  #     name: Setup Haskell Stack
-  #     with:
-  #       ghc-version: ${{ matrix.ghc }}
-  #       stack-version: ${{ matrix.stack }}
-
-  #   - uses: actions/cache@v2.1.3
-  #     name: Cache ~/.stack
-  #     with:
-  #       path: ~/.stack
-  #       key: ${{ runner.os }}-${{ matrix.ghc }}-stack
-
-  #   - name: Install dependencies
-  #     run: |
-  #       stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
-
-  #   - name: Build
-  #     run: |
-  #       stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
-
-  #   - name: Test
-  #     run: |
-  #       stack test --system-ghc
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('./.plan.json') }}
 
   ghcjs:
     name: ubuntu-latest / ghcjs 8.6
@@ -141,16 +107,14 @@ jobs:
         cp cabal.ghcjs.project cabal.project
         cat cabal.project
         nix-shell ghcjs.nix --run "cabal v2-update && cabal v2-freeze"
-
-    - uses: actions/cache/restore@v3
-      name: Cache ~/.cabal/store and dist-newstyle
+    - name: Cache
+      uses: actions/cache@v4.0.0
       with:
-        path: |
+        path: | 
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-ghcjs8.6-${{ hashFiles('cabal.project.freeze') }}
-        restore-keys: |
-          ${{ runner.os }}-ghcjs8.6-
+        key: ${{ runner.os }}-ghcjs8.6-cabal-${{ hashFiles('./.plan.json') }}
+        restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
 
     - name: Build
       run: |

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -19,14 +19,13 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Servant Contributors
 maintainer:         haskell-servant-maintainers@googlegroups.com
-copyright:
-  2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
-
+copyright: 2014-2016 Zalora South East Asia Pte Ltd, 2016-2018 Servant Contributors
 build-type:         Simple
 tested-with:        ghc >=7.8
 extra-source-files:
   CHANGELOG.md
   README.md
+tested-with: GHCJS ==8.6.0.1
 
 source-repository head
   type:     git

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -20,7 +20,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -19,7 +19,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -21,7 +21,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2015-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -20,7 +20,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -23,7 +23,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
   CHANGELOG.md

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -28,7 +28,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           (c) 2015-2018, Servant contributors
 category:            Web, Servant, Swagger
 build-type:          Custom
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
 
 extra-source-files:
     README.md

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -20,7 +20,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
 
-tested-with: GHC==8.6.5, GHC==8.8.4, GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.7, GHC ==9.4.4
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.1
            , GHCJS ==8.6.0.1
 
 extra-source-files:

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -19,8 +19,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-
-tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.1
+tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
            , GHCJS ==8.6.0.1
 
 extra-source-files:


### PR DESCRIPTION
In order to minimise drift, CI testing matrix can be derived from the `tested-with` stanza of the cabal file, which in turn is also displayed by [Flora.pm](https://flora.pm/packages/@hackage/servant)