### PR TITLE
Bump lower dependency bounds

### DIFF
--- a/doc/cookbook/basic-auth/basic-auth.cabal
+++ b/doc/cookbook/basic-auth/basic-auth.cabal
@@ -13,16 +13,16 @@ executable cookbook-basic-auth
   main-is:             BasicAuth.lhs
   build-depends:       base == 4.*
                      , text >= 1.2
-                     , aeson >= 1.2
-                     , containers >= 0.5
+                     , aeson >= 2.2
+                     , containers >= 0.6.5.1
                      , servant
                      , servant-client
                      , servant-server
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/basic-streaming/basic-streaming.cabal
+++ b/doc/cookbook/basic-streaming/basic-streaming.cabal
@@ -16,7 +16,7 @@ executable cookbook-basic-streaming
   ghc-options:         -Wall -pgmL markdown-unlit -threaded -rtsopts
 
   hs-source-dirs: .
-  build-depends:       base >= 4.8 && <5
+  build-depends:       base >= 4.16 && <5
                      , aeson
                      , bytestring
                      , servant

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -12,17 +12,17 @@ build-type:          Simple
 executable cookbook-db-postgres-pool
   main-is:             PostgresPool.lhs
   build-depends:       base == 4.*
-                     , bytestring >= 0.10
+                     , bytestring >= 0.11
                      , text >= 1.2
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , servant
                      , servant-client
                      , servant-server
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
                      , postgresql-simple >= 0.5
                      , resource-pool >= 0.2
                      , transformers

--- a/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
+++ b/doc/cookbook/db-postgres-pool/db-postgres-pool.cabal
@@ -23,8 +23,8 @@ executable cookbook-db-postgres-pool
                      , http-types >= 0.12
                      , markdown-unlit >= 0.5.1
                      , http-client >= 0.7.19
-                     , postgresql-simple >= 0.5
-                     , resource-pool >= 0.2
+                     , postgresql-simple >= 0.7
+                     , resource-pool >= 0.5
                      , transformers
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -22,7 +22,7 @@ executable cookbook-db-sqlite-simple
                      , http-types >= 0.12
                      , markdown-unlit >= 0.5.1
                      , http-client >= 0.7.19
-                     , sqlite-simple >= 0.4.5.0
+                     , sqlite-simple >= 0.4.19.0
                      , transformers
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
+++ b/doc/cookbook/db-sqlite-simple/db-sqlite-simple.cabal
@@ -13,15 +13,15 @@ executable cookbook-db-sqlite-simple
   main-is:             DBConnection.lhs
   build-depends:       base == 4.*
                      , text >= 1.2
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , servant
                      , servant-client
                      , servant-server
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
                      , sqlite-simple >= 0.4.5.0
                      , transformers
   default-language:    Haskell2010

--- a/doc/cookbook/expose-prometheus/expose-prometheus.cabal
+++ b/doc/cookbook/expose-prometheus/expose-prometheus.cabal
@@ -15,16 +15,16 @@ executable cookbook-expose-prometheus
   build-depends:       base == 4.*
                      , text >= 1.2
                      , bytestring >= 0.11
-                     , containers >= 0.5
+                     , containers >= 0.6.5.1
                      , servant
                      , servant-server
                      , prometheus-client
                      , prometheus-metrics-ghc
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
   default-language:    Haskell2010
   ghc-options:         -rtsopts -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/file-upload/file-upload.cabal
+++ b/doc/cookbook/file-upload/file-upload.cabal
@@ -14,16 +14,16 @@ executable cookbook-file-upload
   build-depends:       base == 4.*
                      , text >= 1.2
                      , mtl >= 2.1
-                     , network >= 2.6
-                     , bytestring >= 0.10
+                     , network >= 3.2
+                     , bytestring >= 0.11
                      , servant
                      , servant-server
                      , servant-multipart
                      , transformers
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
+++ b/doc/cookbook/hoist-server-with-context/hoist-server-with-context.cabal
@@ -17,7 +17,7 @@ executable cookbook-hoist-server-with-context
   build-depends:       base == 4.*
                      , base-compat
                      , text >= 1.2
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , data-default
                      , fast-logger
                      , servant
@@ -25,11 +25,11 @@ executable cookbook-hoist-server-with-context
                      , servant-auth >= 0.3.2
                      , servant-auth-server >= 0.4.4.0
                      , time
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , wai-extra
                      , http-types >= 0.12
-                     , bytestring >= 0.10.4
+                     , bytestring >= 0.11
                      , mtl
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/doc/cookbook/https/https.cabal
+++ b/doc/cookbook/https/https.cabal
@@ -15,9 +15,9 @@ executable cookbook-https
                      , servant
                      , servant-server
                      , wai >= 3.2
-                     , warp >= 3.2
-                     , warp-tls >= 3.2.9
-                     , markdown-unlit >= 0.4
+                     , warp >= 3.4.9
+                     , warp-tls >= 3.3.4
+                     , markdown-unlit >= 0.5.1
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/infinite-streams/infinite-streams.cabal
+++ b/doc/cookbook/infinite-streams/infinite-streams.cabal
@@ -16,7 +16,7 @@ executable cookbook-infinite-streams
   ghc-options:         -Wall -pgmL markdown-unlit -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
 
   hs-source-dirs: .
-  build-depends:       base >= 4.8 && <5
+  build-depends:       base >= 4.16 && <5
                      , aeson
                      , async
                      , http-client

--- a/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
+++ b/doc/cookbook/jwt-and-basic-auth/jwt-and-basic-auth.cabal
@@ -16,19 +16,19 @@ executable cookbook-jwt-and-basic-auth
   main-is:             JWTAndBasicAuth.lhs
   build-depends:       base == 4.*
                      , text >= 1.2
