### PR TITLE
codebase clean-up

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -54,6 +54,11 @@ packages:
 
 tests: True
 optimization: False
+
+-- Development flags
+package *
+  ghc-options: -fshow-hole-constraints -fhide-source-paths
+
 -- reorder-goals: True
 
 -- Print ticks so that doctest type querying is consistent across GHC versions.

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -1,109 +1,154 @@
-cabal-version:       2.2
-name:                servant-client-core
-version:             0.20
+cabal-version:      3.0
+name:               servant-client-core
+version:            0.20
+synopsis:
+  Core functionality and class for client function generation for servant APIs
 
-synopsis:            Core functionality and class for client function generation for servant APIs
-category:            Servant, Web
+category:           Servant, Web
 description:
   This library provides backend-agnostic generation of client functions. For
   more information, see the README.
 
-homepage:            http://docs.servant.dev/
-bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Servant Contributors
-maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
-build-type:          Simple
-tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
+homepage:           http://docs.servant.dev/
+bug-reports:        http://github.com/haskell-servant/servant/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Servant Contributors
+maintainer:         haskell-servant-maintainers@googlegroups.com
+copyright:
+  2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
+
+build-type:         Simple
+tested-with:
+  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.2
 
 extra-source-files:
   CHANGELOG.md
   README.md
 
 source-repository head
-  type:              git
-  location:          http://github.com/haskell-servant/servant.git
+  type:     git
+  location: http://github.com/haskell-servant/servant.git
+
+common extensions
+  default-extensions:
+    AllowAmbiguousTypes
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    ExplicitNamespaces
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NoStarIsType
+    OverloadedLabels
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    QuantifiedConstraints
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  default-language:   Haskell2010
+
+common ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -fdicts-strict
+    -Wno-unticked-promoted-constructors -Werror=unused-imports
+    -Wunused-packages
 
 library
+  import:          extensions
+  import:          ghc-options
   exposed-modules:
-      Servant.Client.Core
-      Servant.Client.Free
-      Servant.Client.Generic
-      Servant.Client.Core.Reexport
-      Servant.Client.Core.Auth
-      Servant.Client.Core.BaseUrl
-      Servant.Client.Core.BasicAuth
-      Servant.Client.Core.ClientError
-      Servant.Client.Core.HasClient
-      Servant.Client.Core.Request
-      Servant.Client.Core.Response
-      Servant.Client.Core.RunClient
+    Servant.Client.Core
+    Servant.Client.Core.Auth
+    Servant.Client.Core.BaseUrl
+    Servant.Client.Core.BasicAuth
+    Servant.Client.Core.ClientError
+    Servant.Client.Core.HasClient
+    Servant.Client.Core.Reexport
+    Servant.Client.Core.Request
+    Servant.Client.Core.Response
+    Servant.Client.Core.RunClient
+    Servant.Client.Free
+    Servant.Client.Generic
 
-  other-modules:
-      Servant.Client.Core.Internal
+  other-modules:   Servant.Client.Core.Internal
 
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                  >= 4.9      && < 4.20
-    , bytestring            >= 0.10.8.1 && < 0.13
-    , constraints           >= 0.2      && < 0.15
-    , containers            >= 0.5.7.1  && < 0.7
-    , deepseq               >= 1.4.2.0  && < 1.6
-    , text                  >= 1.2.3.0  && < 2.2
-    , template-haskell      >= 2.11.1.0 && < 2.22
-
-  if !impl(ghc >= 8.2)
-    build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+    , base              >=4.9      && <4.20
+    , bytestring        >=0.10.8.1 && <0.13
+    , constraints       >=0.2      && <0.15
+    , containers        >=0.5.7.1  && <0.7
+    , deepseq           >=1.4.2.0  && <1.6
+    , template-haskell  >=2.11.1.0 && <2.22
+    , text              >=1.2.3.0  && <2.2
 
   -- Servant dependencies
-  build-depends:
-      servant            >= 0.20
+  build-depends:   servant >=0.20
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                 >= 1.4.1.0  && < 3
-    , base-compat           >= 0.10.5   && < 0.14
-    , base64-bytestring     >= 1.0.0.1  && < 1.3
-    , exceptions            >= 0.10.0   && < 0.11
-    , free                  >= 5.1      && < 5.3
-    , http-media            >= 0.7.1.3  && < 0.9
-    , http-types            >= 0.12.2   && < 0.13
-    , network-uri           >= 2.6.1.0  && < 2.7
-    , safe                  >= 0.3.17   && < 0.4
-    , sop-core              >= 0.4.0.0  && < 0.6
+    , aeson              >=1.4.1.0 && <3
+    , base-compat        >=0.10.5  && <0.14
+    , base64-bytestring  >=1.0.0.1 && <1.3
+    , exceptions         >=0.10.0  && <0.11
+    , free               >=5.1     && <5.3
+    , http-media         >=0.7.1.3 && <0.9
+    , http-types         >=0.12.2  && <0.13
+    , network-uri        >=2.6.1.0 && <2.7
+    , safe               >=0.3.17  && <0.4
+    , sop-core           >=0.4.0.0 && <0.6
 
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
+  hs-source-dirs:  src
 
 test-suite spec
-  type:                exitcode-stdio-1.0
-  ghc-options:         -Wall
-  default-language:    Haskell2010
-  hs-source-dirs:      test
-  main-is:             Spec.hs
+  import:             extensions
+  import:             ghc-options
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Spec.hs
   other-modules:
-      Servant.Client.Core.Internal.BaseUrlSpec
-      Servant.Client.Core.RequestSpec
+    Servant.Client.Core.Internal.BaseUrlSpec
+    Servant.Client.Core.RequestSpec
 
   -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base
+    , base
     , base-compat
     , servant-client-core
 
   -- Additional dependencies
   build-depends:
-      deepseq    >= 1.4.2.0  && < 1.6
-    , hspec      >= 2.6.0    && < 2.12
-    , QuickCheck >= 2.12.6.1 && < 2.15
+    , deepseq     >=1.4.2.0  && <1.6
+    , hspec       >=2.6.0    && <2.12
+    , QuickCheck  >=2.12.6.1 && <2.15
 
