### PR TITLE
servant-openapi3: Raise lower bounds, remove unused deps

### DIFF
--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -51,7 +51,7 @@ source-repository head
   subdir:   servant-openapi3
 
 library
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Wunused-packages
   exposed-modules:
     Servant.OpenApi
     Servant.OpenApi.Test
@@ -66,49 +66,38 @@ library
     Servant.OpenApi.Internal.TypeLevel.Every
     Servant.OpenApi.Internal.TypeLevel.TMap
   hs-source-dirs:      src
-  build-depends:       aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && <2.4
-                     , aeson-pretty              >=0.8.7    && <0.9
-                     , base                      >=4.9.1.0  && <4.23
-                     , base-compat               >=0.10.5   && <0.15
-                     , bytestring                >=0.10.8.1 && <0.13
+  build-depends:       aeson                     >=2.2      && <2.4
+                     , aeson-pretty              >=0.8.9    && <0.9
+                     , base                      >=4.16.4   && <4.23
+                     , base-compat               >=0.12     && <0.15
+                     , bytestring                >=0.11     && <0.13
                      , http-media                >=0.7.1.3  && <0.9
-                     , insert-ordered-containers >=0.3      && <0.4
-                     , lens                      >=4.17     && <5.4
-                     , servant                   >=0.17     && <0.21
-                     , servant-server            >=0.17     && <0.21
-                     , servant-client-core       >=0.17     && <0.21
-                     , singleton-bool            >=0.1.4    && <0.2
+                     , lens                      >=5.3.6    && <5.4
+                     , servant                   >=0.20.3   && <0.21
+                     , servant-server            >=0.20.3   && <0.21
+                     , singleton-bool            >=0.1.6    && <0.2
                      , openapi3                  >=3.2.5    && <3.3
-                     , text                      >=1.2.3.0  && <3
-                     , unordered-containers      >=0.2.9.0  && <0.3
-                     , generics-sop              >=0.5.1    && <0.6
+                     , text                      >=1.2.5.0  && <3
 
-                     , hspec                     >=2.6.0    && <2.12
+                     , hspec                     >=2.11     && <2.12
                      , QuickCheck                >=2.18     && <2.19
   default-language:    Haskell2010
 
 test-suite spec
-  ghc-options:      -Wall
+  ghc-options:      -Wall -Wunused-packages
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.12
-  build-depends:    base <5
-                  , base-compat
+  build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12
+  build-depends:    base
                   , aeson
-                  , hspec >=2.6.0 && <2.12
-                  , QuickCheck
+                  , hspec
                   , lens
-                  , lens-aeson >=1.0.2    && <1.3
                   , servant
                   , servant-openapi3
-                    -- openapi3 3.1.0 fixes some ordering-related issues, making tests stable
-                  , openapi3 >= 3.1.0
+                  , openapi3
                   , text
-                  , template-haskell
-                  , utf8-string >=1.0.1.1 && <1.1
                   , time
-                  , vector
   other-modules:
     Servant.OpenApiSpec
   default-language: Haskell2010


### PR DESCRIPTION
Before making the next release (which is necessary for GHC 9.14 compat, because openapi3-3.2.5 has breaking changes), let us clean up bounds.