-                     , aeson >= 1.2
-                     , containers >= 0.5
+                     , aeson >= 2.2
+                     , containers >= 0.6.5.1
                      , servant
                      , servant-client
                      , servant-server
                      , servant-auth == 0.4.*
                      , servant-auth-server >= 0.3.1.0
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
-                     , bytestring >= 0.10.4
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
+                     , bytestring >= 0.11
                      , transformers
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/doc/cookbook/managed-resource/managed-resource.cabal
+++ b/doc/cookbook/managed-resource/managed-resource.cabal
@@ -13,15 +13,15 @@ executable cookbook-managed-resource
   main-is:             ManagedResource.lhs
   build-depends:       base == 4.*
                      , text >= 1.2
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , servant >= 0.20 && <0.21
                      , servant-client >= 0.20 && <0.21
                      , servant-server >= 0.20 && <0.21
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12
-                     , markdown-unlit >= 0.4
-                     , http-client >= 0.5
+                     , markdown-unlit >= 0.5.1
+                     , http-client >= 0.7.19
                      , transformers
                      , resourcet
   default-language:    Haskell2010

--- a/doc/cookbook/named-routes/cookbook-named-routes.cabal
+++ b/doc/cookbook/named-routes/cookbook-named-routes.cabal
@@ -15,7 +15,7 @@ tested-with:   GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.1
 executable cookbook-named-routes
   main-is:            NamedRoutes.lhs
   build-depends:
-      aeson                >=1.2
+      aeson                >=2.2
     , base                 >=4   && <5
     , servant
     , servant-client
@@ -24,7 +24,7 @@ executable cookbook-named-routes
     , transformers
     , text
     , wai                  >=3.2
-    , warp                 >=3.2
+    , warp                 >=3.4.9
 
   default-language:   Haskell2010
   ghc-options:        -Wall -pgmL markdown-unlit

--- a/doc/cookbook/open-id-connect/OpenIdConnect.cabal
+++ b/doc/cookbook/open-id-connect/OpenIdConnect.cabal
@@ -38,7 +38,7 @@ executable cookbook-openidconnect
     , time
     , vector
     , wai
-    , warp >= 3.2
+    , warp >= 3.4.9
   default-language: Haskell2010
   ghc-options: -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints -Wnoncanonical-monad-instances -pgmL markdown-unlit
-  build-tool-depends: markdown-unlit:markdown-unlit >= 0.4
+  build-tool-depends: markdown-unlit:markdown-unlit >= 0.5.1

--- a/doc/cookbook/openapi3/openapi3.cabal
+++ b/doc/cookbook/openapi3/openapi3.cabal
@@ -14,7 +14,7 @@ executable cookbook-openapi3
   build-tool-depends:  markdown-unlit:markdown-unlit
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
-  build-depends:       base >= 4.9 && <5
+  build-depends:       base >= 4.16 && <5
                      , aeson
                      , openapi3
                      , servant

--- a/doc/cookbook/pagination/pagination.cabal
+++ b/doc/cookbook/pagination/pagination.cabal
@@ -14,7 +14,7 @@ executable cookbook-pagination
   build-tool-depends:  markdown-unlit:markdown-unlit
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
-  build-depends:       base >= 4.9 && <5
+  build-depends:       base >= 4.16 && <5
                      , aeson
                      , servant
                      , servant-server

--- a/doc/cookbook/sentry/sentry.cabal
+++ b/doc/cookbook/sentry/sentry.cabal
@@ -13,10 +13,10 @@ executable cookbook-sentry
   main-is:             Sentry.lhs
   build-depends:       base == 4.*
                      , bytestring
-                     , markdown-unlit >= 0.4
+                     , markdown-unlit >= 0.5.1
                      , raven-haskell >= 0.1.2
                      , servant-server
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/doc/cookbook/structuring-apis/structuring-apis.cabal
+++ b/doc/cookbook/structuring-apis/structuring-apis.cabal
@@ -12,11 +12,11 @@ build-type:          Simple
 executable cookbook-structuring-apis
   main-is:             StructuringApis.lhs
   build-depends:       base == 4.*
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , servant
                      , servant-server
-                     , warp >= 3.2
-                     , markdown-unlit >= 0.4
+                     , warp >= 3.4.9
+                     , markdown-unlit >= 0.5.1
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/testing/testing.cabal
+++ b/doc/cookbook/testing/testing.cabal
@@ -16,7 +16,7 @@ executable cookbook-testing
   build-depends:       base == 4.*
                      , base-compat
                      , text >= 1.2
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , lens-aeson
                      , lens
                      , servant
@@ -29,7 +29,7 @@ executable cookbook-testing
                      , hspec-wai
                      , QuickCheck
                      , unordered-containers
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
                      , wai-extra
   default-language:    Haskell2010

--- a/doc/cookbook/using-custom-monad/using-custom-monad.cabal
+++ b/doc/cookbook/using-custom-monad/using-custom-monad.cabal
@@ -16,12 +16,12 @@ executable cookbook-using-custom-monad
                      , servant
                      , servant-client
                      , servant-server
-                     , warp >= 3.2
+                     , warp >= 3.4.9
                      , wai >= 3.2
-                     , http-client >= 0.5
-                     , markdown-unlit >= 0.4
+                     , http-client >= 0.7.19
+                     , markdown-unlit >= 0.5.1
                      , stm >= 2.4
-                     , transformers >= 0.3
+                     , transformers >= 0.5.6.2
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
   build-tool-depends: markdown-unlit:markdown-unlit

--- a/doc/cookbook/using-free-client/using-free-client.cabal
+++ b/doc/cookbook/using-free-client/using-free-client.cabal
@@ -11,7 +11,7 @@ build-type:          Simple
 
 executable cookbook-using-free-client
   main-is:             UsingFreeClient.lhs
-  build-depends:       base >= 4.9 && <5
+  build-depends:       base >= 4.16 && <5
                      , free
                      , servant >= 0.20 && <0.21
                      , servant-client >= 0.20 && <0.21
