### PR TITLE
Require QuickCheck-2.18

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -84,3 +84,6 @@ if(impl(ghc >= 9.6.1))
 -- see https://github.com/commercialhaskell/lts-haskell/issues/409
 -- Change this to exclude 'memory' instead when the ecosystem is ready.
 constraints: ram < 0
+
+-- Allow QuickCheck-2.18
+allow-newer: swagger2:QuickCheck

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -63,7 +63,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       hspec                >= 2.5.5    && < 2.12
-    , QuickCheck           >= 2.11.3   && < 2.17
+    , QuickCheck           >= 2.18     && < 2.19
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.11 && < 0.13
     , http-client          >= 0.5.13.1 && < 0.8

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -52,7 +52,7 @@ test-suite doctests
     base,
     servant-auth-docs,
     doctest             >= 0.16   && < 0.25,
-    QuickCheck          >= 2.11.3 && < 2.17,
+    QuickCheck          >= 2.18   && < 2.19,
     template-haskell
   ghc-options:         -Wall -threaded
   hs-source-dirs:      test
@@ -80,6 +80,6 @@ test-suite spec
   build-depends:
       servant-auth-docs
     , hspec             >= 2.5.5  && < 2.12
-    , QuickCheck        >= 2.11.3 && < 2.17
+    , QuickCheck        >= 2.18   && < 2.19
 
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -124,7 +124,7 @@ test-suite spec
   build-depends:
       servant-auth-server
     , hspec       >= 2.5.5     && < 2.12
-    , QuickCheck  >= 2.11.3    && < 2.17
+    , QuickCheck  >= 2.18      && < 2.19
     , http-client >= 0.5.13.1  && < 0.8
     , lens-aeson  >= 1.0.2     && < 1.3
     , warp        >= 3.2.25    && < 3.5

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -64,7 +64,7 @@ test-suite spec
   build-depends:
       servant-auth-swagger
     , hspec      >= 2.5.5  && < 2.12
-    , QuickCheck >= 2.11.3 && < 2.17
+    , QuickCheck >= 2.18   && < 2.19
   other-modules:
       Servant.Auth.SwaggerSpec
   default-language: Haskell2010

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -155,6 +155,6 @@ test-suite spec
   build-depends:
     , deepseq     >=1.4.2.0  && <1.6
     , hspec       >=2.6.0    && <2.12
-    , QuickCheck  >=2.12.6.1 && <2.17
+    , QuickCheck  >=2.18     && <2.19
 
   build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -174,7 +174,7 @@ test-suite spec
     , hspec           >=2.6.0    && <2.12
     , HUnit           >=1.6.0.0  && <1.7
     , network         >=2.8.0.0  && <3.3
-    , QuickCheck      >=2.12.6.1 && <2.17
+    , QuickCheck      >=2.18     && <2.19
     , servant         >=0.20.2   && <0.21
     , servant-server  >=0.20.2   && <0.21
 

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -115,7 +115,7 @@ test-suite spec
     , hspec             >= 2.6.0    && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 2.8.0.0  && < 3.3
-    , QuickCheck        >= 2.12.6.1 && < 2.17
+    , QuickCheck        >= 2.18     && < 2.19
     , servant-server    >= 0.20.2 && < 0.21
     , servant           >= 0.20.2 && < 0.21
 

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -48,7 +48,7 @@ library
     , mtl                    >=2.1    && <2.4
     , pretty                 >=1.1    && <1.2
     , process                >=1.2    && <1.7
-    , QuickCheck             >=2.7    && <2.17
+    , QuickCheck             >=2.18   && <2.19
     , servant                >=0.20.2 && <0.21
     , servant-client         >=0.20.2 && <0.21
     , servant-server         >=0.20.2 && <0.21

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -160,7 +160,7 @@ library
     , http-types        >=0.12.2   && <0.13
     , mmorph            >=1.1.2    && <1.3
     , network-uri       >=2.6.1.0  && <2.7
-    , QuickCheck        >=2.12.6.1 && <2.17
+    , QuickCheck        >=2.18     && <2.19
     , vault             >=0.3.1.2  && <0.4
 
   hs-source-dirs:  src
@@ -191,7 +191,7 @@ test-suite spec
   -- Additional dependencies
   build-depends:
     , hspec                 >=2.6.0    && <2.12
-    , QuickCheck            >=2.12.6.1 && <2.17
-    , quickcheck-instances  >=0.3.19   && <0.4
+    , QuickCheck            >=2.18     && <2.19
+    , quickcheck-instances  >=0.4      && <0.5
 
   build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12


### PR DESCRIPTION
Since the tests do not need to have wide compatibility like the packages
people use, let's just support one major series (2.18).
