### PR TITLE
Fix static routing of explicitly empty segments

### DIFF
--- a/changelog.d/pr-1905
+++ b/changelog.d/pr-1905
@@ -1,0 +1,8 @@
+synopsis: Fix routing of explicitly-empty segments
+packages: servant-server
+prs: #1905
+issues:
+description: {
+Changed the StaticRouter code to honor explicit `"" :> ...` segments when they are present. Routes that do not use `"" :> ...` are unchanged.
+}
+

--- a/servant-server/src/Servant/Server/Internal/Router.hs
+++ b/servant-server/src/Servant/Server/Internal/Router.hs
@@ -184,8 +184,11 @@ runRouterEnv fmt router env request respond =
     StaticRouter table ls ->
       case pathInfo request of
         [] -> runChoice fmt ls env request respond
-        -- This case is to handle trailing slashes.
-        [""] -> runChoice fmt ls env request respond
+        -- This case is to handle trailing slashes, but only when they are
+        -- /explicitly not/ present in the routing table.
+        [""]
+          | Nothing <- M.lookup "" table ->
+              runChoice fmt ls env request respond
         first : rest
           | Just router' <- M.lookup first table ->
               let request' = request{pathInfo = rest}


### PR DESCRIPTION
The route `"hello" :> "" :> "world"` ought to explicitly match `hello//world`, but instead it matches `hello/world`. This PR changes the routing code slightly to support explicitly empty segments when they are present in the routing table, keeping the previous behavior if not.