### PR TITLE
Make defaultMakeClientRequest not depend on IO

### DIFF
--- a/servant-client/src/Servant/Client/Internal/HttpClient.hs
+++ b/servant-client/src/Servant/Client/Internal/HttpClient.hs
@@ -232,8 +232,15 @@ clientResponseToResponse f r = Response
 -- | Create a @http-client@ 'Client.Request' from a @servant@ 'Request'
 --    The 'Client.host', 'Client.path' and 'Client.port' fields are extracted from the 'BaseUrl'
 --    otherwise the body, headers and query string are derived from the @servant@ 'Request'
-defaultMakeClientRequest :: BaseUrl -> Request -> IO Client.Request
-defaultMakeClientRequest burl r = return Client.defaultRequest
+--
+-- Note that @Applicative@ dependency is not really needed for this function
+-- implementation. But in the past the return type was wrapped into @IO@
+-- without a necessity breaking the API backward-compatibility. In order to not
+-- break the API again it was changed to @Applicative@ so that you can just use
+-- something like @Data.Functor.Identity@ without a need to involve @IO@ but
+-- still keeping it compatible with the code written when it was typed as @IO@.
+defaultMakeClientRequest :: Applicative f => BaseUrl -> Request -> f Client.Request
+defaultMakeClientRequest burl r = pure Client.defaultRequest
     { Client.method = requestMethod r
     , Client.host = fromString $ baseUrlHost burl
     , Client.port = baseUrlPort burl


### PR DESCRIPTION
The `IO` wrap for the return type of this function was never necessary. Inside the function there’s only `return` call that wraps a _pure_ value into `IO`. There is nothing else that would be related to `IO`. The `IO` wrap was introduced in 9df16f9f1a81b0b9ae605820a4348627b102c75d

In order to not break the API again the wrap was preserved but this change makes it to depend on any `Applicative` instead of `IO`. So it still works in `IO`/`MonadIO` context but allows to use something like `Data.Functor.Identity` to work with _pure_ values.

See for more context:
https://github.com/haskell-servant/servant/pull/1595