### PR TITLE
Set `errBody` of `defaultErrorFormatters.notFoundErrorFormatter` in `servant-server` (#1790)

### DIFF
--- a/changelog.d/pr-1843
+++ b/changelog.d/pr-1843
@@ -1,0 +1,7 @@
+synopsis: Set `errBody` of `defaultErrorFormatters.notFoundErrorFormatter`
+packages: servant-server
+prs: #1843
+issues: #1790
+description: {
+  Set `errBody` of `defaultErrorFormatters.notFoundErrorFormatter` to avoid an empty body.
+}

--- a/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
+++ b/servant-server/src/Servant/Server/Internal/ErrorFormatter.hs
@@ -48,7 +48,7 @@ defaultErrorFormatters =
     { bodyParserErrorFormatter = err400Formatter
     , urlParseErrorFormatter = err400Formatter
     , headerParseErrorFormatter = err400Formatter
-    , notFoundErrorFormatter = const err404
+    , notFoundErrorFormatter = const err404{errBody = "404 Not Found"}
     }
 
 -- | A custom formatter for errors produced by parsing combinators like


### PR DESCRIPTION
I'm not sure it's the correct fix, I've only set `errBody`.

closes #1790.