### PR TITLE
Support GHC-9.14 for libs and most cookbooks

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,29 +31,32 @@ packages:
 -- Cookbooks
 packages:
   doc/cookbook/basic-auth
+  doc/cookbook/basic-streaming
   doc/cookbook/curl-mock
   doc/cookbook/custom-errors
-  doc/cookbook/basic-streaming
-  doc/cookbook/db-postgres-pool
   doc/cookbook/db-sqlite-simple
+  doc/cookbook/expose-prometheus
   doc/cookbook/file-upload
-  doc/cookbook/named-routes
   doc/cookbook/hoist-server-with-context
   doc/cookbook/https
+  doc/cookbook/infinite-streams
   doc/cookbook/jwt-and-basic-auth
+  doc/cookbook/managed-resource
+  doc/cookbook/named-routes
+  -- doc/cookbook/open-id-connect -- Bitrotted since 2019
+  doc/cookbook/openapi3
   doc/cookbook/pagination
-  -- doc/cookbook/sentry
-  -- Commented out because servant-quickcheck currently doesn't build.
-  -- doc/cookbook/testing
-  doc/cookbook/uverb
+  doc/cookbook/sentry
   doc/cookbook/structuring-apis
+  doc/cookbook/testing
   doc/cookbook/using-custom-monad
   doc/cookbook/using-free-client
-  -- doc/cookbook/open-id-connect
-  doc/cookbook/managed-resource
-  doc/cookbook/infinite-streams
-  -- doc/cookbook/openapi3 -- Disabled until openapi3 starts accepting insert-ordered-containers-0.3
-  doc/cookbook/expose-prometheus
+  doc/cookbook/uverb
+
+if(impl(ghc<9.14.1))
+  packages:
+    -- Waiting for Oleg Grenrus
+    doc/cookbook/db-postgres-pool
 
 tests: True
 optimization: False
@@ -81,5 +84,13 @@ if(impl(ghc >= 9.6.1))
   package lzma
     flags: -pkgconfig
 
--- Allow QuickCheck-2.18
-allow-newer: swagger2:QuickCheck
+if(impl(ghc >= 9.14.1))
+  allow-newer: servant-js:base
+
+  -- Waiting for Oleg Grenrus
+  allow-newer: file-embed-lzma:base
+  allow-newer: file-embed-lzma:template-haskell
+  allow-newer: lzma:base
+
+  -- https://github.com/Gabriella439/Haskell-Pipes-Safe-Library/issues/71
+  allow-newer: pipes-safe:base

--- a/doc/cookbook/testing/Testing.lhs
+++ b/doc/cookbook/testing/Testing.lhs
@@ -49,6 +49,7 @@ import           Control.Concurrent.MVar
 import           Control.Exception                (bracket)
 import           Control.Lens              hiding (Context)
 import           Data.Aeson
+import qualified Data.Aeson.KeyMap                as KeyMap
 import           Data.Aeson.Lens
 import qualified Data.HashMap.Strict              as HM
 import           Data.Text                        (Text, unpack)
@@ -318,8 +319,8 @@ getESDocument docId
   -- arbitrary things we can use in our tests to simulate failure:
   -- we want to trigger different code paths.
   | docId > 1000 = throwError err500
-  | docId > 500 = pure . Object $ HM.fromList [("bad", String "data")]
-  | otherwise = pure $ Object $ HM.fromList [("_source", Object $ HM.fromList [("a", String "b")])]
+  | docId > 500 = pure . Object $ KeyMap.fromList [("bad", String "data")]
+  | otherwise = pure $ Object $ KeyMap.fromList [("_source", Object $ KeyMap.fromList [("a", String "b")])]
 ```
 
 Now, we should be ready to write some tests.
@@ -356,7 +357,7 @@ thirdPartyResourcesSpec = around_ withElasticsearch $ do
 bodyMatcher :: [Network.HTTP.Types.Header] -> Body -> Maybe String
 bodyMatcher _ body = case (decode body :: Maybe Value) of
   -- success in this case means we return `Nothing`
-  Just val | val == (Object $ HM.fromList [("a", String "b")]) -> Nothing
+  Just val | val == (Object $ KeyMap.fromList [("a", String "b")]) -> Nothing
   _ -> Just "This is how we represent failure: this message will be printed"
 ```
 

