### PR TITLE
Remove allow-newer for file-embed-lzma

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,11 +74,6 @@ allow-newer: postgresql-simple:base
 allow-newer: postgresql-simple:template-haskell
 allow-newer: postgresql-simple:containers
 allow-newer: postgresql-libpq:base
-allow-newer: servant-swagger-ui:base
-allow-newer: servant-swagger-ui-core:base
-allow-newer: file-embed-lzma:base
-allow-newer: file-embed-lzma:template-haskell
-allow-newer: file-embed-lzma:filepath
 allow-newer: servant-openapi3:base
 allow-newer: openapi3:base
 allow-newer: openapi3:template-haskell


### PR DESCRIPTION
The package that wasn't compatible with the newest release was servant-swagger-ui{,-core}, and they were just updated on Hackage.