### PR TITLE
Accept network-3.2, misc bumps

### DIFF
--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -126,7 +126,7 @@ test-suite spec
       entropy           >= 0.4.1.3  && < 0.5
     , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
-    , network           >= 2.8.0.0  && < 3.2
+    , network           >= 2.8.0.0  && < 3.3
     , QuickCheck        >= 2.12.6.1 && < 2.15
     , servant           >= 0.20     && < 0.21
     , servant-server    >= 0.20     && < 0.21

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -114,7 +114,7 @@ test-suite spec
       entropy           >= 0.4.1.3  && < 0.5
     , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
-    , network           >= 2.8.0.0  && < 3.2
+    , network           >= 2.8.0.0  && < 3.3
     , QuickCheck        >= 2.12.6.1 && < 2.15
     , servant-server    >= 0.20 && < 0.21
     , servant           >= 0.20 && < 0.21

--- a/servant-quickcheck/doc/doc.cabal
+++ b/servant-quickcheck/doc/doc.cabal
@@ -10,8 +10,8 @@ cabal-version: >=1.10
 -- library
 --   exposed-modules:     ServersEqual
 --   other-extensions:    DataKinds, TypeOperators
---   build-depends:       base >=4.8 && <4.9
---                      , servant-server == 0.7.*
+--   build-depends:       base
+--                      , servant-server
 --                      , servant-quickcheck
 --                      , servant-client
 --                      , QuickCheck
@@ -25,8 +25,8 @@ cabal-version: >=1.10
 --
 -- executable doc
 --   main-is:             Main.hs
---   build-depends:       base >=4.8 && <4.9
---                      , servant-server == 0.7.*
+--   build-depends:       base
+--                      , servant-server
 --                      , servant-quickcheck
 --                      , servant-client
 --                      , QuickCheck
@@ -42,14 +42,14 @@ executable announcement
   main-is:          Announcement.lhs
   build-depends:
       aeson
-    , base                >=4.8 && <4.9
+    , base
     , containers
     , hspec
     , postgresql-simple
     , QuickCheck
     , servant-client
     , servant-quickcheck
-    , servant-server      >=0.7 && <0.8
+    , servant-server
     , stm
     , text
     , transformers

--- a/servant-quickcheck/doc/posts/posts.cabal
+++ b/servant-quickcheck/doc/posts/posts.cabal
@@ -18,13 +18,13 @@ cabal-version: >=1.10
 executable posts
   main-is:          Main.hs
   build-depends:
-      aeson              >=0.9 && <0.12
-    , base               >=4.8 && <4.9
+      aeson
+    , base
     , postgresql-simple
-    , servant-server     >=0.5 && <0.8
-    , text               >=1   && <2
-    , transformers       >=0.4 && <0.5
-    , warp               >=3.0 && <3.3
+    , servant-server
+    , text
+    , transformers
+    , warp
 
   hs-source-dirs:   src
   ghc-options:      -Wall -O2 -threaded
@@ -41,14 +41,14 @@ test-suite spec
   --  see http://haskell.org/cabal/users-guide/
 
   build-depends:
-      aeson                 >=0.9 && <0.12
-    , base                  >=4   && <5
-    , hspec                 >=2   && <3
+      aeson
+    , base
+    , hspec
     , postgresql-simple
     , QuickCheck
     , quickcheck-instances
     , servant-quickcheck
-    , servant-server        >=0.5 && <0.8
-    , text                  >=1   && <2
-    , transformers          >=0.4 && <0.5
-    , warp                  >=3.0 && <3.3
+    , servant-server
+    , text
+    , transformers
+    , warp

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -58,7 +58,7 @@ library
     , temporary              >=1.2    && <1.4
     , text                   >=1      && <2.2
     , time                   >=1.5    && <1.13
-    , warp                   >=3.2.4  && <3.4
+    , warp                   >=3.2.4  && <3.5
 
   hs-source-dirs:     src
   default-extensions:

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -85,7 +85,7 @@ library
     , http-types          >= 0.12.2   && < 0.13
     , network-uri         >= 2.6.1.0  && < 2.8
     , monad-control       >= 1.0.2.3  && < 1.1
-    , network             >= 2.8      && < 3.2
+    , network             >= 2.8      && < 3.3
     , sop-core            >= 0.4.0.0  && < 0.6
     , string-conversions  >= 0.4.0.1  && < 0.5
     , resourcet           >= 1.2.2    && < 1.4


### PR DESCRIPTION
Tested with

    cabal build -c 'network>=3.2' -c 'filepath >= 1.4' -c 'warm >= 3.4' --allow-newer=swagger2:network,io-streams:network,openssl-streams:network,HsOpenSSL:network

I have created issues for these allow-newers. Have removed version constraints from cookbook examples since we always forget them. And they're not published anyway.