### PR TITLE
Allow doctest-0.25

### DIFF
--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -51,7 +51,7 @@ test-suite doctests
   build-depends:
     base,
     servant-auth-docs,
-    doctest             >= 0.16   && < 0.25,
+    doctest             >= 0.24   && < 0.26,
     QuickCheck          >= 2.18   && < 2.19,
     template-haskell
   ghc-options:         -Wall -threaded

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -92,7 +92,7 @@ test-suite doctests
   build-depends:
     base < 5,
     directory >= 1.0,
-    doctest >= 0.17 && <0.25,
+    doctest >= 0.24 && <0.26,
     servant,
     QuickCheck,
     filepath


### PR DESCRIPTION
Fixes #1890.

Tested using

     cabal test -c 'doctest>=0.25' servant-auth-docs:doctests servant-swagger:doctests


Note that this also raises the lower bound.