### PR TITLE
Prepare servant-quickcheck-0.1.0.0

### DIFF
--- a/servant-client-core/src/Servant/Client/Core/HasClient.hs
+++ b/servant-client-core/src/Servant/Client/Core/HasClient.hs
@@ -26,10 +26,7 @@ import           Data.Foldable
                  (toList)
 import           Data.Kind
                  (Type)
-#if !MIN_VERSION_base_compat(0,14,0)
-import           Data.List
-                 (foldl')
-#endif
+import qualified Data.List as List
 import           Data.Sequence
                  (fromList)
 import qualified Data.Text                       as T
@@ -232,7 +229,7 @@ instance (ToHttpApiData a, HasClient m sublayout)
 
   clientWithRoute pm Proxy req vals =
     clientWithRoute pm (Proxy :: Proxy sublayout)
-                    (foldl' (flip appendToPath) req ps)
+                    (List.foldl' (flip appendToPath) req ps)
 
     where ps = map toEncodedUrlPiece vals
 
@@ -603,7 +600,7 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient m api)
 
   clientWithRoute pm Proxy req paramlist =
     clientWithRoute pm (Proxy :: Proxy api)
-                    (foldl' (\ req' -> maybe req' (flip (appendToQueryString pname) req' . Just))
+                    (List.foldl' (\ req' -> maybe req' (flip (appendToQueryString pname) req' . Just))
                             req
                             paramlist'
                     )
@@ -672,7 +669,7 @@ instance (KnownSymbol sym, ToDeepQuery a, HasClient m api)
 
   clientWithRoute pm Proxy req deepObject =
     let params = toDeepQuery deepObject
-        withParams = foldl' addDeepParam req params
+        withParams = List.foldl' addDeepParam req params
         addDeepParam r' kv =
           let (k, textV) = generateDeepParam paramname kv
            in appendToQueryString k (encodeUtf8 <$> textV) r'

--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -33,10 +33,9 @@ import qualified Data.ByteString             as BS
 import           Data.ByteString.Builder
                  (toLazyByteString)
 import qualified Data.ByteString.Lazy        as BSL
-#if !MIN_VERSION_base_compat(0,14,0)
-import           Data.Foldable (foldl')
-#endif
-import           Data.Foldable (toList)
+import qualified Data.List as List
+import           Data.Foldable
+                 (toList)
 import           Data.Functor.Alt
                  (Alt (..))
 import           Data.Maybe
@@ -294,7 +293,7 @@ defaultMakeClientRequest burl r = return Client.defaultRequest
 
     -- Query string builder which does not do any encoding
     buildQueryString [] = mempty
-    buildQueryString qps = "?" <> foldl' addQueryParam mempty qps
+    buildQueryString qps = "?" <> List.foldl' addQueryParam mempty qps
 
     addQueryParam qs (k, v) =
           qs <> (if BS.null qs then mempty else "&") <> urlEncode True k <> foldMap ("=" <>) v

--- a/servant-quickcheck/LICENSE
+++ b/servant-quickcheck/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2024 Julian K. Arni
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -1,16 +1,16 @@
+cabal-version:      3.4
 name:               servant-quickcheck
 version:            0.1.0.0
 synopsis:           QuickCheck entire APIs
 description:
   This packages provides QuickCheck properties that are tested across an entire API.
 
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Julian K. Arni
 maintainer:         haskell-servant-maintainers@googlegroups.com
 category:           Web
 build-type:         Simple
-cabal-version:      >=1.10
 extra-source-files: CHANGELOG.yaml
 tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.1
 

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -49,7 +49,7 @@ library
     , mtl                    >=2.1    && <2.4
     , pretty                 >=1.1    && <1.2
     , process                >=1.2    && <1.7
-    , QuickCheck             >=2.7    && <2.15
+    , QuickCheck             >=2.7    && <2.16
     , servant                >=0.18.2 && <0.21
     , servant-client         >=0.17   && <0.21
     , servant-server         >=0.17   && <0.21


### PR DESCRIPTION
This PR prepares the release of servant-quickcheck-0.1.0.0:

* Add missing LICENSE file to servant-quickcheck

closes #1757 

blocks https://github.com/commercialhaskell/stackage/issues/7391