### PR TITLE
Added a note about cookie settings for browser clients

### DIFF
--- a/doc/cookbook/hoist-server-with-context/HoistServerWithContext.lhs
+++ b/doc/cookbook/hoist-server-with-context/HoistServerWithContext.lhs
@@ -334,6 +334,8 @@ main = do
   Warp.runSettings settings $ warpLogger $ mkApp cfg cookieCfg jwtCfg ctx
 ```
 
+**Note for browser clients**: default cookie settings (`defaultCookieSettings`) may not be suitable for
+browser clients due to [XSRF protection](https://github.com/haskell-servant/servant/tree/master/servant-auth#xsrf-and-the-frontend).
 
 ## Usage
 


### PR DESCRIPTION
Hi,

I was following this [cookbook recipe](https://docs.servant.dev/en/stable/cookbook/hoist-server-with-context/HoistServerWithContext.html), but it turns out that it doesn't quite work with web browser clients due to XSRF protection. 

This PR directs readers to the appropriate explanation.