### PR TITLE
Add `MkHandler` pattern synonym

### DIFF
--- a/changelog.d/1733
+++ b/changelog.d/1733
@@ -1,0 +1,7 @@
+synopsis: Add `MkHandler` pattern synonym
+prs: #1733
+issues: #1732
+description: {
+Add a bidirectional pattern synonym to construct `Handler a` values from `IO
+(Either ServerError a)` ones, and match in the other direction.
+}

--- a/servant-server/src/Servant/Server.hs
+++ b/servant-server/src/Servant/Server.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE PatternSynonyms     #-}
 
 -- | This module lets you implement 'Server's for defined APIs. You'll
 -- most likely just need 'serve'.
@@ -25,6 +26,7 @@ module Servant.Server
   , emptyServer
   , Handler (..)
   , runHandler
+  , pattern MkHandler
 
     -- * Debugging the server layout
   , layout

--- a/servant-server/src/Servant/Server/Internal/Handler.hs
+++ b/servant-server/src/Servant/Server/Internal/Handler.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE PatternSynonyms            #-}
 module Servant.Server.Internal.Handler where
 
 import           Prelude ()
@@ -19,7 +20,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Control
                  (MonadBaseControl (..))
 import           Control.Monad.Trans.Except
-                 (ExceptT, runExceptT)
+                 (ExceptT(ExceptT), runExceptT)
 import           Data.String
                  (fromString)
 import           GHC.Generics
@@ -51,3 +52,10 @@ instance MonadBaseControl IO Handler where
 
 runHandler :: Handler a -> IO (Either ServerError a)
 runHandler = runExceptT . runHandler'
+
+-- | Pattern synonym that matches directly on the inner 'IO' action.
+--
+-- To lift 'IO' actions that don't carry a 'ServerError', use 'Control.Monad.IO.Class.liftIO' instead.
+pattern MkHandler :: IO (Either ServerError a) -> Handler a
+pattern MkHandler ioe = Handler (ExceptT ioe)
+{-# COMPLETE MkHandler #-}


### PR DESCRIPTION
This bidirectional pattern synonym makes it easier to build `Handler a` values from `IO (Either ServerError a)` values, and is a complement to the already existing `runHandler` function.

![image](https://github.com/haskell-servant/servant/assets/1136927/5f786fff-d8a7-4b28-b62e-a9af3cd638b6)


As an alternative to this, I also considered re-exporting the `ExceptT` constructor, but I think it's better to have an explicit pattern synonym. `ExceptT` is not exactly an internal implementation detail, but it's sufficiently close to being one.

As for naming the pattern synonym, I considered `HandlerT` but it would be a bit misleading because `Handler` is not really a monad transformer. The prefix is `Mk` instead of `Make` because other parts of the Servant ecosystem (like safe links) have already settled on `Mk`.

Solves #1732.