@@ -19,7 +19,7 @@ executable cookbook-using-free-client
                      , servant-client-core >= 0.20 && <0.21
                      , base-compat
                      , servant-server >= 0.20 && <0.21
-                     , warp >= 3.2
+                     , warp >= 3.4.9
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit
-  build-tool-depends: markdown-unlit:markdown-unlit >= 0.4
+  build-tool-depends: markdown-unlit:markdown-unlit >= 0.5.1

--- a/doc/cookbook/uverb/uverb.cabal
+++ b/doc/cookbook/uverb/uverb.cabal
@@ -14,7 +14,7 @@ build-type:          Simple
 executable cookbook-uverb
   main-is:             UVerb.lhs
   build-depends:       base == 4.*
-                     , aeson >= 1.2
+                     , aeson >= 2.2
                      , aeson-pretty >= 0.8.8
                      , async
                      , http-client

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -64,7 +64,7 @@ library
     , lucid        >= 2.9.11  && < 2.12
     , random       >= 1.1     && < 1.4
     , servant-js   >= 0.9     && < 0.10
-    , time         >= 1.6.0.1 && < 1.15
+    , time         >= 1.11    && < 1.15
 
   -- For legacy tools, we need to specify build-depends too
   build-depends: markdown-unlit >= 0.5.0 && <0.7

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -67,7 +67,7 @@ test-suite spec
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.11 && < 0.13
     , http-client          >= 0.7.19   && < 0.8
-    , http-types           >= 0.12.2   && < 0.13
+    , http-types           >= 0.12.4   && < 0.13
     , servant-auth-server  >= 0.4.2.0  && < 0.5
     , servant-server       >= 0.20.2   && < 0.21
     , time                 >= 1.11     && < 1.15

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -32,7 +32,7 @@ library
   ghc-options: -Wall
   build-depends:
       base                >= 4.16.4.0 && < 4.22
-    , bytestring          >= 0.10.6.0 && < 0.13
+    , bytestring          >= 0.11     && < 0.13
     , containers          >=0.6.5.1  && < 0.9
     , servant-auth        == 0.4.9.2
     , servant             >= 0.20.3   && < 0.21
@@ -62,18 +62,18 @@ test-suite spec
 
   -- test dependencies
   build-depends:
-      hspec                >= 2.5.5    && < 2.12
+      hspec                >= 2.11     && < 2.12
     , QuickCheck           >= 2.18     && < 2.19
     , aeson                >= 1.3.1.1  && < 3
     , bytestring           >= 0.11 && < 0.13
-    , http-client          >= 0.5.13.1 && < 0.8
+    , http-client          >= 0.7.19   && < 0.8
     , http-types           >= 0.12.2   && < 0.13
     , servant-auth-server  >= 0.4.2.0  && < 0.5
     , servant-server       >= 0.20.2   && < 0.21
-    , time                 >= 1.5.0.1  && < 1.15
-    , transformers         >= 0.4.2.0  && < 0.7
+    , time                 >= 1.11     && < 1.15
+    , transformers         >= 0.5.6.2  && < 0.7
     , wai                  >= 3.2.1.2  && < 3.3
-    , warp                 >= 3.2.25   && < 3.5
+    , warp                 >= 3.4.9    && < 3.5
     , jose                 >= 0.10     && < 0.13
   other-modules:
       Servant.Auth.ClientSpec

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -40,7 +40,7 @@ library
     , servant-docs >= 0.13.1  && < 0.14
     , servant      >= 0.20.2  && < 0.21
     , servant-auth >= 0.4.2.0 && < 0.5
-    , lens         >= 4.16.1  && <5.4
+    , lens         >= 5.3     && <5.4
   exposed-modules:
       Servant.Auth.Docs
   default-language: Haskell2010
@@ -79,7 +79,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-docs
-    , hspec             >= 2.5.5  && < 2.12
+    , hspec             >= 2.11   && < 2.12
     , QuickCheck        >= 2.18   && < 2.19
 
   default-language: Haskell2010

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -126,7 +126,7 @@ test-suite spec
     , hspec       >= 2.11      && < 2.12
     , QuickCheck  >= 2.18      && < 2.19
     , http-client >= 0.7.19    && < 0.8
-    , lens-aeson  >= 1.0.2     && < 1.3
+    , lens-aeson  >= 1.2.3     && < 1.3
     , warp        >= 3.4.9     && < 3.5
     , wreq        >= 0.5.2.1   && < 0.6
     , text        >= 1.2.3.0   && < 2.2

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -40,7 +40,7 @@ library
     , cookie                  >= 0.4.4    && < 0.6
     , data-default            >= 0.8      && < 0.9
     , entropy                 >= 0.4.1.3  && < 0.5
-    , http-types              >= 0.12.2   && < 0.13
+    , http-types              >= 0.12.4   && < 0.13
     , jose                    >= 0.10     && < 0.13
     , lens                    >= 5.3      && < 5.4
     , memory                  >= 0.14.16  && < 0.19

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -32,17 +32,17 @@ library
   ghc-options: -Wall
   build-depends:
       base                    >= 4.16.4.0 && < 4.22
-    , aeson                   >= 1.0.0.1  && < 3
-    , base64-bytestring       >= 1.0.0.1  && < 2
-    , blaze-builder           >= 0.4.1.0  && < 0.5
+    , aeson                   >= 2.2      && < 3
+    , base64-bytestring       >= 1.2      && < 2
+    , blaze-builder           >= 0.4.4.1  && < 0.5
     , bytestring              >= 0.11 && < 0.13
-    , case-insensitive        >= 1.2.0.11 && < 1.3
+    , case-insensitive        >= 1.2.1.0  && < 1.3
     , cookie                  >= 0.4.4    && < 0.6
-    , data-default            >= 0.2      && < 0.9
+    , data-default            >= 0.8      && < 0.9
     , entropy                 >= 0.4.1.3  && < 0.5
     , http-types              >= 0.12.2   && < 0.13
     , jose                    >= 0.10     && < 0.13