--- a/doc/cookbook/testing/testing.cabal
+++ b/doc/cookbook/testing/testing.cabal
@@ -33,5 +33,5 @@ executable cookbook-testing
                      , wai >= 3.2
                      , wai-extra
   default-language:    Haskell2010
-  ghc-options:         -Wall -pgmL markdown-unlit
+  ghc-options:         -Wall -threaded -pgmL markdown-unlit
   build-tool-depends:  markdown-unlit:markdown-unlit

--- a/doc/tutorial/tutorial.cabal
+++ b/doc/tutorial/tutorial.cabal
@@ -64,7 +64,7 @@ library
     , lucid        >= 2.9.11  && < 2.12
     , random       >= 1.1     && < 1.4
     , servant-js   >= 0.9     && < 0.10
-    , time         >= 1.11    && < 1.15
+    , time         >= 1.11    && < 1.16
 
   -- For legacy tools, we need to specify build-depends too
   build-depends: markdown-unlit >= 0.5.0 && <0.7

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -16,7 +16,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
@@ -31,7 +31,7 @@ library
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                >= 4.16.4.0 && < 4.22
+      base                >= 4.16.4.0 && < 4.23
     , bytestring          >= 0.11     && < 0.13
     , containers          >=0.6.5.1  && < 0.9
     , servant-auth        == 0.4.10.0
@@ -70,7 +70,7 @@ test-suite spec
     , http-types           >= 0.12.4   && < 0.13
     , servant-auth-server  >= 0.4.2.0  && < 0.5
     , servant-server       >= 0.20.2   && < 0.21
-    , time                 >= 1.11     && < 1.15
+    , time                 >= 1.11     && < 1.16
     , transformers         >= 0.5.6.2  && < 0.7
     , wai                  >= 3.2.1.2  && < 3.3
     , warp                 >= 3.4.9    && < 3.5

--- a/servant-auth/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth/servant-auth-docs/servant-auth-docs.cabal
@@ -16,14 +16,14 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 build-type:     Custom
 extra-source-files:
     CHANGELOG.md
 
 custom-setup
   setup-depends:
-    base >= 4.16.4.0 && < 4.22,
+    base >= 4.16.4.0 && < 4.23,
     Cabal < 4, cabal-doctest >=1.0.6 && <1.1
 
 source-repository head
@@ -36,7 +36,7 @@ library
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base         >= 4.16.4.0 && < 4.22
+      base         >= 4.16.4.0 && < 4.23
     , servant-docs >= 0.13.1  && < 0.14
     , servant      >= 0.20.2  && < 0.21
     , servant-auth >= 0.4.2.0 && < 0.5

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -16,7 +16,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
@@ -31,7 +31,7 @@ library
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                    >= 4.16.4.0 && < 4.22
+      base                    >= 4.16.4.0 && < 4.23
     , aeson                   >= 2.2      && < 3
     , base64-bytestring       >= 1.2      && < 2
     , blaze-builder           >= 0.4.4.1  && < 0.5
@@ -50,7 +50,7 @@ library
     , servant-server          >= 0.20.3   && < 0.21
     , tagged                  >= 0.8.4    && < 0.9
     , text                    >= 1.2.3.0  && < 2.2
-    , time                    >= 1.11     && < 1.15
+    , time                    >= 1.11     && < 1.16
     , unordered-containers    >= 0.2.21   && < 0.3
     , wai                     >= 3.2.1.2  && < 3.3
 

--- a/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth/servant-auth-swagger/servant-auth-swagger.cabal
@@ -16,7 +16,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 build-type:     Simple
 extra-source-files:
     CHANGELOG.md
@@ -31,7 +31,7 @@ library
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base            >= 4.16.4.0 && < 4.22
+      base            >= 4.16.4.0 && < 4.23
     , text            >= 1.2.3.0 && < 2.2
     , servant-swagger >= 1.2.1   && < 2
     , swagger2        >= 2.2.2   && < 3

