### PR TITLE
Abstract `ByteString` out of `MIME` rendering

### DIFF
--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -200,7 +200,7 @@ instance
 --
 -- >>> import Network.HTTP.Media hiding (Accept)
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSC
--- >>> newtype MyContentType = MyContentType String
+-- >>> data MyContentType
 -- >>> newtype MyData = MyData String
 --
 -- >>> :{

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -163,7 +163,7 @@ newtype AcceptHeader = AcceptHeader BS.ByteString
 -- >    contentType _ = "example" // "prs.me.mine" /: ("charset", "utf-8")
 -- >
 -- > instance MimeRender MyContentType String where
--- >    mimeRender _ val = pack ("This is MINE! " ++ show val)
+-- >    mimeRender _ val = pack ("This is MINE! " ++ val)
 -- >
 -- > type MyAPI = "path" :> Get '[MyContentType] Int
 class Accept ctype => MimeRender ctype a where
@@ -209,7 +209,7 @@ instance
 -- >>> :{
 -- instance MimeUnrender MyContentType String where
 --    mimeUnrender _ bs = case BSC.take 12 bs of
---      "MyContentType" -> return . read . BSC.unpack $ BSC.drop 12 bs
+--      "MyContentType" -> return . BSC.unpack $ BSC.drop 12 bs
 --      _ -> Left "didn't start with the magic incantation"
 -- :}
 --

--- a/servant/src/Servant/API/ContentTypes.hs
+++ b/servant/src/Servant/API/ContentTypes.hs
@@ -158,12 +158,13 @@ newtype AcceptHeader = AcceptHeader BS.ByteString
 -- Example:
 --
 -- > data MyContentType
+-- > newtype MyData = MyData String
 -- >
 -- > instance Accept MyContentType where
 -- >    contentType _ = "example" // "prs.me.mine" /: ("charset", "utf-8")
 -- >
--- > instance MimeRender MyContentType String where
--- >    mimeRender _ val = pack ("This is MINE! " ++ val)
+-- > instance MimeRender MyContentType MyData where
+-- >    mimeRender _ (MyData val) = pack ("This is MINE! " ++ val)
 -- >
 -- > type MyAPI = "path" :> Get '[MyContentType] Int
 class Accept ctype => MimeRender ctype a where
@@ -199,7 +200,8 @@ instance
 --
 -- >>> import Network.HTTP.Media hiding (Accept)
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSC
--- >>> data MyContentType = MyContentType String
+-- >>> newtype MyContentType = MyContentType String
+-- >>> newtype MyData = MyData String
 --
 -- >>> :{
 -- instance Accept MyContentType where
@@ -207,9 +209,9 @@ instance
 -- :}
 --
 -- >>> :{
--- instance MimeUnrender MyContentType String where
+-- instance MimeUnrender MyContentType MyData where
 --    mimeUnrender _ bs = case BSC.take 12 bs of
---      "MyContentType" -> return . BSC.unpack $ BSC.drop 12 bs
+--      "MyContentType" -> return . MyData . BSC.unpack $ BSC.drop 12 bs
 --      _ -> Left "didn't start with the magic incantation"
 -- :}
 --


### PR DESCRIPTION
This should allow us to abstract over `ByteString` from the `MimeRender` / `MimeUnrender` classes, without breaking any code and preserving existing semantics, while gaining extensibility to other platforms. 

On the client (e.g. browser) dealing with `JSString` / `JSVal` is often more efficient than marshalling by way of `ByteString` (at least for the JS backend). This change should be an easy win, keeping all existing code unaffected (via the type family defaulting rules), but allowing users on different platforms to use a type other than `ByteString`. 

Usage would look like:

```haskell
-- * when using servant-client on native platforms,
-- default to ByteString (existing code should be unaffected)
instance MimeUnrender JSON String where
  mimeUnrender Proxy = eitherDecode

-- * when using servant-client in the browser,
-- you can specify `JSVal`.
instance MimeUnrender OctetStream Blob where
  type MimeUnrenderType Blob = JSVal
  mimeUnrender Proxy = pure . Blob
  ```