### PR TITLE
Export generalized authentication things from `servant-client`

### DIFF
--- a/changelog.d/pr-1835
+++ b/changelog.d/pr-1835
@@ -1,0 +1,9 @@
+synopsis: Re-export client authentication primitives from `servant-client`
+packages: servant-client-core, servant-client
+prs: #1835
+issues: #1834
+description: {
+Add `AuthClientData`, `AuthenticatedRequest`, and `mkAuthenticatedRequest` to the `Servant.Client.Core.Reexport` module, which is re-exported within `servant-client`.
+
+This means that authenticated client requests can now be made using `servant-client` only, without an explicit dependency on `servant-client-core`.
+}

--- a/servant-client-core/src/Servant/Client/Core/Reexport.hs
+++ b/servant-client-core/src/Servant/Client/Core/Reexport.hs
@@ -25,9 +25,15 @@ module Servant.Client.Core.Reexport
   , showBaseUrl
   , parseBaseUrl
   , InvalidBaseUrlException
+
+    -- * Authentication
+  , AuthClientData
+  , AuthenticatedRequest (..)
+  , mkAuthenticatedRequest
   )
 where
 
+import Servant.Client.Core.Auth
 import Servant.Client.Core.BaseUrl
 import Servant.Client.Core.ClientError
 import Servant.Client.Core.HasClient


### PR DESCRIPTION
Currently, to use generalized authentication from the client side, users must depend on both `servant-client` and `servant-client-core`. This PR re-exports `AuthClientData`, `AuthenticatedRequest`, and `mkAuthenticatedRequest` such that users will only need to depend on `servant-client` directly.

Fixes #1834 