### PR TITLE
Bump servant-{client,client-core,server} bounds to forbid 0.20.2.0

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -113,7 +113,7 @@ library
     , text              >=1.2.3.0  && <2.2
 
   -- Servant dependencies
-  build-depends:   servant >=0.20.2
+  build-depends:   servant >=0.20.3
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -105,8 +105,8 @@ library
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.
   build-depends:
-    , servant              >=0.20.2 && <0.21
-    , servant-client-core  >=0.20.2 && <0.21
+    , servant              >=0.20.3 && <0.21
+    , servant-client-core  >=0.20.3 && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -128,7 +128,7 @@ library
   -- strict dependency as we re-export 'servant' things.
   build-depends:
     , http-api-data  >=0.4.1 && <0.7
-    , servant        >=0.20.2 && <0.21
+    , servant        >=0.20.3 && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.


### PR DESCRIPTION
Fix #1821