-  build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12

--- a/servant-client-core/src/Servant/Client/Core/Auth.hs
+++ b/servant-client-core/src/Servant/Client/Core/Auth.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
@@ -10,6 +9,8 @@ module Servant.Client.Core.Auth (
     mkAuthenticatedRequest,
     ) where
 
+import Data.Kind (Type)
+
 import           Servant.Client.Core.Request
                  (Request)
 
@@ -18,7 +19,7 @@ import           Servant.Client.Core.Request
 -- to a request
 --
 -- NOTE: THIS API IS EXPERIMENTAL AND SUBJECT TO CHANGE
-type family AuthClientData a :: *
+type family AuthClientData a :: Type
 
 -- | For better type inference and to avoid usage of a data family, we newtype
 -- wrap the combination of some 'AuthClientData' and a function to add authentication

--- a/servant-client-core/src/Servant/Client/Core/BaseUrl.hs
+++ b/servant-client-core/src/Servant/Client/Core/BaseUrl.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DeriveLift         #-}
-{-# LANGUAGE ViewPatterns       #-}
 module Servant.Client.Core.BaseUrl (
     BaseUrl (..),
     Scheme (..),
@@ -21,7 +18,7 @@ import           Data.Aeson.Types
                  withText)
 import           Data.Data
                  (Data)
-import           Data.List
+import qualified Data.List as List
 import qualified Data.Text                  as T
 import           GHC.Generics
 import           Language.Haskell.TH.Syntax
@@ -91,7 +88,7 @@ showBaseUrl :: BaseUrl -> String
 showBaseUrl (BaseUrl urlscheme host port path) =
   schemeString ++ "//" ++ host ++ (portString </> path)
     where
-      a </> b = if "/" `isPrefixOf` b || null b then a ++ b else a ++ '/':b
+      a </> b = if "/" `List.isPrefixOf` b || null b then a ++ b else a ++ '/':b
       schemeString = case urlscheme of
         Http  -> "http:"
         Https -> "https:"
@@ -128,7 +125,7 @@ parseBaseUrl s = case parseURI (removeTrailingSlash s) of
     return (BaseUrl Https host port path)
   Just (URI "https:" (Just (URIAuth "" host "")) path "" "") ->
     return (BaseUrl Https host 443 path)
-  _ -> if "://" `isInfixOf` s
+  _ -> if "://" `List.isInfixOf` s
     then throwM (InvalidBaseUrlException $ "Invalid base URL: " ++ s)
     else parseBaseUrl ("http://" ++ s)
  where

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -1,19 +1,4 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
+{-# OPTIONS_GHC -Wno-missing-methods #-}
 module Servant.Client.Core.HasClient (
     clientIn,
     HasClient (..),
@@ -32,7 +17,6 @@ import           Control.Arrow
                  (left, (+++))
 import           Control.Monad
                  (unless)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import           Data.Either
                  (partitionEithers)
@@ -81,7 +65,7 @@ import           Servant.API
                  ReflectMethod (..),
                  StreamBody',
                  Verb,
-                 getResponse, AuthProtect, BasicAuth, BasicAuthData, Capture', CaptureAll, DeepQuery, Description, Fragment, FramingRender (..), FramingUnrender (..), Header', Headers (..), HttpVersion, MimeRender (mimeRender), NoContent (NoContent), QueryFlag, QueryParam', QueryParams, QueryString, Raw, RawM, RemoteHost, ReqBody', SBoolI, Stream, Summary, ToHttpApiData, ToSourceIO (..), Vault, WithNamedContext, WithResource, WithStatus (..), contentType, getHeadersHList, toEncodedUrlPiece, toUrlPiece, NamedRoutes)
+                 getResponse, AuthProtect, BasicAuth, BasicAuthData, Capture', CaptureAll, DeepQuery, Description, Fragment, FramingRender (..), FramingUnrender (..), Header', Headers (..), HttpVersion, MimeRender (mimeRender), NoContent (NoContent), QueryFlag, QueryParam', QueryParams, QueryString, Raw, RawM, RemoteHost, ReqBody', SBoolI, Stream, Summary, ToHttpApiData, ToSourceIO (..), Vault, WithNamedContext, WithResource, WithStatus (..), contentType, getHeadersHList, toEncodedUrlPiece, NamedRoutes)
 import           Servant.API.Generic
                  (GenericMode(..), ToServant, ToServantApi
                  , GenericServant, toServant, fromServant)
@@ -202,7 +186,7 @@ instance RunClient m => HasClient m EmptyAPI where
 -- > getBook :: Text -> ClientM Book
 -- > getBook = client myApi
 -- > -- then you can just use "getBook" to query that endpoint
-instance (KnownSymbol capture, ToHttpApiData a, HasClient m api)
+instance (ToHttpApiData a, HasClient m api)
       => HasClient m (Capture' mods capture a :> api) where
 
   type Client m (Capture' mods capture a :> api) =
@@ -237,7 +221,7 @@ instance (KnownSymbol capture, ToHttpApiData a, HasClient m api)
 -- > getSourceFile :: [Text] -> ClientM SourceFile
 -- > getSourceFile = client myApi
 -- > -- then you can use "getSourceFile" to query that endpoint
-instance (KnownSymbol capture, ToHttpApiData a, HasClient m sublayout)
+instance (ToHttpApiData a, HasClient m sublayout)
       => HasClient m (CaptureAll capture a :> sublayout) where
 
   type Client m (CaptureAll capture a :> sublayout) =

--- a/servant-client-core/src/Servant/Client/Core/Request.hs
+++ b/servant-client-core/src/Servant/Client/Core/Request.hs
@@ -54,7 +54,7 @@ import           Network.HTTP.Types
                  (Header, HeaderName, HttpVersion (..), Method, Query, QueryItem,
                  http11, methodGet, urlEncodeBuilder)
 import           Servant.API
-                 (ToHttpApiData, toEncodedUrlPiece, toQueryParam, toHeader, SourceIO)
+                 (ToHttpApiData, toQueryParam, toHeader, SourceIO)
 
 import Servant.Client.Core.Internal (mediaTypeRnf)
 

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -1,9 +1,8 @@
-cabal-version:       2.2
-name:                servant-client
-version:             0.20
-
-synopsis:            Automatic derivation of querying functions for servant
-category:            Servant, Web
+cabal-version:      3.0
+name:               servant-client
+version:            0.20
+synopsis:           Automatic derivation of querying functions for servant
+category:           Servant, Web
 description:
   This library lets you derive automatically Haskell functions that
   let you query each endpoint of a <http://hackage.haskell.org/package/servant servant> webservice.
@@ -12,133 +11,190 @@ description:
   .
   <https://github.com/haskell-servant/servant/blob/master/servant-client/CHANGELOG.md CHANGELOG>
 
-homepage:            http://docs.servant.dev/
-bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Servant Contributors
-maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
-build-type:          Simple
-tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
+homepage:           http://docs.servant.dev/
+bug-reports:        http://github.com/haskell-servant/servant/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Servant Contributors
+maintainer:         haskell-servant-maintainers@googlegroups.com
+copyright:
+  2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
+
+build-type:         Simple
+tested-with:
+  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.2
 
 extra-source-files:
   CHANGELOG.md
   README.md
 
 source-repository head
-  type: git
+  type:     git
   location: http://github.com/haskell-servant/servant.git
 
+common extensions
+  default-extensions:
+    AllowAmbiguousTypes
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    ExplicitNamespaces
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NoStarIsType
+    OverloadedLabels
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    QuantifiedConstraints
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  default-language:   Haskell2010
+
+common ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -fdicts-strict
+    -Wno-unticked-promoted-constructors -Werror=unused-imports
+    -Wunused-packages
+
 library
+  import:          extensions
+  import:          ghc-options
   exposed-modules:
     Servant.Client
-    Servant.Client.Streaming
     Servant.Client.Internal.HttpClient
     Servant.Client.Internal.HttpClient.Streaming
+    Servant.Client.Streaming
 
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                  >= 4.9      && < 4.20
-    , bytestring            >= 0.10.8.1 && < 0.13
-    , containers            >= 0.5.7.1  && < 0.7
-    , deepseq               >= 1.4.2.0  && < 1.6
-    , mtl                   ^>= 2.2.2   || ^>= 2.3.1
-    , stm                   >= 2.4.5.1  && < 2.6
-    , text                  >= 1.2.3.0  && < 2.2
-    , time                  >= 1.6.0.1  && < 1.13
-    , transformers          >= 0.5.2.0  && < 0.7
-
-  if !impl(ghc >= 8.2)
-    build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+    , base          >=4.9      && <4.20
+    , bytestring    >=0.10.8.1 && <0.13
+    , containers    >=0.5.7.1  && <0.7
+    , deepseq       >=1.4.2.0  && <1.6
+    , mtl           ^>=2.2.2   || ^>=2.3.1
+    , stm           >=2.4.5.1  && <2.6
+    , time          >=1.6.0.1  && <1.13
+    , transformers  >=0.5.2.0  && <0.7
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.
   build-depends:
-      servant               >= 0.20 && < 0.21
-    , servant-client-core   >= 0.20 && < 0.21
+    , servant              >=0.20 && <0.21
+    , servant-client-core  >=0.20 && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat           >= 0.10.5   && < 0.14
-    , http-client           >= 0.5.13.1 && < 0.8
-    , http-media            >= 0.7.1.3  && < 0.9
-    , http-types            >= 0.12.2   && < 0.13
-    , exceptions            >= 0.10.0   && < 0.11
-    , kan-extensions        >= 5.2      && < 5.3
-    , monad-control         >= 1.0.2.3  && < 1.1
-    , semigroupoids         >= 5.3.1    && < 6.1
-    , transformers-base     >= 0.4.5.2  && < 0.5
-    , transformers-compat   >= 0.6.2    && < 0.8
+    , base-compat          >=0.10.5   && <0.14
+    , exceptions           >=0.10.0   && <0.11
+    , http-client          >=0.5.13.1 && <0.8
+    , http-media           >=0.7.1.3  && <0.9
+    , http-types           >=0.12.2   && <0.13
+    , kan-extensions       >=5.2      && <5.3
+    , monad-control        >=1.0.2.3  && <1.1
+    , semigroupoids        >=5.3.1    && <6.1
+    , transformers-base    >=0.4.5.2  && <0.5
 
-  hs-source-dirs: src
-  default-language: Haskell2010
-  ghc-options: -Wall -Wno-redundant-constraints
+  hs-source-dirs:  src
 
 test-suite spec
-  type: exitcode-stdio-1.0
-  ghc-options: -Wall -rtsopts -threaded "-with-rtsopts=-T -N2"
-  default-language: Haskell2010
+  import:             extensions
+  import:             ghc-options
+  type:               exitcode-stdio-1.0
+  ghc-options:        -Wall -rtsopts -threaded "-with-rtsopts=-T -N2"
+
   if impl(ghcjs)
-     buildable: False
-  hs-source-dirs: test
-  main-is: Spec.hs
+    buildable: False
+
+  hs-source-dirs:     test
+  main-is:            Spec.hs
   other-modules:
-      Servant.BasicAuthSpec
-      Servant.BrokenSpec
-      Servant.ClientTestUtils
-      Servant.ConnectionErrorSpec
-      Servant.FailSpec
-      Servant.GenAuthSpec
-      Servant.GenericSpec
-      Servant.HoistClientSpec
-      Servant.StreamSpec
-      Servant.SuccessSpec
-      Servant.WrappedApiSpec
+    Servant.BasicAuthSpec
+    Servant.BrokenSpec
+    Servant.ClientTestUtils
+    Servant.ConnectionErrorSpec
+    Servant.FailSpec
+    Servant.GenAuthSpec
+    Servant.GenericSpec
+    Servant.HoistClientSpec
+    Servant.MiddlewareSpec
+    Servant.StreamSpec
+    Servant.SuccessSpec
+    Servant.WrappedApiSpec
 
   -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base
     , aeson
+    , base
     , base-compat
     , bytestring
     , http-api-data
     , http-client
     , http-types
     , mtl
-    , kan-extensions
     , servant-client
     , servant-client-core
     , sop-core
     , stm
     , text
     , transformers
-    , transformers-compat
     , wai
     , warp
 
   -- Additional dependencies
   build-depends:
-      entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.12
-    , HUnit             >= 1.6.0.0  && < 1.7
-    , network           >= 2.8.0.0  && < 3.3
-    , QuickCheck        >= 2.12.6.1 && < 2.15
-    , servant           >= 0.20     && < 0.21
-    , servant-server    >= 0.20     && < 0.21
+    , entropy         >=0.4.1.3  && <0.5
+    , hspec           >=2.6.0    && <2.12
+    , HUnit           >=1.6.0.0  && <1.7
+    , network         >=2.8.0.0  && <3.3
+    , QuickCheck      >=2.12.6.1 && <2.15
+    , servant         >=0.20     && <0.21
+    , servant-server  >=0.20     && <0.21
 
-  build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
 
 test-suite readme
-  type:           exitcode-stdio-1.0
-  main-is:        README.lhs
-  build-depends:  base, servant, http-client, text, servant-client, markdown-unlit
+  import:             extensions
+  import:             ghc-options
+  type:               exitcode-stdio-1.0
+  main-is:            README.lhs
+  build-depends:
+    , base
+    , http-client
+    , markdown-unlit
+    , servant
+    , servant-client
+    , text
+
   build-tool-depends: markdown-unlit:markdown-unlit
-  ghc-options:    -pgmL markdown-unlit
-  default-language: Haskell2010
+  ghc-options:        -pgmL markdown-unlit
+
   if impl(ghcjs)
-     buildable: False
+    buildable: False

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -1,15 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE NamedFieldPuns             #-}
 module Servant.Client.Internal.HttpClient where
 
 import           Prelude ()
@@ -44,14 +33,12 @@ import qualified Data.ByteString             as BS
 import           Data.ByteString.Builder
                  (toLazyByteString)
 import qualified Data.ByteString.Lazy        as BSL
-import           Data.Either
-                 (either)
 import           Data.Foldable
                  (foldl',toList)
 import           Data.Functor.Alt
                  (Alt (..))
 import           Data.Maybe
-                 (maybe, maybeToList)
+                 (maybeToList)
 import           Data.Proxy
                  (Proxy (..))
 import           Data.Sequence
@@ -64,7 +51,7 @@ import           GHC.Generics
 import           Network.HTTP.Media
                  (renderHeader)
 import           Network.HTTP.Types
-                 (hContentType, renderQuery, statusIsSuccessful, urlEncode, Status)
+                 (hContentType, statusIsSuccessful, urlEncode, Status)
 import           Servant.Client.Core
 
 import qualified Network.HTTP.Client         as Client
@@ -146,7 +133,7 @@ hoistClient = hoistClientMonad (Proxy :: Proxy ClientM)
 -- 'Client.Manager' and 'BaseUrl' used for requests in the reader environment.
 newtype ClientM a = ClientM
   { unClientM :: ReaderT ClientEnv (ExceptT ClientError IO) a }
-  deriving ( Functor, Applicative, Monad, MonadIO, Generic
+  deriving newtype ( Functor, Applicative, Monad, MonadIO, Generic
            , MonadReader ClientEnv, MonadError ClientError, MonadThrow
            , MonadCatch, MonadMask)
 

--- a/servant-client/src/Servant/Client/Internal/HttpClient/Streaming.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient/Streaming.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -32,7 +31,8 @@ import           Control.Monad.Codensity
                  (Codensity (..))
 import           Control.Monad.Error.Class
                  (MonadError (..))
-import           Control.Monad.Reader
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
 import           Control.Monad.STM
                  (atomically)
 import           Control.Monad.Trans.Except
@@ -58,6 +58,7 @@ import           Servant.Client.Internal.HttpClient
                  clientResponseToResponse, mkClientEnv, mkFailureResponse,
                  defaultMakeClientRequest)
 import qualified Servant.Types.SourceT              as S
+import Control.Monad.Trans.Class (MonadTrans(..))
 
 
 -- | Generates a set of client functions for an API.
@@ -102,7 +103,7 @@ hoistClient = hoistClientMonad (Proxy :: Proxy ClientM)
 -- 'Client.Manager' and 'BaseUrl' used for requests in the reader environment.
 newtype ClientM a = ClientM
   { unClientM :: ReaderT ClientEnv (ExceptT ClientError (Codensity IO)) a }
-  deriving ( Functor, Applicative, Monad, MonadIO, Generic
+  deriving newtype ( Functor, Applicative, Monad, MonadIO, Generic
            , MonadReader ClientEnv, MonadError ClientError)
 
 instance MonadBase IO ClientM where

--- a/servant-client/test/Servant/WrappedApiSpec.hs
+++ b/servant-client/test/Servant/WrappedApiSpec.hs
@@ -20,6 +20,7 @@ module Servant.WrappedApiSpec (spec) where
 import           Prelude ()
 import           Prelude.Compat
 
+import           Data.Kind (Type)
 import           Control.Exception
                  (bracket)
 import           Control.Monad.Error.Class
@@ -40,7 +41,7 @@ spec = describe "Servant.WrappedApiSpec" $ do
     wrappedApiSpec
 
 data WrappedApi where
-  WrappedApi :: (HasServer (api :: *) '[], Server api ~ Handler a,
+  WrappedApi :: (HasServer (api :: Type) '[], Server api ~ Handler a,
                  HasClient ClientM api, Client ClientM api ~ ClientM ()) =>
     Proxy api -> WrappedApi
 

--- a/servant-docs/example/greet.hs
+++ b/servant-docs/example/greet.hs
@@ -9,8 +9,7 @@ import           Control.Lens
 import           Data.Aeson
 import           Data.Proxy
 import           Data.String.Conversions
-import           Data.Text
-                 (Text)
+import           Data.Text (Text)
 import           GHC.Generics
 import           Servant.API
 import           Servant.Docs

--- a/servant-server/example/greet.hs
+++ b/servant-server/example/greet.hs
@@ -18,7 +18,6 @@ import           Network.Wai.Handler.Warp
 
 import           Servant
 import           Servant.Server.Generic ()
-import           Servant.API.Generic ((:-))
 
 -- * Example
 

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -1,9 +1,10 @@
-cabal-version:       2.2
-name:                servant-server
-version:             0.20
+cabal-version:      3.0
+name:               servant-server
+version:            0.20
+synopsis:
+  A family of combinators for defining webservices APIs and serving them
 
-synopsis:            A family of combinators for defining webservices APIs and serving them
-category:            Servant, Web
+category:           Servant, Web
 description:
   A family of combinators for defining webservices APIs and serving them
   .
@@ -15,25 +16,81 @@ description:
   .
   <https://github.com/haskell-servant/servant/blob/master/servant-server/CHANGELOG.md CHANGELOG>
 
-homepage:            http://docs.servant.dev/
-bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Servant Contributors
-maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
-build-type:          Simple
-tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
+homepage:           http://docs.servant.dev/
+bug-reports:        http://github.com/haskell-servant/servant/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Servant Contributors
+maintainer:         haskell-servant-maintainers@googlegroups.com
+copyright:
+  2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
+
+build-type:         Simple
+tested-with:
+  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.2
 
 extra-source-files:
   CHANGELOG.md
   README.md
 
 source-repository head
-  type: git
+  type:     git
   location: http://github.com/haskell-servant/servant.git
 
+common extensions
+  default-extensions:
+    AllowAmbiguousTypes
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    EmptyDataDecls
+    ExplicitNamespaces
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NoStarIsType
+    OverloadedLabels
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    QuantifiedConstraints
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  default-language:   Haskell2010
+
+common ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -fdicts-strict
+    -Wno-unticked-promoted-constructors -Werror=unused-imports
+    -Wunused-packages
+
 library
+  import:          extensions
+  import:          ghc-options
   exposed-modules:
     Servant
     Servant.Server
@@ -46,96 +103,91 @@ library
     Servant.Server.Internal.DelayedIO
     Servant.Server.Internal.ErrorFormatter
     Servant.Server.Internal.Handler
-    Servant.Server.Internal.RouteResult
     Servant.Server.Internal.Router
+    Servant.Server.Internal.RouteResult
     Servant.Server.Internal.RoutingApplication
     Servant.Server.Internal.ServerError
     Servant.Server.StaticFiles
     Servant.Server.UVerb
 
   -- deprecated
-  exposed-modules:
-    Servant.Utils.StaticFiles
+  exposed-modules: Servant.Utils.StaticFiles
 
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                >= 4.9      && < 4.20
-    , bytestring          >= 0.10.8.1 && < 0.13
-    , constraints         >= 0.2      && < 0.15
-    , containers          >= 0.5.7.1  && < 0.7
-    , mtl                 ^>= 2.2.2   || ^>= 2.3.1
-    , text                >= 1.2.3.0  && < 2.2
-    , transformers        >= 0.5.2.0  && < 0.7
-    , filepath            >= 1.4.1.1  && < 1.5
+    , base          >=4.9      && <4.20
+    , bytestring    >=0.10.8.1 && <0.13
+    , constraints   >=0.2      && <0.15
+    , containers    >=0.5.7.1  && <0.7
+    , filepath      >=1.4.1.1  && <1.5
+    , mtl           ^>=2.2.2   || ^>=2.3.1
+    , text          >=1.2.3.0  && <2.2
+    , transformers  >=0.5.2.0  && <0.7
 
   -- Servant dependencies
   -- strict dependency as we re-export 'servant' things.
   build-depends:
-      servant             >= 0.20     && < 0.21
-    , http-api-data       >= 0.4.1    && < 0.7
+    , http-api-data  >=0.4.1 && <0.7
+    , servant        >=0.20  && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , base64-bytestring   >= 1.0.0.1  && < 1.3
-    , exceptions          >= 0.10.0   && < 0.11
-    , http-media          >= 0.7.1.3  && < 0.9
-    , http-types          >= 0.12.2   && < 0.13
-    , monad-control       >= 1.0.2.3  && < 1.1
-    , network             >= 2.8      && < 3.3
-    , sop-core            >= 0.4.0.0  && < 0.6
-    , resourcet           >= 1.2.2    && < 1.4
-    , tagged              >= 0.8.6    && < 0.9
-    , transformers-base   >= 0.4.5.2  && < 0.5
-    , wai                 >= 3.2.2.1  && < 3.3
-    , wai-app-static      >= 3.1.6.2  && < 3.2
-    , word8               >= 0.1.3    && < 0.2
+    , base64-bytestring  >=1.0.0.1 && <1.3
+    , exceptions         >=0.10.0  && <0.11
+    , http-media         >=0.7.1.3 && <0.9
+    , http-types         >=0.12.2  && <0.13
+    , monad-control      >=1.0.2.3 && <1.1
+    , network            >=2.8     && <3.3
+    , resourcet          >=1.2.2   && <1.4
+    , sop-core           >=0.4.0.0 && <0.6
+    , tagged             >=0.8.6   && <0.9
+    , transformers-base  >=0.4.5.2 && <0.5
+    , wai                >=3.2.2.1 && <3.3
+    , wai-app-static     >=3.1.6.2 && <3.2
+    , word8              >=0.1.3   && <0.2
 
-  hs-source-dirs: src
-  default-language: Haskell2010
-
-  ghc-options: -Wall -Wno-redundant-constraints
+  hs-source-dirs:  src
 
 executable greet
-  main-is: greet.hs
+  import:         extensions
+  import:         ghc-options
+  main-is:        greet.hs
   hs-source-dirs: example
-  ghc-options: -Wall
-  default-language: Haskell2010
   build-depends:
-      base
+    , base
     , base-compat
-    , servant
     , servant-server
-    , wai
     , text
+    , wai
 
   build-depends:
-      aeson               >= 1.4.1.0  && < 3
-    , warp                >= 3.2.25   && < 3.5
+    , aeson  >=1.4.1.0 && <3
+    , warp   >=3.2.25  && <3.5
 
 test-suite spec
-  type: exitcode-stdio-1.0
-  ghc-options: -Wall
-  default-language: Haskell2010
-  hs-source-dirs: test
-  main-is: Spec.hs
+  import:             extensions
+  import:             ghc-options
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Spec.hs
   other-modules:
-      Servant.ArbitraryMonadServerSpec
-      Servant.Server.ErrorSpec
-      Servant.Server.Internal.ContextSpec
-      Servant.Server.Internal.RoutingApplicationSpec
-      Servant.Server.RouterSpec
-      Servant.Server.StaticFilesSpec
-      Servant.Server.StreamingSpec
-      Servant.Server.UsingContextSpec
-      Servant.Server.UsingContextSpec.TestCombinators
-      Servant.HoistSpec
-      Servant.ServerSpec
+    Servant.ArbitraryMonadServerSpec
+    Servant.HoistSpec
+    Servant.Server.ErrorSpec
+    Servant.Server.Internal.ContextSpec
+    Servant.Server.Internal.RoutingApplicationSpec
+    Servant.Server.RouterSpec
+    Servant.Server.StaticFilesSpec
+    Servant.Server.StreamingSpec
+    Servant.Server.UsingContextSpec
+    Servant.Server.UsingContextSpec.TestCombinators
+    Servant.ServerSpec
 
   -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base
+    , base
     , base-compat
     , base64-bytestring
     , bytestring
@@ -150,13 +202,12 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-      aeson                >= 1.4.1.0  && < 3
-    , directory            >= 1.3.0.0  && < 1.4
-    , hspec                >= 2.6.0    && < 2.12
-    , hspec-wai            >= 0.10.1   && < 0.12
-    , should-not-typecheck >= 2.1.0    && < 2.2
-    , temporary            >= 1.3      && < 1.4
-    , wai-extra            >= 3.0.24.3 && < 3.2
+    , aeson                 >=1.4.1.0  && <3
+    , directory             >=1.3.0.0  && <1.4
+    , hspec                 >=2.6.0    && <2.12
+    , hspec-wai             >=0.10.1   && <0.12
+    , should-not-typecheck  >=2.1.0    && <2.2
+    , temporary             >=1.3      && <1.4
+    , wai-extra             >=3.0.24.3 && <3.2
 
-  build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12

--- a/servant-server/src/Servant/Server/Internal.hs
+++ b/servant-server/src/Servant/Server/Internal.hs
@@ -1,23 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveDataTypeable    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 module Servant.Server.Internal
   ( module Servant.Server.Internal

--- a/servant-server/src/Servant/Server/Internal/DelayedIO.hs
+++ b/servant-server/src/Servant/Server/Internal/DelayedIO.hs
@@ -28,7 +28,7 @@ import           Servant.Server.Internal.ServerError
 -- (with the possibility to recover), or fail fatally.
 --
 newtype DelayedIO a = DelayedIO { runDelayedIO' :: ReaderT Request (ResourceT (RouteResultT IO)) a }
-  deriving
+  deriving newtype
     ( Functor, Applicative, Monad
     , MonadIO, MonadReader Request
     , MonadThrow

--- a/servant-server/src/Servant/Server/Internal/Handler.hs
+++ b/servant-server/src/Servant/Server/Internal/Handler.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -26,8 +25,9 @@ import           Servant.Server.Internal.ServerError
                  (ServerError, errBody, err500)
 
 newtype Handler a = Handler { runHandler' :: ExceptT ServerError IO a }
-  deriving
-    ( Functor, Applicative, Monad, MonadIO, Generic
+  deriving stock (Generic)
+  deriving newtype
+    ( Functor, Applicative, Monad, MonadIO
     , MonadError ServerError
     , MonadThrow, MonadCatch, MonadMask
     )

--- a/servant-server/src/Servant/Server/Internal/RouteResult.hs
+++ b/servant-server/src/Servant/Server/Internal/RouteResult.hs
@@ -28,11 +28,11 @@ data RouteResult a =
   deriving (Eq, Show, Read, Functor)
 
 instance Applicative RouteResult where
-    pure = return
+    pure = Route
     (<*>) = ap
 
 instance Monad RouteResult where
-    return = Route
+    return = pure
     Route a     >>= f = f a
     Fail e      >>= _ = Fail e
     FailFatal e >>= _ = FailFatal e
@@ -41,14 +41,14 @@ newtype RouteResultT m a = RouteResultT { runRouteResultT :: m (RouteResult a) }
   deriving (Functor)
 
 instance MonadTrans RouteResultT where
-    lift = RouteResultT . liftM Route
+    lift = RouteResultT . fmap Route
 
 instance (Functor m, Monad m) => Applicative (RouteResultT m) where
-    pure  = return
+    pure = RouteResultT . return . Route
     (<*>) = ap
 
 instance Monad m => Monad (RouteResultT m) where
-    return = RouteResultT . return . Route
+    return = pure
     m >>= k = RouteResultT $ do
         a <- runRouteResultT m
         case a of

--- a/servant-server/test/Servant/Server/StreamingSpec.hs
+++ b/servant-server/test/Servant/Server/StreamingSpec.hs
@@ -81,10 +81,10 @@ spec = do
 executeRequest :: Application -> Request -> IO Response
 executeRequest app request = do
   responseMVar <- newEmptyMVar
-  let respond response = do
+  let respondToRequest response = do
         putMVar responseMVar response
         return ResponseReceived
-  ResponseReceived <- app request respond
+  ResponseReceived <- app request respondToRequest
   takeMVar responseMVar
 
 timeout :: IO a -> IO a

--- a/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
+++ b/servant-server/test/Servant/Server/UsingContextSpec/TestCombinators.hs
@@ -20,6 +20,7 @@ module Servant.Server.UsingContextSpec.TestCombinators where
 import           GHC.TypeLits
 
 import           Servant
+import Data.Kind (Type)
 
 data ExtractFromContext
 
@@ -32,12 +33,12 @@ instance (HasContextEntry context String, HasServer subApi context) =>
   hoistServerWithContext _ pc nt s = hoistServerWithContext (Proxy :: Proxy subApi) pc nt . s
 
   route Proxy context delayed =
-    route subProxy context (fmap inject delayed)
+    route subProxy context (fmap injectContext delayed)
     where
       subProxy :: Proxy subApi
       subProxy = Proxy
 
-      inject f = f (getContextEntry context)
+      injectContext f = f (getContextEntry context)
 
 data InjectIntoContext
 
@@ -58,7 +59,7 @@ instance (HasServer subApi (String ': context)) =>
 
       newContext = ("injected" :: String) :. context
 
-data NamedContextWithBirdface (name :: Symbol) (subContext :: [*])
+data NamedContextWithBirdface (name :: Symbol) (subContext :: [Type])
 
 instance (HasContextEntry context (NamedContext name subContext), HasServer subApi subContext) =>
   HasServer (NamedContextWithBirdface name subContext :> subApi) context where

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -685,7 +685,7 @@ type RawMApi = "foo" :> RawM
 rawMApi :: Proxy RawMApi
 rawMApi = Proxy
 
-rawMServer :: (Monad m, MonadIO m, Show a) => (Request -> m a) -> ServerT RawMApi m
+rawMServer :: (MonadIO m, Show a) => (Request -> m a) -> ServerT RawMApi m
 rawMServer f req resp = liftIO . resp . responseLBS ok200 [] . BSL8.pack . show =<< f req
 
 rawMSpec :: Spec

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -1,9 +1,8 @@
-cabal-version:       2.2
-name:                servant
-version:             0.20.1
-
-synopsis:            A family of combinators for defining webservices APIs
-category:            Servant, Web
+cabal-version:      3.0
+name:               servant
+version:            0.20.1
+synopsis:           A family of combinators for defining webservices APIs
+category:           Servant, Web
 description:
   A family of combinators for defining webservices APIs and serving them
   .
@@ -11,24 +10,75 @@ description:
   .
   <https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md CHANGELOG>
 
-homepage:            http://docs.servant.dev/
-bug-reports:         http://github.com/haskell-servant/servant/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Servant Contributors
-maintainer:          haskell-servant-maintainers@googlegroups.com
-copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
-build-type:          Simple
-tested-with: GHC ==8.10.7, GHC ==9.0.2, GHC ==9.2.8, GHC ==9.4.8, GHC ==9.6.4, GHC ==9.8.2
+homepage:           http://docs.servant.dev/
+bug-reports:        http://github.com/haskell-servant/servant/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Servant Contributors
+maintainer:         haskell-servant-maintainers@googlegroups.com
+copyright:
+  2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 
-extra-source-files:
-  CHANGELOG.md
+build-type:         Simple
+tested-with:
+  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.2
+
+extra-source-files: CHANGELOG.md
 
 source-repository head
-  type: git
+  type:     git
   location: http://github.com/haskell-servant/servant.git
 
+common extensions
+  default-extensions:
+    AllowAmbiguousTypes
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    ExplicitNamespaces
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NoStarIsType
+    OverloadedLabels
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  default-language:   Haskell2010
+
+common ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -fdicts-strict
+    -Wno-unticked-promoted-constructors -Werror=unused-imports
+    -Wunused-packages
+
 library
+  import:          extensions
+  import:          ghc-options
   exposed-modules:
     Servant.API
     Servant.API.Alternative
@@ -64,96 +114,67 @@ library
     Servant.API.WithResource
 
   -- Types
-  exposed-modules:
-    Servant.Types.SourceT
+  exposed-modules: Servant.Types.SourceT
 
   -- Test stuff
-  exposed-modules:
-    Servant.Test.ComprehensiveAPI
+  exposed-modules: Servant.Test.ComprehensiveAPI
 
   -- Safe links
-  exposed-modules:
-    Servant.Links
+  exposed-modules: Servant.Links
 
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base                   >= 4.9      && < 4.20
-    , bytestring             >= 0.10.8.1 && < 0.13
-    , constraints            >= 0.2
-    , containers             >= 0.6      && < 0.7
-    , mtl                    ^>= 2.2.2   || ^>= 2.3.1
-    , sop-core               >= 0.4.0.0  && < 0.6
-    , transformers           >= 0.5.2.0  && < 0.7
-    , text                   >= 1.2.3.0  && < 2.2
-
+    , base          >=4.9      && <4.20
+    , bytestring    >=0.10.8.1 && <0.13
+    , constraints   >=0.2
+    , containers    >=0.6      && <0.7
+    , mtl           ^>=2.2.2   || ^>=2.3.1
+    , sop-core      >=0.4.0.0  && <0.6
+    , text          >=1.2.3.0  && <2.2
+    , transformers  >=0.5.2.0  && <0.7
 
   -- We depend (heavily) on the API of these packages:
   -- i.e. re-export, or allow using without direct dependency
   build-depends:
-      http-api-data          >= 0.4.1    && < 0.7
-    , singleton-bool         >= 0.1.4    && < 0.2
+    , http-api-data   >=0.4.1 && <0.7
+    , singleton-bool  >=0.1.4 && <0.2
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                  >= 1.4.1.0  && < 2.3
-    , attoparsec             >= 0.13.2.2 && < 0.15
-    , bifunctors             >= 5.5.3    && < 5.7
-    , case-insensitive       >= 1.2.0.11 && < 1.3
-    , deepseq                >= 1.4.2.0  && < 1.6
-    , http-media             >= 0.7.1.3  && < 0.9
-    , http-types             >= 0.12.2   && < 0.13
-    , mmorph                 >= 1.1.2    && < 1.3
-    , network-uri            >= 2.6.1.0  && < 2.7
-    , QuickCheck             >= 2.12.6.1 && < 2.15
-    , vault                  >= 0.3.1.2  && < 0.4
+    , aeson             >=1.4.1.0  && <2.3
+    , attoparsec        >=0.13.2.2 && <0.15
+    , bifunctors        >=5.5.3    && <5.7
+    , case-insensitive  >=1.2.0.11 && <1.3
+    , deepseq           >=1.4.2.0  && <1.6
+    , http-media        >=0.7.1.3  && <0.9
+    , http-types        >=0.12.2   && <0.13
+    , mmorph            >=1.1.2    && <1.3
+    , network-uri       >=2.6.1.0  && <2.7
+    , QuickCheck        >=2.12.6.1 && <2.15
+    , vault             >=0.3.1.2  && <0.4
 
-  hs-source-dirs: src
-  default-language: Haskell2010
-  other-extensions: AllowAmbiguousTypes
-                  , CPP
-                  , ConstraintKinds
-                  , DataKinds
-                  , DeriveDataTypeable
-                  , DeriveGeneric
-                  , ExplicitNamespaces
-                  , FlexibleContexts
-                  , FlexibleInstances
-                  , FunctionalDependencies
-                  , GADTs
-                  , KindSignatures
-                  , MultiParamTypeClasses
-                  , OverloadedStrings
-                  , PolyKinds
-                  , RankNTypes
-                  , ScopedTypeVariables
-                  , TupleSections
-                  , TypeFamilies
-                  , TypeOperators
-                  , UndecidableInstances
-
-  ghc-options: -Wall -Wno-redundant-constraints
+  hs-source-dirs:  src
 
 test-suite spec
-  type: exitcode-stdio-1.0
-  ghc-options: -Wall
-  default-language: Haskell2010
-  hs-source-dirs: test
-  main-is: Spec.hs
+  import:             extensions
+  import:             ghc-options
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Spec.hs
   other-modules:
-      Servant.API.ContentTypesSpec
-      Servant.API.ResponseHeadersSpec
-      Servant.API.StreamSpec
-      Servant.LinksSpec
+    Servant.API.ContentTypesSpec
+    Servant.API.ResponseHeadersSpec
+    Servant.API.StreamSpec
+    Servant.LinksSpec
 
   -- Dependencies inherited from the library. No need to specify bounds.
   build-depends:
-      base
-    , base-compat
     , aeson
+    , base
     , bytestring
     , http-media
     , mtl
@@ -162,9 +183,8 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-      hspec                >= 2.6.0    && < 2.12
-    , QuickCheck           >= 2.12.6.1 && < 2.15
-    , quickcheck-instances >= 0.3.19   && < 0.4
+    , hspec                 >=2.6.0    && <2.12
+    , QuickCheck            >=2.12.6.1 && <2.15
+    , quickcheck-instances  >=0.3.19   && <0.4
 
-  build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12

--- a/servant/src/Servant/API/Alternative.hs
+++ b/servant/src/Servant/API/Alternative.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveTraversable  #-}
-{-# LANGUAGE TypeOperators      #-}
+{-# LANGUAGE CPP      #-}
 {-# OPTIONS_HADDOCK not-home    #-}
 module Servant.API.Alternative ((:<|>)(..)) where
 
-import           Control.Applicative (liftA2)
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
 import           Data.Biapplicative
                  (Biapplicative (..))
 import           Data.Bifoldable

--- a/servant/src/Servant/API/Generic.hs
+++ b/servant/src/Servant/API/Generic.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE TypeOperators    #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 -- | Define servant servers from record types. Generics for the win.
 --
 -- The usage is simple, if you only need a collection of routes.  First you

--- a/servant/src/Servant/API/Modifiers.hs
+++ b/servant/src/Servant/API/Modifiers.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 module Servant.API.Modifiers (
     -- * Required / optional argument
     Required, Optional,

--- a/servant/src/Servant/API/ResponseHeaders.hs
+++ b/servant/src/Servant/API/ResponseHeaders.hs
@@ -1,16 +1,5 @@
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DeriveDataTypeable     #-}
-{-# LANGUAGE DeriveFunctor          #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE PolyKinds              #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE TypeOperators          #-}
-{-# LANGUAGE UndecidableInstances   #-}
 {-# OPTIONS_HADDOCK not-home        #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | This module provides facilities for adding headers to a response.
 --

--- a/servant/src/Servant/Types/SourceT.hs
+++ b/servant/src/Servant/Types/SourceT.hs
@@ -1,9 +1,4 @@
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
 module Servant.Types.SourceT where
 
 import           Control.Monad.Except
@@ -24,6 +19,7 @@ import           System.IO
 import qualified Test.QuickCheck            as QC
 
 -- $setup
+-- >>> :set -XNoOverloadedStrings
 -- >>> import Data.String (fromString)
 -- >>> import Control.Monad.Except (runExcept)
 -- >>> import Data.Foldable (toList)
@@ -325,8 +321,8 @@ fromActionStep stop action = loop where
 -- | Read file.
 --
 -- >>> foreach fail BS.putStr (readFile "servant.cabal")
--- cabal-version:       2.2
--- name:                servant
+-- cabal-version:      3.0
+-- name:               servant
 -- ...
 --
 readFile :: FilePath -> SourceT IO BS.ByteString

--- a/servant/test/Servant/API/ContentTypesSpec.hs
+++ b/servant/test/Servant/API/ContentTypesSpec.hs
@@ -31,6 +31,7 @@ import           Control.Exception
                  (evaluate)
 import           GHC.Generics
 import           Test.Hspec
+import           Network.HTTP.Media () -- for CPP
 import           Test.QuickCheck
 import           "quickcheck-instances" Test.QuickCheck.Instances ()
 import           Text.Read


### PR DESCRIPTION
This PR adds more compilation flags by default to prevent anti-patterns like non-canonical instances, unrestricted imports of Data.List, redundant imports, etc.