-    , lens                    >= 4.16.1   && < 5.4
+    , lens                    >= 5.3      && < 5.4
     , memory                  >= 0.14.16  && < 0.19
     , monad-time              >= 0.3.1.0  && < 0.5
     , mtl                     ^>= 2.2.2   || ^>= 2.3.1
@@ -51,8 +51,8 @@ library
     , servant-server          >= 0.20.3   && < 0.21
     , tagged                  >= 0.8.4    && < 0.9
     , text                    >= 1.2.3.0  && < 2.2
-    , time                    >= 1.5.0.1  && < 1.15
-    , unordered-containers    >= 0.2.9.0  && < 0.3
+    , time                    >= 1.11     && < 1.15
+    , unordered-containers    >= 0.2.21   && < 0.3
     , wai                     >= 3.2.1.2  && < 3.3
 
   if impl(ghc >= 9)
@@ -123,11 +123,11 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-server
-    , hspec       >= 2.5.5     && < 2.12
+    , hspec       >= 2.11      && < 2.12
     , QuickCheck  >= 2.18      && < 2.19
-    , http-client >= 0.5.13.1  && < 0.8
+    , http-client >= 0.7.19    && < 0.8
     , lens-aeson  >= 1.0.2     && < 1.3
-    , warp        >= 3.2.25    && < 3.5
+    , warp        >= 3.4.9     && < 3.5
     , wreq        >= 0.5.2.1   && < 0.6
     , text        >= 1.2.3.0   && < 2.2
   other-modules:

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -37,7 +37,7 @@ library
     , swagger2        >= 2.2.2   && < 3
     , servant         >= 0.20.2  && < 0.21
     , servant-auth    >= 0.4.2.0 && < 0.5
-    , lens            >= 4.16.1  && < 5.4
+    , lens            >= 5.3     && < 5.4
   exposed-modules:
       Servant.Auth.Swagger
   default-language: Haskell2010
@@ -63,7 +63,7 @@ test-suite spec
   -- test dependencies
   build-depends:
       servant-auth-swagger
-    , hspec      >= 2.5.5  && < 2.12
+    , hspec      >= 2.11   && < 2.12
     , QuickCheck >= 2.18   && < 2.19
   other-modules:
       Servant.Auth.SwaggerSpec

--- a/servant-auth/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth/servant-auth.cabal
@@ -37,10 +37,10 @@ library
     , containers              >=0.6.5.1   && < 0.9
     , aeson                   >= 2.0      && < 3
     , jose                    >= 0.10     && < 0.13
-    , lens                    >= 4.16.1   && < 5.4
+    , lens                    >= 5.3      && < 5.4
     , servant                 >= 0.20.3   && < 0.21
     , text                    >= 1.2.3.0  && < 2.2
-    , unordered-containers    >= 0.2.9.0  && < 0.3
+    , unordered-containers    >= 0.2.21   && < 0.3
   exposed-modules:
       Servant.Auth
       Servant.Auth.JWT

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -122,9 +122,9 @@ library
     , base-compat        >=0.12    && <0.15
     , base64-bytestring  >=1.2     && <1.3
     , exceptions         >=0.10.4  && <0.11
-    , free               >=5.1     && <5.3
+    , free               >=5.2     && <5.3
     , http-media         >=0.8     && <0.9
-    , http-types         >=0.12.2  && <0.13
+    , http-types         >=0.12.4  && <0.13
     , network-uri        >=2.6.4.2 && <2.7
     , safe               >=0.3.21  && <0.4
     , sop-core           >=0.5     && <0.6

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -103,13 +103,13 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-    , attoparsec        >= 0.13.2.2 && < 0.15
+    , attoparsec        >= 0.14.4   && < 0.15
     , base              >= 4.16.4.0 && < 4.22
     , bytestring        >=0.11 && <0.13
-    , constraints       >=0.2      && <0.15
+    , constraints       >=0.14.4   && <0.15
     , containers        >=0.6.5.1  && <0.9
-    , deepseq           >=1.4.2.0  && <1.6
-    , template-haskell  >=2.11.1.0 && <2.24
+    , deepseq           >=1.4.6.1  && <1.6
+    , template-haskell  >=2.18     && <2.24
     , text              >=1.2.3.0  && <2.2
 
   -- Servant dependencies
@@ -118,16 +118,16 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , aeson              >=1.4.1.0 && <3
-    , base-compat        >=0.10.5  && <0.15
-    , base64-bytestring  >=1.0.0.1 && <1.3
-    , exceptions         >=0.10.0  && <0.11
+    , aeson              >=2.2     && <3
+    , base-compat        >=0.12    && <0.15
+    , base64-bytestring  >=1.2     && <1.3
+    , exceptions         >=0.10.4  && <0.11
     , free               >=5.1     && <5.3
-    , http-media         >=0.7.1.3 && <0.9
+    , http-media         >=0.8     && <0.9
     , http-types         >=0.12.2  && <0.13
-    , network-uri        >=2.6.1.0 && <2.7
-    , safe               >=0.3.17  && <0.4
-    , sop-core           >=0.4.0.0 && <0.6
+    , network-uri        >=2.6.4.2 && <2.7
+    , safe               >=0.3.21  && <0.4
+    , sop-core           >=0.5     && <0.6
 
   hs-source-dirs:  src
 
@@ -153,8 +153,8 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    , deepseq     >=1.4.2.0  && <1.6
-    , hspec       >=2.6.0    && <2.12
+    , deepseq     >=1.4.6.1  && <1.6
+    , hspec       >=2.11     && <2.12
     , QuickCheck  >=2.18     && <2.19
 
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -37,20 +37,20 @@ library
 
   build-depends:
       base                >=4.11    && <5
-    , bytestring          >=0.10    && <0.13
+    , bytestring          >=0.11    && <0.13
     , case-insensitive    >=1.2.0.0 && <1.3.0.0