--- a/servant-auth/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth/servant-auth.cabal
@@ -18,7 +18,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:    GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
@@ -33,7 +33,7 @@ library
   default-extensions: ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                    >= 4.16.4.0 && < 4.22
+      base                    >= 4.16.4.0 && < 4.23
     , containers              >=0.6.5.1   && < 0.9
     , aeson                   >= 2.0      && < 3
     , jose                    >= 0.11     && < 0.14

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -19,7 +19,7 @@ copyright:
   2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 
 build-type:         Simple
-tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -104,12 +104,12 @@ library
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
     , attoparsec        >= 0.14.4   && < 0.15
-    , base              >= 4.16.4.0 && < 4.22
+    , base              >= 4.16.4.0 && < 4.23
     , bytestring        >=0.11 && <0.13
     , constraints       >=0.14.4   && <0.15
     , containers        >=0.6.5.1  && <0.9
     , deepseq           >=1.4.6.1  && <1.6
-    , template-haskell  >=2.18     && <2.24
+    , template-haskell  >=2.18     && <2.25
     , text              >=1.2.3.0  && <2.2
 
   -- Servant dependencies

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -21,7 +21,7 @@ copyright:
   2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 
 build-type:         Simple
-tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -93,13 +93,13 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-    , base          >= 4.16.4.0 && < 4.22
+    , base          >= 4.16.4.0 && < 4.23
     , bytestring    >=0.11 && <0.13
     , containers    >=0.6.5.1  && <0.9
     , deepseq       >=1.4.6.1  && <1.6
     , mtl           ^>=2.2.2   || ^>=2.3.1
     , stm           >=2.4.5.1  && <2.6
-    , time          >=1.11     && <1.15
+    , time          >=1.11     && <1.16
     , transformers  >=0.5.2.0  && <0.7
 
   -- Servant dependencies.

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -28,7 +28,7 @@ source-repository head
 library
   exposed-modules:     Servant.Conduit
   build-depends:
-      base          >= 4.16.4.0 && < 4.22
+      base          >= 4.16.4.0 && < 4.23
     , conduit       >=1.3.1    && <1.4
     , resourcet     >=1.2.2    && <1.4
     , servant       >=0.20.2   && <0.21

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -19,7 +19,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -41,7 +41,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base       >= 4.16.4.0 && < 4.22
+      base       >= 4.16.4.0 && < 4.23
     , bytestring >= 0.11 && < 0.13
     , text       >= 1.2.3.0  && < 2.2
 

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -21,7 +21,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2015-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -41,7 +41,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-      base        >= 4.16.4.0 && < 4.22
+      base        >= 4.16.4.0 && < 4.23
     , text        >= 1.2.3.0 && < 2.2
 
   -- Servant dependencies

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -20,7 +20,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -38,7 +38,7 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base                  >= 4.16.4.0 && < 4.22
+      base                  >= 4.16.4.0 && < 4.23
     , bytestring            >= 0.11 && < 0.13
     , containers            >= 0.6.5.1  && < 0.9
     , deepseq               >= 1.4.6.1  && < 1.6

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -28,7 +28,7 @@ source-repository head
 library
   exposed-modules:     Servant.Machines
   build-depends:
-      base          >= 4.16.4.0 && < 4.22
+      base          >= 4.16.4.0 && < 4.23
     , machines      >=0.6.4    && <0.8
     , servant       >=0.20.2   && <0.21
   hs-source-dirs:      src

--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -68,7 +68,7 @@ library
   hs-source-dirs:      src
   build-depends:       aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && <2.4
                      , aeson-pretty              >=0.8.7    && <0.9
-                     , base                      >=4.9.1.0  && <4.22
+                     , base                      >=4.9.1.0  && <4.23
                      , base-compat               >=0.10.5   && <0.15
                      , bytestring                >=0.10.8.1 && <0.13
                      , http-media                >=0.7.1.3  && <0.9

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -16,7 +16,7 @@ author:              Servant Contributors
 maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2018-2019 Servant Contributors
 build-type:          Simple
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -28,7 +28,7 @@ source-repository head
 library
   exposed-modules:     Servant.Pipes
   build-depends:
