### PR TITLE
Allow QuickCheck-2.15

### DIFF
--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -63,7 +63,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       hspec                >= 2.5.5    && < 2.12
-    , QuickCheck           >= 2.11.3   && < 2.15
+    , QuickCheck           >= 2.11.3   && < 2.16
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.10.6.0 && < 0.13
     , http-client          >= 0.5.13.1 && < 0.8

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -51,7 +51,7 @@ test-suite doctests
     base,
     servant-auth-docs,
     doctest             >= 0.16   && < 0.23,
-    QuickCheck          >= 2.11.3 && < 2.15,
+    QuickCheck          >= 2.11.3 && < 2.16,
     template-haskell
   ghc-options:         -Wall -threaded
   hs-source-dirs:      test
@@ -79,6 +79,6 @@ test-suite spec
   build-depends:
       servant-auth-docs
     , hspec             >= 2.5.5  && < 2.12
-    , QuickCheck        >= 2.11.3 && < 2.15
+    , QuickCheck        >= 2.11.3 && < 2.16
 
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -124,7 +124,7 @@ test-suite spec
   build-depends:
       servant-auth-server
     , hspec       >= 2.5.5     && < 2.12
-    , QuickCheck  >= 2.11.3    && < 2.15
+    , QuickCheck  >= 2.11.3    && < 2.16
     , http-client >= 0.5.13.1  && < 0.8
     , lens-aeson  >= 1.0.2     && < 1.3
     , warp        >= 3.2.25    && < 3.5

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -64,7 +64,7 @@ test-suite spec
   build-depends:
       servant-auth-swagger
     , hspec      >= 2.5.5  && < 2.12
-    , QuickCheck >= 2.11.3 && < 2.15
+    , QuickCheck >= 2.11.3 && < 2.16
   other-modules:
       Servant.Auth.SwaggerSpec
   default-language: Haskell2010

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -149,6 +149,6 @@ test-suite spec
   build-depends:
     , deepseq     >=1.4.2.0  && <1.6
     , hspec       >=2.6.0    && <2.12
-    , QuickCheck  >=2.12.6.1 && <2.15
+    , QuickCheck  >=2.12.6.1 && <2.16
 
   build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -174,7 +174,7 @@ test-suite spec
     , hspec           >=2.6.0    && <2.12
     , HUnit           >=1.6.0.0  && <1.7
     , network         >=2.8.0.0  && <3.3
-    , QuickCheck      >=2.12.6.1 && <2.15
+    , QuickCheck      >=2.12.6.1 && <2.16
     , servant         >=0.20     && <0.21
     , servant-server  >=0.20     && <0.21
 

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -115,7 +115,7 @@ test-suite spec
     , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.3
-    , QuickCheck        >= 2.12.6.1 && < 2.15
+    , QuickCheck        >= 2.12.6.1 && < 2.16
     , servant-server    >= 0.20 && < 0.21
     , servant           >= 0.20 && < 0.21
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -154,7 +154,7 @@ library
     , http-types        >=0.12.2   && <0.13
     , mmorph            >=1.1.2    && <1.3
     , network-uri       >=2.6.1.0  && <2.7
-    , QuickCheck        >=2.12.6.1 && <2.15
+    , QuickCheck        >=2.12.6.1 && <2.16
     , vault             >=0.3.1.2  && <0.4
 
   hs-source-dirs:  src
@@ -184,7 +184,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
     , hspec                 >=2.6.0    && <2.12
-    , QuickCheck            >=2.12.6.1 && <2.15
+    , QuickCheck            >=2.12.6.1 && <2.16
     , quickcheck-instances  >=0.3.19   && <0.4
 
   build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12


### PR DESCRIPTION
Tested using

    cabal build all -w ghc-9.8.2 -c 'QuickCheck>=2.15' --allow-newer=openapi3:QuickCheck,swagger2:QuickCheck