-    , containers          >=0.5     && <0.7
-    , exceptions          >=0.8     && <0.11
+    , containers          >=0.6.5.1 && <0.7
+    , exceptions          >=0.10.4  && <0.11
     , ghcjs-base          >=0.2.0.0 && <0.3.0.0
     , ghcjs-prim          >=0.1.0.0 && <0.2.0.0
-    , http-media          >=0.6.2   && <0.9
+    , http-media          >=0.8     && <0.9
     , http-types          >=0.12    && <0.13
-    , monad-control       >=1.0.0.4 && <1.1
+    , monad-control       >=1.0.3   && <1.1
     , mtl                 ^>=2.2.2  || ^>=2.3.1
-    , semigroupoids       >=5.3     && <6.1
+    , semigroupoids       >=6.0     && <6.1
     , string-conversions  >=0.3     && <0.5
-    , transformers        >=0.3     && <0.7
-    , transformers-base   >=0.4.4   && <0.5
+    , transformers        >=0.5.6.2 && <0.7
+    , transformers-base   >=0.4.6.1 && <0.5
 
   -- strict, as we re-export stuff
   build-depends:

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -96,10 +96,10 @@ library
     , base          >= 4.16.4.0 && < 4.22
     , bytestring    >=0.11 && <0.13
     , containers    >=0.6.5.1  && <0.9
-    , deepseq       >=1.4.2.0  && <1.6
+    , deepseq       >=1.4.6.1  && <1.6
     , mtl           ^>=2.2.2   || ^>=2.3.1
     , stm           >=2.4.5.1  && <2.6
-    , time          >=1.6.0.1  && <1.15
+    , time          >=1.11     && <1.15
     , transformers  >=0.5.2.0  && <0.7
 
   -- Servant dependencies.
@@ -111,15 +111,15 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , base-compat          >=0.10.5   && <0.15
-    , exceptions           >=0.10.0   && <0.11
-    , http-client          >=0.5.13.1 && <0.8
-    , http-media           >=0.7.1.3  && <0.9
+    , base-compat          >=0.12     && <0.15
+    , exceptions           >=0.10.4   && <0.11
+    , http-client          >=0.7.19   && <0.8
+    , http-media           >=0.8      && <0.9
     , http-types           >=0.12.2   && <0.13
     , kan-extensions       >=5.2      && <5.3
-    , monad-control        >=1.0.2.3  && <1.1
-    , semigroupoids        >=5.3.1    && <6.1
-    , transformers-base    >=0.4.5.2  && <0.5
+    , monad-control        >=1.0.3    && <1.1
+    , semigroupoids        >=6.0      && <6.1
+    , transformers-base    >=0.4.6.1  && <0.5
 
   hs-source-dirs:  src
 
@@ -171,14 +171,14 @@ test-suite spec
   -- Additional dependencies
   build-depends:
     , entropy         >=0.4.1.3  && <0.5
-    , hspec           >=2.6.0    && <2.12
+    , hspec           >=2.11     && <2.12
     , HUnit           >=1.6.0.0  && <1.7
-    , network         >=2.8.0.0  && <3.3
+    , network         >=3.2      && <3.3
     , QuickCheck      >=2.18     && <2.19
     , servant         >=0.20.2   && <0.21
     , servant-server  >=0.20.2   && <0.21
 
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12
 
 test-suite readme
   import:             extensions

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -115,7 +115,7 @@ library
     , exceptions           >=0.10.4   && <0.11
     , http-client          >=0.7.19   && <0.8
     , http-media           >=0.8      && <0.9
-    , http-types           >=0.12.2   && <0.13
+    , http-types           >=0.12.4   && <0.13
     , kan-extensions       >=5.2      && <5.3
     , monad-control        >=1.0.3    && <1.1
     , semigroupoids        >=6.0      && <6.1

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -57,6 +57,6 @@ test-suite example
     , servant-server >=0.20.2   && <0.21
     , servant-client >=0.20.2   && <0.21
     , wai            >=3.2.1.2  && <3.3
-    , warp           >=3.2.25   && <3.5
+    , warp           >=3.4.9    && <3.5
     , http-client
   default-language: Haskell2010

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -58,7 +58,7 @@ library
     , case-insensitive     >= 1.2.0.11 && < 1.3
     , hashable             >= 1.4.7.0  && < 1.6
     , http-media           >= 0.8      && < 0.9
-    , http-types           >= 0.12.2   && < 0.13
+    , http-types           >= 0.12.4   && < 0.13
     , lens                 >= 5.3      && < 5.4
     , string-conversions   >= 0.4.0.1  && < 0.5
     , universe-base        >= 1.1.1    && < 1.2

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -52,17 +52,17 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      aeson                >= 1.4.1.0  && < 3
+      aeson                >= 2.2      && < 3
     , aeson-pretty         >= 0.8.5    && < 0.9
-    , base-compat          >= 0.10.5   && < 0.15
+    , base-compat          >= 0.12     && < 0.15
     , case-insensitive     >= 1.2.0.11 && < 1.3
-    , hashable             >= 1.2.7.0  && < 1.6
-    , http-media           >= 0.7.1.3  && < 0.9
+    , hashable             >= 1.4.7.0  && < 1.6
+    , http-media           >= 0.8      && < 0.9
     , http-types           >= 0.12.2   && < 0.13
-    , lens                 >= 4.17     && < 5.4
+    , lens                 >= 5.3      && < 5.4
     , string-conversions   >= 0.4.0.1  && < 0.5
     , universe-base        >= 1.1.1    && < 1.2
-    , unordered-containers >= 0.2.9.0  && < 0.3
+    , unordered-containers >= 0.2.21   && < 0.3
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -51,8 +51,8 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat >= 0.10.5  && < 0.15
-    , lens        >= 4.17    && < 5.4
+      base-compat >= 0.12    && < 0.15
+    , lens        >= 5.3     && < 5.4
     , http-types  >= 0.12.2  && < 0.13
 
   hs-source-dirs:      src
