### PR TITLE
RFC: Delegate Verb/NoContentVerb implementations to MultiVerb.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,7 +51,8 @@ packages:
   -- doc/cookbook/open-id-connect
   doc/cookbook/managed-resource
   doc/cookbook/infinite-streams
-  doc/cookbook/openapi3
+  -- Commented out because servant-openapi3 doesn't build with new Verb using StdMethod
+  -- doc/cookbook/openapi3
   doc/cookbook/expose-prometheus
 
 tests: True

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -138,6 +138,21 @@ type TestHeaders = '[Header "X-Example1" Int, Header "X-Example2" String]
 
 type TestSetCookieHeaders = '[Header "Set-Cookie" String, Header "Set-Cookie" String]
 
+-- | AsHeaders instance for extracting two Set-Cookie headers
+-- Returns: (body, (cookie1, cookie2))
+instance AsHeaders '[a, b] c (c, (a, b)) where
+  toHeaders (body, (h1, h2)) = (I h1 :* I h2 :* Nil, body)
+  fromHeaders (I h1 :* I h2 :* Nil, body) = (body, (h1, h2))
+
+-- | MultiVerb endpoint definition for SetCookie test
+type MultiVerbSetCookie =
+  "multiverb-set-cookie"
+    :> MultiVerb
+         'GET
+         '[JSON]
+         '[WithHeaders TestSetCookieHeaders (Bool, (String, String)) (Respond 200 "OK" Bool)]
+         (Bool, (String, String))
+
 data RecordRoutes mode = RecordRoutes
   { version :: mode :- "version" :> Get '[JSON] Int
   , echo :: mode :- "echo" :> Capture "string" String :> Get '[JSON] String
@@ -252,6 +267,7 @@ type Api =
     :<|> "multiple-choices-int" :> MultipleChoicesInt
     :<|> "captureVerbatim" :> Capture "someString" Verbatim :> Get '[PlainText] Text
     :<|> "host-test" :> Host "servant.example" :> Get '[JSON] Bool
+    :<|> MultiVerbSetCookie
     :<|> PaginatedAPI
 
 api :: Proxy Api
@@ -298,6 +314,7 @@ recordRoutes :: RecordRoutes (AsClientT ClientM)
 multiChoicesInt :: Int -> ClientM MultipleChoicesIntResult
 captureVerbatim :: Verbatim -> ClientM Text
 getHost :: ClientM Bool
+getMultiVerbSetCookie :: ClientM (Bool, (String, String))
 getPaginatedPerson :: Maybe (Range 1 100) -> ClientM [Person]
 getRoot
   :<|> getGet
@@ -329,6 +346,7 @@ getRoot
   :<|> multiChoicesInt
   :<|> captureVerbatim
   :<|> getHost
+  :<|> getMultiVerbSetCookie
   :<|> getPaginatedPerson = client api
 
 server :: Application
@@ -409,6 +427,7 @@ server =
              )
         :<|> pure . decodeUtf8 . unVerbatim
         :<|> pure True
+        :<|> pure (True, ("cookie1", "cookie2"))
         :<|> usersServer
     )
 

--- a/servant-client/test/Servant/ClientTestUtils.hs
+++ b/servant-client/test/Servant/ClientTestUtils.hs
@@ -138,7 +138,7 @@ type TestHeaders = '[Header "X-Example1" Int, Header "X-Example2" String]
 
 type TestSetCookieHeaders = '[Header "Set-Cookie" String, Header "Set-Cookie" String]
 
--- | AsHeaders instance for extracting two Set-Cookie headers
+-- | AsHeaders instance for extracting two headers (Required by the MultiVerbSetCookie test)
 -- Returns: (body, (cookie1, cookie2))
 instance AsHeaders '[a, b] c (c, (a, b)) where
   toHeaders (body, (h1, h2)) = (I h1 :* I h2 :* Nil, body)

--- a/servant-client/test/Servant/SuccessSpec.hs
+++ b/servant-client/test/Servant/SuccessSpec.hs
@@ -147,6 +147,15 @@ successSpec = beforeAll (startWaiApp server) $ afterAll endWaiApp $ do
       Left e -> assertFailure $ show e
       Right val -> getHeaders val `shouldBe` [("Set-Cookie", "cookie1"), ("Set-Cookie", "cookie2")]
 
+  it "Returns multiple Set-Cookie headers via MultiVerb WithHeaders" $ \(_, baseUrl) -> do
+    res <- runClient getMultiVerbSetCookie baseUrl
+    case res of
+      Left e -> assertFailure $ show e
+      Right (body, (cookie1, cookie2)) -> do
+        body `shouldBe` True
+        cookie1 `shouldBe` "cookie1"
+        cookie2 `shouldBe` "cookie2"
+
   it "Stores Cookie in CookieJar after a redirect" $ \(_, baseUrl) -> do
     mgr <- C.newManager C.defaultManagerSettings
     cj <- atomically . newTVar $ C.createCookieJar []

