### PR TITLE
Remove strict data from servant{,-server}'s cabal files

### DIFF
--- a/changelog.d/config
+++ b/changelog.d/config
@@ -1,0 +1,11 @@
+-- Possible fields for changelog entry
+-- synopsis: Brief description of the change. Often just the PR title.
+-- description:	Longer description, with a list of sub-changes. Not needed for small/atomic changes.
+-- packages: Packages affected by the change. Omit if it's an overarching or non-package change.
+-- prs: Space-separated hash-prefixed pull request numbers containing the change (usually just one).
+-- issues: Space-separated hash-prefixed issue numbers that the change fixes/closes/affects.
+-- significance: Set to significant if the change is significant, that is if it warrants being put near the top of the changelog.
+organization: haskell-servant
+repository: servant
+required-fields: synopsis description prs
+packages: servant servant-server servant-client-core servant-client servant-quickcheck servant

--- a/changelog.d/issue-1780
+++ b/changelog.d/issue-1780
@@ -1,0 +1,10 @@
+synopsis: Remove -XStrictData from servant{,-server}'s cabal files
+packages: servant servant-server
+prs: #1781
+issues: #1780
+significance: significant
+description: {
+  The addition of -XStrictData to servant.cabal and servant-server.cabal reduced the laziness
+  of routing, which would trigger unimplemented endpoints using `error` or `undefined`,
+  despite the fact that these endpoints themselves were not queried.
+}

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -70,7 +70,6 @@ common extensions
     RankNTypes
     RecordWildCards
     ScopedTypeVariables
-    StrictData
     TupleSections
     TypeApplications
     TypeFamilies

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -58,7 +58,6 @@ common extensions
     RankNTypes
     RecordWildCards
     ScopedTypeVariables
-    StrictData
     TupleSections
     TypeApplications
     TypeFamilies


### PR DESCRIPTION
This has triggered a regression in 0.20.2, and is related to #1780