### PR TITLE
Allow hashable-1.5, with allow-newers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -105,3 +105,5 @@ allow-newer: openapi3:hashable
 allow-newer: http-api-data:hashable
 allow-newer: swagger2:hashable
 allow-newer: quickcheck-instances:hashable
+allow-newer: postgresql-libpq:hashable
+allow-newer: postgresql-simple:hashable

--- a/cabal.project
+++ b/cabal.project
@@ -70,6 +70,7 @@ if(impl(ghc >= 9.6.1))
   package servant-server
     ghc-options: -fprint-redundant-promotion-ticks
 
+-- This block is for GHC 9.10.1.
 allow-newer: postgresql-simple:base
 allow-newer: postgresql-simple:template-haskell
 allow-newer: postgresql-simple:containers
@@ -86,3 +87,21 @@ allow-newer: servant-js:base
 allow-newer: servant-js:lens
 allow-newer: lucid:base
 allow-newer: Cabal
+
+-- This block is for hashable-1.5
+allow-newer: vault:hashable
+allow-newer: unordered-containers:hashable
+allow-newer: async:hashable
+allow-newer: psqueues:hashable
+allow-newer: aeson:hashable
+allow-newer: witherable:hashable
+allow-newer: these:hashable
+allow-newer: strict:hashable
+allow-newer: semialign:hashable
+allow-newer: lens:hashable
+allow-newer: insert-ordered-containers:hashable
+allow-newer: optics-extra:hashable
+allow-newer: openapi3:hashable
+allow-newer: http-api-data:hashable
+allow-newer: swagger2:hashable
+allow-newer: quickcheck-instances:hashable

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -56,7 +56,7 @@ library
     , aeson-pretty         >= 0.8.5    && < 0.9
     , base-compat          >= 0.10.5   && < 0.15
     , case-insensitive     >= 1.2.0.11 && < 1.3
-    , hashable             >= 1.2.7.0  && < 1.5
+    , hashable             >= 1.2.7.0  && < 1.6
     , http-media           >= 0.7.1.3  && < 0.9
     , http-types           >= 0.12.2   && < 0.13
     , lens                 >= 4.17     && < 5.4
@@ -102,7 +102,7 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-      tasty         >= 1.1.0.4  && < 1.5,
+      tasty         >= 1.1.0.4  && < 1.6,
       tasty-golden  >= 2.3.2    && < 2.4,
       tasty-hunit   >= 0.10.0.1 && < 0.11,
       transformers  >= 0.5.2.0  && < 0.7


### PR DESCRIPTION
Tested using

    cabal test servant-docs -w ghc-9.8.2 -c 'tasty>=1.5' -c 'hashable>=1.5'
