### PR TITLE
Fix typo in Content-Type docs

### DIFF
--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -24,7 +24,7 @@
 -- >>> type MyEndpoint = ReqBody '[JSON, PlainText] Book :> Put '[JSON, PlainText] Book
 --
 -- Meaning the endpoint accepts requests of Content-Type @application/json@
--- or @text/plain;charset-utf8@, and returns data in either one of those
+-- or @text/plain;charset=utf8@, and returns data in either one of those
 -- formats (depending on the @Accept@ header).
 --
 -- If you would like to support Content-Types beyond those provided here,


### PR DESCRIPTION
It seems that the Content-Type header for `Plaintext` should be `text/plain;charset=utf8` and not `text/plain;charset-utf8`, as I'm getting `415 Unsupported Media Type` for the former.