@@ -74,7 +74,7 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    hspec >= 2.6.0 && <2.12
+    hspec >= 2.11  && <2.12
   build-tool-depends:
-    hspec-discover:hspec-discover >=2.6.0 && <2.12
+    hspec-discover:hspec-discover >=2.11  && <2.12
   default-language:  Haskell2010

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -53,7 +53,7 @@ library
   build-depends:
       base-compat >= 0.12    && < 0.15
     , lens        >= 5.3     && < 5.4
-    , http-types  >= 0.12.2  && < 0.13
+    , http-types  >= 0.12.4  && < 0.13
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -65,7 +65,7 @@ library
     , http-streams          >= 0.8.9.9  && < 0.9
     , http-media            >= 0.8      && < 0.9
     , io-streams            >= 1.5.2.2  && < 1.6
-    , http-types            >= 0.12.2   && < 0.13
+    , http-types            >= 0.12.4   && < 0.13
     , http-common           >= 0.8.3.4  && < 0.9
     , exceptions            >= 0.10.4   && < 0.11
     , kan-extensions        >= 5.2      && < 5.3

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -41,15 +41,15 @@ library
       base                  >= 4.16.4.0 && < 4.22
     , bytestring            >= 0.11 && < 0.13
     , containers            >= 0.6.5.1  && < 0.9
-    , deepseq               >= 1.4.2.0  && < 1.6
+    , deepseq               >= 1.4.6.1  && < 1.6
     , mtl                   ^>= 2.2.2   || ^>= 2.3.1
     , text                  >= 1.2.3.0  && < 2.2
-    , time                  >= 1.6.0.1  && < 1.15
-    , transformers          >= 0.5.2.0  && < 0.7
+    , time                  >= 1.11     && < 1.15
+    , transformers          >= 0.5.6.2  && < 0.7
 
   if !impl(ghc >= 8.2)
     build-depends:
-      bifunctors >= 5.5.3 && < 5.7
+      bifunctors >= 5.6.3 && < 5.7
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.
@@ -60,19 +60,19 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat           >= 0.10.5   && < 0.15
+      base-compat           >= 0.12     && < 0.15
     , case-insensitive
-    , http-streams          >= 0.8.6.1  && < 0.9
-    , http-media            >= 0.7.1.3  && < 0.9
-    , io-streams            >= 1.5.0.1  && < 1.6
+    , http-streams          >= 0.8.9.9  && < 0.9
+    , http-media            >= 0.8      && < 0.9
+    , io-streams            >= 1.5.2.2  && < 1.6
     , http-types            >= 0.12.2   && < 0.13
-    , http-common           >= 0.8.2.0  && < 0.9
-    , exceptions            >= 0.10.0   && < 0.11
+    , http-common           >= 0.8.3.4  && < 0.9
+    , exceptions            >= 0.10.4   && < 0.11
     , kan-extensions        >= 5.2      && < 5.3
-    , monad-control         >= 1.0.2.3  && < 1.1
-    , semigroupoids         >= 5.3.1    && < 6.1
-    , transformers-base     >= 0.4.5.2  && < 0.5
-    , transformers-compat   >= 0.6.2    && < 0.8
+    , monad-control         >= 1.0.3    && < 1.1
+    , semigroupoids         >= 6.0      && < 6.1
+    , transformers-base     >= 0.4.6.1  && < 0.5
+    , transformers-compat   >= 0.7.2    && < 0.8
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -112,15 +112,15 @@ test-suite spec
   -- Additional dependencies
   build-depends:
       entropy           >= 0.4.1.3  && < 0.5
-    , hspec             >= 2.6.0    && < 2.12
+    , hspec             >= 2.11     && < 2.12
     , HUnit             >= 1.6.0.0  && < 1.7
-    , network           >= 2.8.0.0  && < 3.3
+    , network           >= 3.2      && < 3.3
     , QuickCheck        >= 2.18     && < 2.19
     , servant-server    >= 0.20.2 && < 0.21
     , servant           >= 0.20.2 && < 0.21
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
+    hspec-discover:hspec-discover >= 2.11  && < 2.12
 
 test-suite readme
   type:           exitcode-stdio-1.0

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -54,6 +54,6 @@ test-suite example
     , servant-server >=0.20.2   && <0.21
     , servant-client >=0.20.2   && <0.21
     , wai            >=3.2.1.2  && <3.3
-    , warp           >=3.2.25   && <3.5
+    , warp           >=3.4.9    && <3.5
     , http-client
   default-language: Haskell2010

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -33,7 +33,7 @@ library
     , pipes         >=4.3.9    && <4.4
     , pipes-safe    >=2.3.1    && <2.4
     , mtl           ^>=2.2.2   || ^>=2.3.1
-    , monad-control >=1.0.2.3  && <1.1
+    , monad-control >=1.0.3    && <1.1
     , servant       >=0.20.2   && <0.21
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -58,6 +58,6 @@ test-suite example
     , servant-server    >=0.20.2   && <0.21
     , servant-client    >=0.20.2   && <0.21
     , wai               >=3.2.1.2  && <3.3
-    , warp              >=3.2.25   && <3.5
+    , warp              >=3.4.9    && <3.5
     , http-client
   default-language: Haskell2010

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -44,7 +44,7 @@ library
     , hspec                  >=2.11   && <2.12
     , http-client            >=0.7.19 && <0.8
     , http-media             >=0.8    && <0.9
-    , http-types             >=0.8    && <0.13
+    , http-types             >=0.12.4 && <0.13
     , mtl                    >=2.1    && <2.4
     , pretty                 >=1.1    && <1.2
     , process                >=1.6.16 && <1.7
@@ -53,7 +53,7 @@ library
     , servant-client         >=0.20.2 && <0.21
     , servant-server         >=0.20.2 && <0.21
     , split                  >=0.2    && <0.3
