### PR TITLE
Allow base-compat-0.14

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -117,7 +117,7 @@ library
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
     , aeson              >=1.4.1.0 && <3
-    , base-compat        >=0.10.5  && <0.14
+    , base-compat        >=0.10.5  && <0.15
     , base64-bytestring  >=1.0.0.1 && <1.3
     , exceptions         >=0.10.0  && <0.11
     , free               >=5.1     && <5.3

--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 module Servant.Client.Core.HasClient (
     clientIn,
@@ -25,8 +26,10 @@ import           Data.Foldable
                  (toList)
 import           Data.Kind
                  (Type)
+#if !MIN_VERSION_base_compat(0,14,0)
 import           Data.List
                  (foldl')
+#endif
 import           Data.Sequence
                  (fromList)
 import qualified Data.Text                       as T

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -112,7 +112,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , base-compat          >=0.10.5   && <0.14
+    , base-compat          >=0.10.5   && <0.15
     , exceptions           >=0.10.0   && <0.11
     , http-client          >=0.5.13.1 && <0.8
     , http-media           >=0.7.1.3  && <0.9

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -33,8 +33,10 @@ import qualified Data.ByteString             as BS
 import           Data.ByteString.Builder
                  (toLazyByteString)
 import qualified Data.ByteString.Lazy        as BSL
-import           Data.Foldable
-                 (foldl',toList)
+#if !MIN_VERSION_base_compat(0,14,0)
+import           Data.Foldable (foldl')
+#endif
+import           Data.Foldable (toList)
 import           Data.Functor.Alt
                  (Alt (..))
 import           Data.Maybe

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -54,7 +54,7 @@ library
   build-depends:
       aeson                >= 1.4.1.0  && < 3
     , aeson-pretty         >= 0.8.5    && < 0.9
-    , base-compat          >= 0.10.5   && < 0.14
+    , base-compat          >= 0.10.5   && < 0.15
     , case-insensitive     >= 1.2.0.11 && < 1.3
     , hashable             >= 1.2.7.0  && < 1.5
     , http-media           >= 0.7.1.3  && < 0.9

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -51,7 +51,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat >= 0.10.5  && < 0.14
+      base-compat >= 0.10.5  && < 0.15
     , lens        >= 4.17    && < 5.3
     , http-types  >= 0.12.2  && < 0.13
 

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -60,7 +60,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat           >= 0.10.5   && < 0.14
+      base-compat           >= 0.10.5   && < 0.15
     , case-insensitive
     , http-streams          >= 0.8.6.1  && < 0.9
     , http-media            >= 0.7.1.3  && < 0.9

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       aeson                  >=0.8    && <2.3
     , base                   >=4.9    && <4.20
-    , base-compat-batteries  >=0.10.1 && <0.14
+    , base-compat-batteries  >=0.10.1 && <0.15
     , bytestring             >=0.10   && <0.13
     , case-insensitive       >=1.2    && <1.3
     , clock                  >=0.7    && <0.9

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -72,7 +72,7 @@ library
   build-depends:       aeson                     >=1.4.2.0 && <3
                      , aeson-pretty              >=0.8.7    && <0.9
                      , base                      >=4.9.1.0  && <5
-                     , base-compat               >=0.10.5   && <0.14
+                     , base-compat               >=0.10.5   && <0.15
                      , bytestring                >=0.10.8.1 && <0.13
                      , http-media                >=0.7.1.3  && <0.9
                      , insert-ordered-containers >=0.2.1.0  && <0.3


### PR DESCRIPTION
Tested using

    cabal build all -c 'base-compat>=0.14'  --allow-newer=servant-openapi3:base-compat,openapi3:base-compat-batteries,swagger2:base-compat-batteries,servant-js:base-compat