-      base          >= 4.16.4.0 && < 4.22
+      base          >= 4.16.4.0 && < 4.23
     , bytestring    >=0.11 && <0.13
     , pipes         >=4.3.9    && <4.4
     , pipes-safe    >=2.3.1    && <2.4

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -12,7 +12,7 @@ maintainer:         haskell-servant-maintainers@googlegroups.com
 category:           Web
 build-type:         Simple
 extra-source-files: CHANGELOG.yaml
-tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 source-repository head
   type:     git
@@ -36,7 +36,7 @@ library
   ghc-options:        -Wall -Wcompat
   build-depends:
       aeson                  >=2.2    && <2.4
-    , base                   >= 4.16.4.0 && < 4.22
+    , base                   >= 4.16.4.0 && < 4.23
     , base-compat-batteries  >=0.12   && <0.15
     , bytestring             >=0.11   && <0.13
     , case-insensitive       >=1.2    && <1.3
@@ -52,7 +52,7 @@ library
     , servant-server         >=0.20.2 && <0.21
     , split                  >=0.2    && <0.3
     , text                   >=1.2    && <2.2
-    , time                   >=1.11   && <1.15
+    , time                   >=1.11   && <1.16
     , warp                   >=3.4.9  && <3.5
 
   hs-source-dirs:     src

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -26,7 +26,7 @@ copyright:
   2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 
 build-type:         Simple
-tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
   CHANGELOG.md
@@ -115,7 +115,7 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-    , base          >= 4.16.4.0 && < 4.22
+    , base          >= 4.16.4.0 && < 4.23
     , bytestring    >=0.11 && <0.13
     , constraints   >=0.14.4   && <0.15
     , containers    >=0.6.5.1  && <0.9

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -28,7 +28,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           (c) 2015-2018, Servant contributors
 category:            Web, Servant, Swagger
 build-type:          Custom
-tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files:
     README.md
@@ -49,7 +49,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-    base  >= 4.16.4.0 && < 4.22,
+    base  >= 4.16.4.0 && < 4.23,
     Cabal >= 3.6.3 && <4,
     cabal-doctest >=1.0.6 && <1.1
 
@@ -71,15 +71,14 @@ library
   hs-source-dirs:      src
   build-depends:       aeson                     >=2.2     && <3
                      , aeson-pretty              >=0.8.7    && <0.9
-                     , base                      >= 4.16.4.0 && < 4.22
+                     , base                      >= 4.16.4.0 && < 4.23
                      , base-compat               >=0.12     && <0.15
                      , bytestring                >=0.11 && <0.13
                      , http-media                >=0.8      && <0.9
-                     , insert-ordered-containers >=0.3      && <0.4
                      , lens                      >=5.3      && <6
                      , servant                   >=0.20.3   && <0.21
                      , singleton-bool            >=0.1.8    && <0.2
-                     , swagger2                  >=2.9      && <2.10
+                     , swagger2                  >=2.9.1    && <2.10
                      , text                      >=1.2.3.0  && <2.2
                      , unordered-containers      >=0.2.21   && <0.3
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -20,7 +20,7 @@ copyright:
   2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
 
 build-type:         Simple
-tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:        GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 
 extra-source-files: CHANGELOG.md
 
@@ -134,7 +134,7 @@ library
   --
   -- note: mtl lower bound is so low because of GHC-7.8
   build-depends:
-    , base          >= 4.16.4.0 && <4.22
+    , base          >= 4.16.4.0 && <4.23
     , bytestring    >=0.11 && <0.13
     , constraints   >=0.14.4
     , containers    >=0.6.5.1  && <0.9


### PR DESCRIPTION
Most packages seem compatible with GHC-9.14. Let's start verifying this in CI.

I will make Hackage revisions after merging this.

Adds references to:

* Gabriella439/Haskell-Pipes-Safe-Library#71