-    , temporary              >=1.2    && <1.4
+    , temporary              >=1.3    && <1.4
     , text                   >=1.2    && <2.2
     , time                   >=1.11   && <1.15
     , warp                   >=3.4.9  && <3.5

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -35,28 +35,28 @@ library
 
   ghc-options:        -Wall -Wcompat
   build-depends:
-      aeson                  >=0.8    && <2.3
+      aeson                  >=2.2    && <2.3
     , base                   >= 4.16.4.0 && < 4.22
-    , base-compat-batteries  >=0.10.1 && <0.15
+    , base-compat-batteries  >=0.12   && <0.15
     , bytestring             >=0.11   && <0.13
     , case-insensitive       >=1.2    && <1.3
     , clock                  >=0.7    && <0.9
-    , hspec                  >=2.5.6  && <2.12
-    , http-client            >=0.7.0  && <0.8
-    , http-media             >=0.6    && <0.9
+    , hspec                  >=2.11   && <2.12
+    , http-client            >=0.7.19 && <0.8
+    , http-media             >=0.8    && <0.9
     , http-types             >=0.8    && <0.13
     , mtl                    >=2.1    && <2.4
     , pretty                 >=1.1    && <1.2
-    , process                >=1.2    && <1.7
+    , process                >=1.6.16 && <1.7
     , QuickCheck             >=2.18   && <2.19
     , servant                >=0.20.2 && <0.21
     , servant-client         >=0.20.2 && <0.21
     , servant-server         >=0.20.2 && <0.21
     , split                  >=0.2    && <0.3
     , temporary              >=1.2    && <1.4
-    , text                   >=1      && <2.2
-    , time                   >=1.5    && <1.15
-    , warp                   >=3.2.4  && <3.5
+    , text                   >=1.2    && <2.2
+    , time                   >=1.11   && <1.15
+    , warp                   >=3.4.9  && <3.5
 
   hs-source-dirs:     src
   default-extensions:
@@ -94,7 +94,7 @@ test-suite spec
     , blaze-html
     , bytestring
     , hspec
-    , hspec-core             >=2.5.5 && <2.12
+    , hspec-core             >=2.11  && <2.12
     , http-client
     , QuickCheck
     , quickcheck-io

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -117,34 +117,34 @@ library
   build-depends:
     , base          >= 4.16.4.0 && < 4.22
     , bytestring    >=0.11 && <0.13
-    , constraints   >=0.2      && <0.15
+    , constraints   >=0.14.4   && <0.15
     , containers    >=0.6.5.1  && <0.9
-    , filepath      >=1.4.1.1  && <1.6
+    , filepath      >=1.4.2.2  && <1.6
     , mtl           ^>=2.2.2   || ^>=2.3.1
     , text          >=1.2.3.0  && <2.2
-    , transformers  >=0.5.2.0  && <0.7
+    , transformers  >=0.5.6.2  && <0.7
 
   -- Servant dependencies
   -- strict dependency as we re-export 'servant' things.
   build-depends:
-    , http-api-data  >=0.4.1 && <0.8
+    , http-api-data  >=0.6.3 && <0.8
     , servant        >=0.20.3 && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , base64-bytestring  >=1.0.0.1 && <1.3
-    , exceptions         >=0.10.0  && <0.11
-    , http-media         >=0.7.1.3 && <0.9
+    , base64-bytestring  >=1.2     && <1.3
+    , exceptions         >=0.10.4  && <0.11
+    , http-media         >=0.8     && <0.9
     , http-types         >=0.12.2  && <0.13
-    , monad-control      >=1.0.2.3 && <1.1
-    , network            >=2.8     && <3.3
+    , monad-control      >=1.0.3   && <1.1
+    , network            >=3.2     && <3.3
     , resourcet          >=1.2.2   && <1.4
-    , sop-core           >=0.4.0.0 && <0.6
+    , sop-core           >=0.5     && <0.6
     , tagged             >=0.8.6   && <0.9
-    , transformers-base  >=0.4.5.2 && <0.5
+    , transformers-base  >=0.4.6.1 && <0.5
     , wai                >=3.2.2.1 && <3.3
-    , wai-app-static     >=3.1.6.2 && <3.3
+    , wai-app-static     >=3.2     && <3.3
     , word8              >=0.1.3   && <0.2
 
   hs-source-dirs:  src
@@ -162,8 +162,8 @@ executable greet
     , wai
 
   build-depends:
-    , aeson  >=1.4.1.0 && <3
-    , warp   >=3.2.25  && <3.5
+    , aeson  >=2.2     && <3
+    , warp   >=3.4.9   && <3.5
 
 test-suite spec
   import:             extensions
@@ -201,12 +201,12 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    , aeson                 >=1.4.1.0  && <3
+    , aeson                 >=2.2      && <3
     , directory             >=1.3.0.0  && <1.4
-    , hspec                 >=2.6.0    && <2.12
+    , hspec                 >=2.11     && <2.12
     , hspec-wai             >=0.10.1   && <0.12
     , should-not-typecheck  >=2.1.0    && <2.2
     , temporary             >=1.3      && <1.4
-    , wai-extra             >=3.0.24.3 && <3.2
+    , wai-extra             >=3.1      && <3.2
 
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -136,7 +136,7 @@ library
     , base64-bytestring  >=1.2     && <1.3
     , exceptions         >=0.10.4  && <0.11
     , http-media         >=0.8     && <0.9
-    , http-types         >=0.12.2  && <0.13
+    , http-types         >=0.12.4  && <0.13
     , monad-control      >=1.0.3   && <1.1
     , network            >=3.2     && <3.3
     , resourcet          >=1.2.2   && <1.4

--- a/servant-swagger/example/example.cabal
+++ b/servant-swagger/example/example.cabal
@@ -50,8 +50,8 @@ test-suite swagger-server-spec
     TodoSpec
     Paths_example
   build-depends:    base  == 4.*