--- a/servant-quickcheck/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/servant-quickcheck/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE StarIsType #-}
 
 module Servant.QuickCheck.Internal.HasGenRequest where
 
@@ -223,7 +222,7 @@ instance
 
 instance
   ReflectMethod method
-  => HasGenRequest (Verb (method :: k) (status :: Nat) (cts :: [Type]) a)
+  => HasGenRequest (Verb (method :: StdMethod) (status :: Nat) (cts :: [Type]) a)
   where
   genRequest _ =
     ( 1
@@ -238,7 +237,7 @@ instance
 
 instance
   ReflectMethod method
-  => HasGenRequest (NoContentVerb (method :: k))
+  => HasGenRequest (NoContentVerb (method :: StdMethod))
   where
   genRequest _ =
     ( 1

--- a/servant-server/test/Servant/ServerSpec.hs
+++ b/servant-server/test/Servant/ServerSpec.hs
@@ -115,6 +115,7 @@ import Servant.API
   , (:>)
   )
 import Servant.API.QueryString (FromDeepQuery (..))
+import Servant.API.Status (KnownStatus (..), statusFromNat)
 import Servant.Test.ComprehensiveAPI
 import qualified Servant.Types.SourceT as S
 import Test.Hspec (Spec, context, describe, it, shouldBe, shouldContain)
@@ -155,6 +156,12 @@ import Servant.Server.Internal.BasicAuth
   , BasicAuthResult (Authorized, Unauthorized)
   )
 import Servant.Server.Internal.Context (NamedContext (..))
+
+-- * KnownStatus instances for non-standard test status codes
+
+instance KnownStatus 210 where statusVal _ = statusFromNat (Proxy @210)
+instance KnownStatus 214 where statusVal _ = statusFromNat (Proxy @214)
+instance KnownStatus 280 where statusVal _ = statusFromNat (Proxy @280)
 
 -- * comprehensive api test
 

