### PR TITLE
Allow aeson 2.3

### DIFF
--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -35,7 +35,7 @@ library
 
   ghc-options:        -Wall -Wcompat
   build-depends:
-      aeson                  >=2.2    && <2.3
+      aeson                  >=2.2    && <2.4
     , base                   >= 4.16.4.0 && < 4.22
     , base-compat-batteries  >=0.12   && <0.15
     , bytestring             >=0.11   && <0.13

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -151,7 +151,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , aeson             >=2.2      && <2.3
+    , aeson             >=2.2      && <2.4
     , attoparsec        >=0.14.4   && <0.15
     , bifunctors        >=5.6.3    && <5.7
     , case-insensitive  >=1.2.1.0  && <1.3


### PR DESCRIPTION
https://hackage.haskell.org/package/aeson-2.3.0.0/changelog
https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html

Successfully built with

    cabal build all \
      --constraint=aeson==2.3.0.0 \
      --allow-newer=postgresql-simple:aeson \
      --allow-newer=http-api-data:text-iso8601 \
      --allow-newer=swagger2:aeson \
      --allow-newer=insert-ordered-containers:aeson \
      --allow-newer=aeson-pretty:aeson \
      --allow-newer=http-streams:aeson

and tested with the same flags.