-                  , base-compat >= 0.6.0
-                  , aeson >=0.11.2.0
+                  , base-compat >= 0.12
+                  , aeson >= 2.2
                   , bytestring
                   , example
                   , hspec

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -106,20 +106,20 @@ test-suite spec
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12
   build-depends:    base < 5
                   , base-compat
                   , aeson >=2.2     && <3
                   , hspec >=2.11  && <2.12
                   , QuickCheck
                   , lens
-                  , lens-aeson >=1.0.2    && <1.3
+                  , lens-aeson >=1.2.3    && <1.3
                   , servant
                   , servant-swagger
                   , swagger2
                   , text
                   , template-haskell
-                  , utf8-string >=1.0.1.1 && <1.1
+                  , utf8-string >=1.0.2   && <1.1
                   , time
                   , vector
   other-modules:

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -69,19 +69,19 @@ library
     Servant.Swagger.Internal.TypeLevel.Every
     Servant.Swagger.Internal.TypeLevel.TMap
   hs-source-dirs:      src
-  build-depends:       aeson                     >=1.4.2.0 && <3
+  build-depends:       aeson                     >=2.2     && <3
                      , aeson-pretty              >=0.8.7    && <0.9
                      , base                      >= 4.16.4.0 && < 4.22
-                     , base-compat               >=0.10.5   && <0.15
+                     , base-compat               >=0.12     && <0.15
                      , bytestring                >=0.11 && <0.13
-                     , http-media                >=0.7.1.3  && <0.9
+                     , http-media                >=0.8      && <0.9
                      , insert-ordered-containers >=0.3      && <0.4
-                     , lens                      >=4.17     && <6
+                     , lens                      >=5.3      && <6
                      , servant                   >=0.20.3   && <0.21
-                     , singleton-bool            >=0.1.4    && <0.2
+                     , singleton-bool            >=0.1.8    && <0.2
                      , swagger2                  >=2.9      && <2.10
                      , text                      >=1.2.3.0  && <2.2
-                     , unordered-containers      >=0.2.9.0  && <0.3
+                     , unordered-containers      >=0.2.21   && <0.3
 
                      , hspec
                      , QuickCheck
@@ -109,8 +109,8 @@ test-suite spec
   build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
   build-depends:    base < 5
                   , base-compat
-                  , aeson >=1.4.2.0 && <3
-                  , hspec >=2.6.0 && <2.12
+                  , aeson >=2.2     && <3
+                  , hspec >=2.11  && <2.12
                   , QuickCheck
                   , lens
                   , lens-aeson >=1.0.2    && <1.3

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -134,34 +134,34 @@ library
   build-depends:
     , base          >= 4.16.4.0 && <4.22
     , bytestring    >=0.11 && <0.13
-    , constraints   >=0.2
+    , constraints   >=0.14.4
     , containers    >=0.6.5.1  && <0.9
     , mtl           ^>=2.2.2   || ^>=2.3.1
-    , sop-core      >=0.4.0.0  && <0.6
+    , sop-core      >=0.5      && <0.6
     , generics-sop  ^>=0.5.1
     , text          >=1.2.3.0  && <2.2
-    , transformers  >=0.5.2.0  && <0.7
+    , transformers  >=0.5.6.2  && <0.7
 
   -- We depend (heavily) on the API of these packages:
   -- i.e. re-export, or allow using without direct dependency
   build-depends:
-    , http-api-data   >=0.4.1 && <0.8
-    , singleton-bool  >=0.1.4 && <0.2
+    , http-api-data   >=0.6.3 && <0.8
+    , singleton-bool  >=0.1.8 && <0.2
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , aeson             >=1.4.1.0  && <2.3
-    , attoparsec        >=0.13.2.2 && <0.15
-    , bifunctors        >=5.5.3    && <5.7
-    , case-insensitive  >=1.2.0.11 && <1.3
-    , deepseq           >=1.4.2.0  && <1.6
-    , http-media        >=0.7.1.3  && <0.9
+    , aeson             >=2.2      && <2.3
+    , attoparsec        >=0.14.4   && <0.15
+    , bifunctors        >=5.6.3    && <5.7
+    , case-insensitive  >=1.2.1.0  && <1.3
+    , deepseq           >=1.4.6.1  && <1.6
+    , http-media        >=0.8      && <0.9
     , http-types        >=0.12.2   && <0.13
-    , mmorph            >=1.1.2    && <1.3
-    , network-uri       >=2.6.1.0  && <2.7
+    , mmorph            >=1.2.2    && <1.3
+    , network-uri       >=2.6.4.2  && <2.7
     , QuickCheck        >=2.18     && <2.19
-    , vault             >=0.3.1.2  && <0.4
+    , vault             >=0.3.1.6  && <0.4
 
   hs-source-dirs:  src
 
@@ -190,8 +190,8 @@ test-suite spec
 
   -- Additional dependencies
   build-depends:
-    , hspec                 >=2.6.0    && <2.12
+    , hspec                 >=2.11     && <2.12
     , QuickCheck            >=2.18     && <2.19
     , quickcheck-instances  >=0.4      && <0.5
 
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -157,7 +157,7 @@ library
     , case-insensitive  >=1.2.1.0  && <1.3
     , deepseq           >=1.4.6.1  && <1.6
     , http-media        >=0.8      && <0.9
-    , http-types        >=0.12.2   && <0.13
+    , http-types        >=0.12.4   && <0.13
     , mmorph            >=1.2.2    && <1.3
     , network-uri       >=2.6.4.2  && <2.7
     , QuickCheck        >=2.18     && <2.19


### PR DESCRIPTION
This is supposed to use the version from [version history](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history)
for boot libraries. For others, it should roughly use the version in Stackage LTS. Sometimes I truncated the version number.

Remaining:

* free
* postgresql-simple
* temporary
* sqlite-simple