--- a/servant-swagger/src/Servant/Swagger/Internal.hs
+++ b/servant-swagger/src/Servant/Swagger/Internal.hs
@@ -285,7 +285,7 @@ instance {-# OVERLAPPABLE #-} (AllAccept cs, KnownNat status, SwaggerMethod meth
   toSwagger _ = toSwagger (Proxy :: Proxy (Verb method status cs (Headers '[] a)))
 
 -- | @since 1.1.7
-instance (Accept ct, KnownNat status, SwaggerMethod method, ToSchema a) => HasSwagger (Stream method status fr ct a) where
+instance (Accept ct, KnownNat status, SwaggerMethod method, ToSchema a) => HasSwagger (Stream (method :: StdMethod) status fr ct a) where
   toSwagger _ = toSwagger (Proxy :: Proxy (Verb method status '[ct] (Headers '[] a)))
 
 instance

--- a/servant/src/Servant/API/MultiVerb.hs
+++ b/servant/src/Servant/API/MultiVerb.hs
@@ -55,7 +55,9 @@ import Generics.SOP as GSOP
 import Network.HTTP.Types as HTTP
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData, parseHeader, toHeader)
 
+import Servant.API.ContentTypes (NoContent (..))
 import Servant.API.Header (Header')
+import Servant.API.ResponseHeaders (HList (..), Headers (..), ResponseHeader (..))
 import Servant.API.Stream (SourceIO)
 import Servant.API.TypeLevel.List
 import Servant.API.UVerb.Union (Union)
@@ -154,6 +156,32 @@ instance AsHeaders '[h] a (a, h) where
 instance AsHeaders '[a, b] () (a, b) where
   toHeaders (h1, h2) = (I h1 :* I h2 :* Nil, ())
   fromHeaders (I h1 :* I h2 :* Nil, ()) = (h1, h2)
+
+-- | Convert between NP I xs (n-ary product of values) and HList hs (ResponseHeader-wrapped values)
+-- The functional dependency hs -> xs means: given a header spec list, we know the value types
+class NPToHList xs hs | hs -> xs where
+  npToHList :: NP I xs -> HList hs
+  hlistToNP :: HList hs -> NP I xs
+
+instance NPToHList '[] '[] where
+  npToHList Nil = HNil
+  hlistToNP HNil = Nil
+
+instance NPToHList xs hs => NPToHList (x ': xs) (Header' mods name x ': hs) where
+  npToHList (I x :* rest) = Header x `HCons` npToHList rest
+  hlistToNP (Header x `HCons` rest) = I x :* hlistToNP rest
+  hlistToNP (MissingHeader `HCons` _) = error "NPToHList: MissingHeader (should not happen)"
+  hlistToNP (UndecodableHeader _ `HCons` _) = error "NPToHList: UndecodableHeader (should not happen)"
+
+-- | Headers from Servant.API.ResponseHeaders, for backward compatibility with Verb
+instance {-# OVERLAPPABLE #-} NPToHList xs hs => AsHeaders xs a (Headers hs a) where
+  fromHeaders (np, body) = Headers{getResponse = body, getHeadersHList = npToHList np}
+  toHeaders (Headers body hlist) = (hlistToNP hlist, body)
+
+-- | Special case for NoContent body - the underlying response is () but we return NoContent
+instance {-# OVERLAPPING #-} NPToHList xs hs => AsHeaders xs () (Headers hs NoContent) where
+  fromHeaders (np, ()) = Headers{getResponse = NoContent, getHeadersHList = npToHList np}
+  toHeaders (Headers NoContent hlist) = (hlistToNP hlist, ())
 
 data DescHeader (name :: Symbol) (description :: Symbol) (a :: Type)
 

--- a/servant/src/Servant/API/Status.hs
+++ b/servant/src/Servant/API/Status.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
--- Flexible instances is necessary on GHC 8.4 and earlier
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Servant.API.Status where
@@ -12,7 +10,13 @@ import Network.HTTP.Types.Status
 statusFromNat :: forall a proxy. KnownNat a => proxy a -> Status
 statusFromNat = toEnum . fromInteger . natVal
 
--- | Witness that a type-level natural number corresponds to a HTTP status code
+-- | Witness that a type-level natural number corresponds to a HTTP status code.
+--
+-- Provides instances for all standard HTTP status codes. For non-standard codes,
+-- you can define your own instance:
+--
+-- > instance KnownStatus 299 where
+-- >   statusVal _ = statusFromNat (Proxy @299)
 class KnownNat n => KnownStatus n where
   statusVal :: proxy n -> Status
 

--- a/servant/src/Servant/API/Verbs.hs
+++ b/servant/src/Servant/API/Verbs.hs
@@ -33,13 +33,13 @@ import Network.HTTP.Types.Method
 -- provided, but you are free to define your own:
 --
 -- >>> type Post204 contentTypes a = Verb 'POST 204 contentTypes a
-data Verb (method :: k1) (statusCode :: Nat) (contentTypes :: [Type]) (a :: Type)
+data Verb (method :: StdMethod) (statusCode :: Nat) (contentTypes :: [Type]) (a :: Type)
   deriving (Generic, Typeable)
 
 -- | @NoContentVerb@ is a specific type to represent 'NoContent' responses.
 -- It does not require either a list of content types (because there's
 -- no content) or a status code (because it should always be 204).
-data NoContentVerb (method :: k1)
+data NoContentVerb (method :: StdMethod)
   deriving (Generic, Typeable)
 
 -- * 200 responses


### PR DESCRIPTION
**NOTE**: This PR is based on #1859 . You may skip the first two commits when reviewing (but the second one is necessary for the tests to pass).

The goal of this PR is to start exploring the standardization of the core of servant around One True Endpoint Combinator (hereinfafter referred to as OTEC) that supports all of our use cases.

Current situation is more or less the following:

- `Verb` / `NoContentVerb` is the historical endpoint combinator in `servant`.
- The `Stream` combinator is distinct from `Verb` and supports advanced streaming usages with custom framing and arbitrary item type.
- `UVerb` improved upon `Verb` by allowing multiple instances, but leaks details of the HTTP protocol into handler types (namely HTTP status codes) and is about to be deprecated (see #1820 ).
- `MultiVerb` is the closest thing we have to OTEC but:

  1) Does not properly support streaming yet. `RespondStreaming` is limited to `SourceIO ByteString` and is not as expressive as the current `Stream` combinator.
  2) Exhibits some hopefully minor semantic differences w.r.t `Verb` that need to be clarified.
  
This PR tries to re-express the `Verb` semantics for `HasServer` and `HasClient` *in terms* of `MultiVerb` instances, in order to explore the feasibility of the OTEC vision, verify that MultiVerb provides everything we need, and work out some backward compatibility solution. It turns out to be easier than I feared, but does require some breaking changes. Notably:

- Verb status codes must now have `KnownStatus` instances, not just `KnownNat`.
- The `Verb` method parameter was (probably) needlessly polykinded ; it must now be restricted to `StdMethod`, as this is what `MultiVerb` does, in order to support delegation.
- Some semantic changes around header handling in clients are. needed for both `MultiVerb` and `Verb`:
    a) `MultiVerb` incorrectly removed duplicate headers when parsing responses (see #1859 ), which made `Verb` test case failed when expressed in terms of MultiVerb. We fix this.
    b) `Verb` client implementation did not really check that headers were provided even when marked as mandatory. We could break user code that relies on some server _not_ honoring the Servant API from which the client was derived.

Hopefully we can do something with the work on this branch. 

Doing the same thing for `Stream` is essentially feasible but requires extending `RespondStreaming` to support the features required by `Stream` (or add a new response type to `MultiVerb`). I have some non-primetime-ready code around that I'll consolidate in a PR later.

The end goal would be:

- To make MultiVerb the OTEC.
- Ultimately, to rename `MultiVerb` as `Verb`, and possibly move current `Verb` to a dedicated module, or rename it to `SimpleVerb`.

