### PR TITLE
Remove extraneous dependencies (part 2)

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -55,7 +55,6 @@ library
     , containers            >= 0.5.7.1  && < 0.7
     , deepseq               >= 1.4.2.0  && < 1.6
     , text                  >= 1.2.3.0  && < 2.2
-    , transformers          >= 0.5.2.0  && < 0.7
     , template-haskell      >= 2.11.1.0 && < 2.22
 
   if !impl(ghc >= 8.2)

--- a/servant-client/test/Servant/StreamSpec.hs
+++ b/servant-client/test/Servant/StreamSpec.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE CPP                    #-}
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DeriveGeneric          #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE PolyKinds              #-}
-{-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE StandaloneDeriving     #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
@@ -21,12 +17,6 @@
 
 module Servant.StreamSpec (spec) where
 
-import           Control.Monad
-                 (when)
-import           Control.Monad.Codensity
-                 (Codensity (..))
-import           Control.Monad.IO.Class
-                 (MonadIO (..))
 import           Control.Monad.Trans.Except
 import qualified Data.ByteString               as BS
 import           Data.Proxy
@@ -45,19 +35,9 @@ import           System.Entropy
                  (getEntropy, getHardwareEntropy)
 import           System.IO.Unsafe
                  (unsafePerformIO)
-import           System.Mem
-                 (performGC)
 import           Test.Hspec
 import           Servant.ClientTestUtils (Person(..))
 import qualified Servant.ClientTestUtils as CT
-
-#if MIN_VERSION_base(4,10,0)
-import           GHC.Stats
-                 (gc, gcdetails_live_bytes, getRTSStats)
-#else
-import           GHC.Stats
-                 (currentBytesUsed, getGCStats)
-#endif
 
 -- This declaration simply checks that all instances are in place.
 -- Note: this is streaming client

--- a/servant-docs/golden/comprehensive.md
+++ b/servant-docs/golden/comprehensive.md
@@ -544,7 +544,7 @@
 
 - Example (`application/json;charset=utf-8`, `application/json`):
 
-```javascript
+```json
 
 ```
 
@@ -607,3 +607,4 @@
 ```json
 
 ```
+

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -54,7 +54,6 @@ library
     , servant-client         >=0.17   && <0.21
     , servant-server         >=0.17   && <0.21
     , split                  >=0.2    && <0.3
-    , string-conversions     >=0.3    && <0.5
     , temporary              >=1.2    && <1.4
     , text                   >=1      && <2.2
     , time                   >=1.5    && <1.13

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -83,11 +83,9 @@ library
     , exceptions          >= 0.10.0   && < 0.11
     , http-media          >= 0.7.1.3  && < 0.9
     , http-types          >= 0.12.2   && < 0.13
-    , network-uri         >= 2.6.1.0  && < 2.8
     , monad-control       >= 1.0.2.3  && < 1.1
     , network             >= 2.8      && < 3.3
     , sop-core            >= 0.4.0.0  && < 0.6
-    , string-conversions  >= 0.4.0.1  && < 0.5
     , resourcet           >= 1.2.2    && < 1.4
     , tagged              >= 0.8.6    && < 0.9
     , transformers-base   >= 0.4.5.2  && < 0.5
@@ -148,11 +146,7 @@ test-suite spec
     , safe
     , servant
     , servant-server
-    , sop-core
-    , string-conversions
     , text
-    , transformers
-    , transformers-compat
     , wai
 
   -- Additional dependencies
@@ -161,7 +155,6 @@ test-suite spec
     , directory            >= 1.3.0.0  && < 1.4
     , hspec                >= 2.6.0    && < 2.12
     , hspec-wai            >= 0.10.1   && < 0.12
-    , QuickCheck           >= 2.12.6.1 && < 2.15
     , should-not-typecheck >= 2.1.0    && < 2.2
     , temporary            >= 1.3      && < 1.4
     , wai-extra            >= 3.0.24.3 && < 3.2

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -78,7 +78,6 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat         >= 0.10.5   && < 0.14
     , base64-bytestring   >= 1.0.0.1  && < 1.3
     , exceptions          >= 0.10.0   && < 0.11
     , http-media          >= 0.7.1.3  && < 0.9

--- a/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
+++ b/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
@@ -15,13 +15,10 @@ module Servant.Server.Internal.ErrorFormatter
   , mkContextWithErrorFormatter
   ) where
 
-import           Data.Kind
-                 (Type)
-import           Data.String.Conversions
-                 (cs)
+import           Data.Kind (Type)
 import           Data.Typeable
-import           Network.Wai.Internal
-                 (Request)
+import           Network.Wai.Internal (Request)
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 
 import           Servant.API
                  (Capture, ReqBody)
@@ -77,7 +74,7 @@ mkContextWithErrorFormatter ctx = ctx .++ (defaultErrorFormatters :. EmptyContex
 -- Internal
 
 err400Formatter :: ErrorFormatter
-err400Formatter _ _ e = err400 { errBody = cs e }
+err400Formatter _ _ e = err400 { errBody = BSL8.pack e }
 
 -- These definitions suppress "unused import" warning.
 -- The imorts are needed for Haddock to correctly link to them.

--- a/servant-server/src/Servant/Server/Internal/Handler.hs
+++ b/servant-server/src/Servant/Server/Internal/Handler.hs
@@ -6,9 +6,6 @@
 {-# LANGUAGE PatternSynonyms            #-}
 module Servant.Server.Internal.Handler where
 
-import           Prelude ()
-import           Prelude.Compat
-
 import           Control.Monad.Base
                  (MonadBase (..))
 import           Control.Monad.Catch

--- a/servant-server/src/Servant/Server/Internal/Router.hs
+++ b/servant-server/src/Servant/Server/Internal/Router.hs
@@ -4,9 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Servant.Server.Internal.Router where
 
-import           Prelude ()
-import           Prelude.Compat
-
 import           Data.Function
                  (on)
 import           Data.List

--- a/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
+++ b/servant-server/src/Servant/Server/Internal/RoutingApplication.hs
@@ -2,8 +2,6 @@ module Servant.Server.Internal.RoutingApplication where
 
 import           Network.Wai
                  (Application, Request, Response, ResponseReceived)
-import           Prelude ()
-import           Prelude.Compat
 import           Servant.Server.Internal.RouteResult
 import           Servant.Server.Internal.ServerError
 

--- a/servant-server/test/Servant/Server/ErrorSpec.hs
+++ b/servant-server/test/Servant/Server/ErrorSpec.hs
@@ -11,10 +11,8 @@ import           Control.Monad
 import           Data.Aeson
                  (encode)
 import qualified Data.ByteString.Char8      as BC
-import qualified Data.ByteString.Lazy.Char8 as BCL
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import           Data.Proxy
-import           Data.String.Conversions
-                 (cs)
 import           Network.HTTP.Types
                  (hAccept, hAuthorization, hContentType, methodGet, methodPost,
                  methodPut)
@@ -299,7 +297,7 @@ errorChoiceSpec = describe "Multiple handlers return errors"
 -- * Custom errors {{{
 
 customFormatter :: ErrorFormatter
-customFormatter _ _ err = err400 { errBody = "CUSTOM! " <> cs err }
+customFormatter _ _ err = err400 { errBody = "CUSTOM! " <> BSL8.pack err }
 
 customFormatters :: ErrorFormatters
 customFormatters = defaultErrorFormatters
@@ -328,7 +326,7 @@ customFormattersSpec = describe "Custom errors from combinators"
   let startsWithCustom = ResponseMatcher
         { matchStatus = 400
         , matchHeaders = []
-        , matchBody = MatchBody $ \_ body -> if "CUSTOM!" `BCL.isPrefixOf` body
+        , matchBody = MatchBody $ \_ body -> if "CUSTOM!" `BSL8.isPrefixOf` body
             then Nothing
             else Just $ show body <> " does not start with \"CUSTOM!\""
         }
@@ -354,8 +352,8 @@ customFormattersSpec = describe "Custom errors from combinators"
 -- * Instances {{{
 
 instance MimeUnrender PlainText Int where
-    mimeUnrender _ x = maybe (Left "no parse") Right (readMay $ BCL.unpack x)
+    mimeUnrender _ x = maybe (Left "no parse") Right (readMay $ BSL8.unpack x)
 
 instance MimeRender PlainText Int where
-    mimeRender _ = BCL.pack . show
+    mimeRender _ = BSL8.pack . show
 -- }}}

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -109,8 +109,6 @@ library
     , mmorph                 >= 1.1.2    && < 1.3
     , network-uri            >= 2.6.1.0  && < 2.7
     , QuickCheck             >= 2.12.6.1 && < 2.15
-    , string-conversions     >= 0.4.0.1  && < 0.5
-    , tagged                 >= 0.8.6    && < 0.9
     , vault                  >= 0.3.1.2  && < 0.4
 
   hs-source-dirs: src
@@ -160,9 +158,7 @@ test-suite spec
     , http-media
     , mtl
     , servant
-    , string-conversions
     , text
-    , transformers
 
   -- Additional dependencies
   build-depends:

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -236,7 +236,7 @@ class AllCTUnrender (list :: [Type]) a where
 
 instance ( AllMimeUnrender ctyps a ) => AllCTUnrender ctyps a where
     canHandleCTypeH p ctypeH =
-        M.mapContentMedia (allMimeUnrender p) (BS.toStrict ctypeH)
+        M.mapContentMedia (allMimeUnrender p) (toStrict ctypeH)
 
 --------------------------------------------------------------------------
 -- * Utils (Internal)

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -85,8 +85,6 @@ import           Data.Kind
 import qualified Data.List.NonEmpty               as NE
 import           Data.Maybe
                  (isJust)
-import           Data.String.Conversions
-                 (cs)
 import qualified Data.Text                        as TextS
 import qualified Data.Text.Encoding               as TextS
 import qualified Data.Text.Lazy                   as TextL
@@ -238,7 +236,7 @@ class AllCTUnrender (list :: [Type]) a where
 
 instance ( AllMimeUnrender ctyps a ) => AllCTUnrender ctyps a where
     canHandleCTypeH p ctypeH =
-        M.mapContentMedia (allMimeUnrender p) (cs ctypeH)
+        M.mapContentMedia (allMimeUnrender p) (BS.toStrict ctypeH)
 
 --------------------------------------------------------------------------
 -- * Utils (Internal)

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -78,7 +78,7 @@ spec = describe "Servant.API.ContentTypes" $ do
         let p = Proxy :: Proxy '[JSON]
 
         it "does not render any content" $
-          allMimeRender p NoContent `shouldSatisfy` (all (BSL8.null . snd))
+          allMimeRender p NoContent `shouldSatisfy` all (BSL8.null . snd)
 
         it "evaluates the NoContent value" $
           evaluate (allMimeRender p (undefined :: NoContent)) `shouldThrow` anyErrorCall
@@ -155,8 +155,7 @@ spec = describe "Servant.API.ContentTypes" $ do
 #endif
             let acceptH a b c = addToAccept (Proxy :: Proxy OctetStream) a $
                                 addToAccept (Proxy :: Proxy JSON)        b $
-                                addToAccept (Proxy :: Proxy PlainText )  c $
-                                ""
+                                addToAccept (Proxy :: Proxy PlainText )  c ""
             let val a b c i = handleAcceptH (Proxy :: Proxy '[OctetStream, JSON, PlainText])
                                             (acceptH a b c) (i :: Int)
             property $ \a b c i ->


### PR DESCRIPTION
This PR removes unused dependencies, as well as `string-conversions`, which obfuscates the target and destination type of string used.

Due to GHCJS 8.6's inability to have `bytestring`'s `toStrict` function, this PR depends on https://github.com/haskell-servant/servant/pull/1746.