### PR TITLE
Use data-default instead of data-default-class

### DIFF
--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -38,7 +38,7 @@ library
     , bytestring              >= 0.11 && < 0.13
     , case-insensitive        >= 1.2.0.11 && < 1.3
     , cookie                  >= 0.4.4    && < 0.6
-    , data-default-class      >= 0.1.2.0  && < 0.3
+    , data-default            >= 0.2      && < 0.9
     , entropy                 >= 0.4.1.3  && < 0.5
     , http-types              >= 0.12.2   && < 0.13
     , jose                    >= 0.10     && < 0.12

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -38,7 +38,7 @@ library
     , bytestring              >= 0.11 && < 0.13
     , case-insensitive        >= 1.2.0.11 && < 1.3
     , cookie                  >= 0.4.4    && < 0.6
-    , data-default-class      >= 0.1.2.0  && < 0.2
+    , data-default-class      >= 0.1.2.0  && < 0.3
     , entropy                 >= 0.4.1.3  && < 0.5
     , http-types              >= 0.12.2   && < 0.13
     , jose                    >= 0.10     && < 0.12

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server.hs
@@ -141,7 +141,7 @@ module Servant.Auth.Server
 
 import Prelude hiding                           (readFile, writeFile)
 import Data.ByteString                          (ByteString, writeFile, readFile)
-import Data.Default.Class                       (Default (def))
+import Data.Default                             (Default (def))
 import Servant.Auth
 import Servant.Auth.JWT
 import Servant.Auth.Server.Internal             ()

--- a/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -6,7 +6,7 @@ module Servant.Auth.Server.Internal.ConfigTypes
 import           Crypto.JOSE        as Jose
 import           Crypto.JWT         as Jose
 import qualified Data.ByteString    as BS
-import           Data.Default.Class
+import           Data.Default
 import           Data.Time
 import           GHC.Generics       (Generic)
 import           Servant.API        (IsSecure(..))

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -41,7 +41,6 @@ library
     , bytestring             >=0.11   && <0.13
     , case-insensitive       >=1.2    && <1.3
     , clock                  >=0.7    && <0.9
-    , data-default-class     >=0.0    && <0.3
     , hspec                  >=2.5.6  && <2.12
     , http-client            >=0.7.0  && <0.8
     , http-media             >=0.6    && <0.9

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -41,7 +41,7 @@ library
     , bytestring             >=0.11   && <0.13
     , case-insensitive       >=1.2    && <1.3
     , clock                  >=0.7    && <0.9
-    , data-default-class     >=0.0    && <0.2
+    , data-default-class     >=0.0    && <0.3
     , hspec                  >=2.5.6  && <2.12
     , http-client            >=0.7.0  && <0.8
     , http-media             >=0.6    && <0.9


### PR DESCRIPTION
This is a simple version bump to make `servant-auth-server` compatible with `data-default-class 0.2.0.0`.

I noticed that both `data-default` and `data-default-class` are used in this repo. I wonder if there is plan to move to `data-default` for all servant packages, like many other packages on Hackage? For example [`tls`](https://hackage.haskell.org/package/tls-2.1.5/changelog) and [`crypton-connection`](https://hackage.haskell.org/package/crypton-connection-0.4.3/changelog) have recently moved to `data-default`.

I'm happy to update the PR to use `data-default` instead if that's desired.