### PR TITLE
fix: update nix shell to work with current bounds, add flake

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -70,6 +70,9 @@ if(impl(ghc >= 9.6.1))
   package servant-server
     ghc-options: -fprint-redundant-promotion-ticks
 
+  package lzma
+    flags: -pkgconfig
+
 -- This block is for GHC 9.10.1.
 allow-newer: servant-openapi3:base
 allow-newer: openapi3:base

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ with (builtins.fromJSON (builtins.readFile ./nix/nixpkgs.json));
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
   }) {}
-, compiler ? "ghc883"
+, compiler ? "ghc92"
 }:
 let
   overrides = self: super: {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728940272,
+        "narHash": "sha256-zVl25LPDCt1l34AS7Ba4MPTxHQ8tkFL2hxVGEntmngI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8eec6bbcf05c919b19ce8dfb3f96cc4585d30cce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Servant development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        mkDevShell = { compiler ? "ghc92", tutorial ? false }:
+          let
+            ghc = pkgs.haskell.packages.${compiler}.ghcWithPackages (_: []);
+            docstuffs = pkgs.python3.withPackages (ps: with ps; [ recommonmark sphinx sphinx_rtd_theme ]);
+          in
+          pkgs.mkShell {
+            buildInputs = with pkgs; [
+              ghc
+              zlib
+              python3
+              wget
+              cabal-install
+              postgresql
+              openssl
+              stack
+              haskellPackages.hspec-discover
+            ] ++ (if tutorial then [docstuffs postgresql] else []);
+
+            shellHook = ''
+              eval $(grep export ${ghc}/bin/ghc)
+              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"${pkgs.zlib}/lib";
+            '';
+          };
+      in
+      {
+        devShells = {
+          default = mkDevShell {};
+          tutorial = mkDevShell { tutorial = true; };
+        };
+      }
+    );
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -30,6 +30,14 @@ To check which which ghc compiler options are available:
 $ nix-env -f nix/nixpkgs.nix -qaP -A haskell.compiler
 ```
 
+If you prefer to use flakes, the `flake.nix` file provides an
+equivalent default devShell to `shell.nix`. In addition, the
+tutorial is provided as a separate flake output:
+
+```sh
+$ nix develop .#tutorial
+```
+
 ### Cabal users
 
 GHC version can be chosen via the nix-shell parameter

--- a/nix/README.md
+++ b/nix/README.md
@@ -22,11 +22,13 @@ a particular ghc version, e.g:
 $ nix-shell nix/shell.nix --argstr compiler ghcHEAD
 ```
 
-**Possible GHC versions**
--   `ghc865Binary`
--   `ghc884`
--   `ghc8104` - default
--   `ghc901`
+The default is `ghc92`.
+
+To check which which ghc compiler options are available:
+
+```sh
+$ nix-env -f nix/nixpkgs.nix -qaP -A haskell.compiler
+```
 
 ### Cabal users
 

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev" : "05f0934825c2a0750d4888c4735f9420c906b388",
-  "sha256" : "1g8c2w0661qn89ajp44znmwfmghbbiygvdzq0rzlvlpdiz28v6gy"
+  "rev" : "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+  "sha256" : "1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx"
 }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.05.tar.gz";
-  sha256 = "sha256:1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
+  sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
 }) {}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,8 +1,8 @@
-{ compiler ? "ghc8104"
+{ compiler ? "ghc92"
 , tutorial ? false
 , pkgs ? import ./nixpkgs.nix
 }:
-  
+
   with pkgs;
 
   let


### PR DESCRIPTION
The provided `shell.nix` had an earlier default GHC than the minimum `base` package required to build `servant`. I've updated to use `ghc92` and added a flake.