### PR TITLE
openapi3 compat with servant-0.20.3

### DIFF
--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -24,6 +24,7 @@ import Data.Foldable (toList)
 import Data.HashMap.Strict.InsOrd.Compat (InsOrdHashMap)
 import qualified Data.HashMap.Strict.InsOrd.Compat as InsOrdHashMap
 import Data.Kind (Type)
+import qualified Data.Maybe as List
 import Data.OpenApi hiding (Header, contentType)
 import qualified Data.OpenApi as OpenApi
 import Data.OpenApi.Declare
@@ -39,12 +40,11 @@ import Servant.API
 import Servant.API.ContentTypes (AllMime, allMime)
 import Servant.API.Description (FoldDescription, reflectDescription)
 import Servant.API.Modifiers (FoldRequired)
+import Servant.API.MultiVerb
+import qualified Servant.Server.Internal.ResponseRender as Server
 import Prelude ()
 
 import Servant.OpenApi.Internal.TypeLevel.API
-import qualified Servant.Server.Internal.ResponseRender as Server
-import           Servant.API.MultiVerb
-import qualified Data.Maybe as List
 
 -- | Generate a OpenApi specification for a servant API.
 --
@@ -225,13 +225,13 @@ instance HasOpenApi (UVerb method cs '[]) where
 -- | @since <2.0.1.0>
 instance
   {-# OVERLAPPABLE #-}
-  ( ToSchema a,
-    HasStatus a,
-    AllAccept cs,
-    OpenApiMethod method,
-    HasOpenApi (UVerb method cs as)
-  ) =>
-  HasOpenApi (UVerb method cs (a ': as))
+  ( AllAccept cs
+  , HasOpenApi (UVerb method cs as)
+  , HasStatus a
+  , OpenApiMethod method
+  , ToSchema a
+  )
+  => HasOpenApi (UVerb method cs (a ': as))
   where
   toOpenApi _ =
     toOpenApi (Proxy :: Proxy (Verb method (StatusOf a) cs a))
@@ -239,34 +239,36 @@ instance
     where
       -- workaround for https://github.com/GetShopTV/swagger2/issues/218
       combinePathItem :: PathItem -> PathItem -> PathItem
-      combinePathItem s t = PathItem
-        { _pathItemGet = _pathItemGet s <> _pathItemGet t
-        , _pathItemPut = _pathItemPut s <> _pathItemPut t
-        , _pathItemPost = _pathItemPost s <> _pathItemPost t
-        , _pathItemDelete = _pathItemDelete s <> _pathItemDelete t
-        , _pathItemOptions = _pathItemOptions s <> _pathItemOptions t
-        , _pathItemHead = _pathItemHead s <> _pathItemHead t
-        , _pathItemPatch = _pathItemPatch s <> _pathItemPatch t
-        , _pathItemTrace = _pathItemTrace s <> _pathItemTrace t
-        , _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
-        , _pathItemSummary = _pathItemSummary s <|> _pathItemSummary t
-        , _pathItemDescription = _pathItemDescription s <|> _pathItemDescription t
-        , _pathItemServers = _pathItemServers s <> _pathItemServers t
-        }
+      combinePathItem s t =
+        PathItem
+          { _pathItemGet = _pathItemGet s <> _pathItemGet t
+          , _pathItemPut = _pathItemPut s <> _pathItemPut t
+          , _pathItemPost = _pathItemPost s <> _pathItemPost t
+          , _pathItemDelete = _pathItemDelete s <> _pathItemDelete t
+          , _pathItemOptions = _pathItemOptions s <> _pathItemOptions t
+          , _pathItemHead = _pathItemHead s <> _pathItemHead t
+          , _pathItemPatch = _pathItemPatch s <> _pathItemPatch t
+          , _pathItemTrace = _pathItemTrace s <> _pathItemTrace t
+          , _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
+          , _pathItemSummary = _pathItemSummary s <|> _pathItemSummary t
+          , _pathItemDescription = _pathItemDescription s <|> _pathItemDescription t
+          , _pathItemServers = _pathItemServers s <> _pathItemServers t
+          }
 
       combineSwagger :: OpenApi -> OpenApi -> OpenApi
-      combineSwagger s t = OpenApi
-        { _openApiOpenapi = _openApiOpenapi s <> _openApiOpenapi t
-        , _openApiInfo = _openApiInfo s <> _openApiInfo t
-        , _openApiServers = _openApiServers s <> _openApiServers t
-        , _openApiPaths = InsOrdHashMap.unionWith combinePathItem (_openApiPaths s) (_openApiPaths t)
-        , _openApiComponents = _openApiComponents s <> _openApiComponents t
-        , _openApiSecurity = _openApiSecurity s <> _openApiSecurity t
-        , _openApiTags = _openApiTags s <> _openApiTags t
-        , _openApiExternalDocs = _openApiExternalDocs s <|> _openApiExternalDocs t
-        }
+      combineSwagger s t =
+        OpenApi
+          { _openApiOpenapi = _openApiOpenapi s <> _openApiOpenapi t
+          , _openApiInfo = _openApiInfo s <> _openApiInfo t
+          , _openApiServers = _openApiServers s <> _openApiServers t
+          , _openApiPaths = InsOrdHashMap.unionWith combinePathItem (_openApiPaths s) (_openApiPaths t)
+          , _openApiComponents = _openApiComponents s <> _openApiComponents t
+          , _openApiSecurity = _openApiSecurity s <> _openApiSecurity t
+          , _openApiTags = _openApiTags s <> _openApiTags t
+          , _openApiExternalDocs = _openApiExternalDocs s <|> _openApiExternalDocs t
+          }
 
-instance (Typeable (WithStatus s a), ToSchema a) => ToSchema (WithStatus s a) where
+instance (ToSchema a, Typeable (WithStatus s a)) => ToSchema (WithStatus s a) where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
 
 instance {-# OVERLAPPABLE #-} (AllAccept cs, KnownNat status, OpenApiMethod method, ToSchema a) => HasOpenApi (Verb method status cs a) where
@@ -319,7 +321,7 @@ instance HasOpenApi sub => HasOpenApi (HttpVersion :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
 
 -- | @'WithResource'@ combinator does not change our specification at all.
-instance (HasOpenApi sub) => HasOpenApi (WithResource res :> sub) where
+instance HasOpenApi sub => HasOpenApi (WithResource res :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
 
 -- | @'WithNamedContext'@ combinator does not change our specification at all.
@@ -477,10 +479,10 @@ instance (Accept ct, HasOpenApi sub, KnownSymbol (FoldDescription mods), ToSchem
           & description .~ transDesc (reflectDescription (Proxy :: Proxy mods))
           & content .~ InsOrdHashMap.fromList [(t, mempty & schema ?~ ref) | t <- toList $ contentTypes (Proxy :: Proxy ct)]
 
-instance (HasOpenApi sub) => HasOpenApi (Fragment a :> sub) where
+instance HasOpenApi sub => HasOpenApi (Fragment a :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
 
-instance (HasOpenApi (ToServantApi sub)) => HasOpenApi (NamedRoutes sub) where
+instance HasOpenApi (ToServantApi sub) => HasOpenApi (NamedRoutes sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy (ToServantApi sub))
 
 -- =======================================================================
@@ -526,15 +528,15 @@ class IsSwaggerResponse a where
   responseSwagger :: DeclareDefinition Response
 
 instance
-  (AllToResponseHeader hs, IsSwaggerResponse r) =>
-  IsSwaggerResponse (WithHeaders hs a r)
+  (AllToResponseHeader hs, IsSwaggerResponse r)
+  => IsSwaggerResponse (WithHeaders hs a r)
   where
   responseSwagger =
     fmap
       (headers .~ fmap Inline (toAllResponseHeaders (Proxy @hs)))
       (responseSwagger @r)
 
-simpleResponseSwagger :: forall a cs desc. (ToSchema a, KnownSymbol desc, AllMime cs) => DeclareDefinition Response
+simpleResponseSwagger :: forall a cs desc. (AllMime cs, KnownSymbol desc, ToSchema a) => DeclareDefinition Response
 simpleResponseSwagger = do
   ref <- declareSchemaRef (Proxy @a)
   let resps :: InsOrdHashMap MediaType MediaTypeObject
@@ -548,21 +550,21 @@ simpleResponseSwagger = do
     cs = allMime $ Proxy @cs
 
 instance
-  (KnownSymbol desc, ToSchema a) =>
-  IsSwaggerResponse (Respond s desc a)
+  (KnownSymbol desc, ToSchema a)
+  => IsSwaggerResponse (Respond s desc a)
   where
   -- Defaulting this to JSON, as openapi3 needs something to map a schema against.
   responseSwagger = simpleResponseSwagger @a @'[JSON] @desc
 
 instance
-  (KnownSymbol desc, ToSchema a, Accept ct) =>
-  IsSwaggerResponse (RespondAs (ct :: Type) s desc a)
+  (Accept ct, KnownSymbol desc, ToSchema a)
+  => IsSwaggerResponse (RespondAs (ct :: Type) s desc a)
   where
   responseSwagger = simpleResponseSwagger @a @'[ct] @desc
 
 instance
-  (KnownSymbol desc) =>
-  IsSwaggerResponse (RespondEmpty s desc)
+  KnownSymbol desc
+  => IsSwaggerResponse (RespondEmpty s desc)
   where
   responseSwagger =
     pure $
@@ -576,11 +578,11 @@ instance IsSwaggerResponseList '[] where
   responseListSwagger = pure mempty
 
 instance
-  ( IsSwaggerResponse a,
-    KnownNat (Server.ResponseStatus a),
-    IsSwaggerResponseList as
-  ) =>
-  IsSwaggerResponseList (a ': as)
+  ( IsSwaggerResponse a
+  , IsSwaggerResponseList as
+  , KnownNat (Server.ResponseStatus a)
+  )
+  => IsSwaggerResponseList (a ': as)
   where
   responseListSwagger =
     InsOrdHashMap.insertWith
@@ -616,8 +618,8 @@ combineSwaggerSchema s1 s2
   | otherwise = s1
 
 instance
-  (OpenApiMethod method, IsSwaggerResponseList as) =>
-  HasOpenApi (MultiVerb method '() as r)
+  (IsSwaggerResponseList as, OpenApiMethod method)
+  => HasOpenApi (MultiVerb method '() as r)
   where
   toOpenApi _ =
     mempty
@@ -636,8 +638,8 @@ instance
       refResps = Inline <$> resps
 
 instance
-  (OpenApiMethod method, IsSwaggerResponseList as, AllMime cs) =>
-  HasOpenApi (MultiVerb method (cs :: [Type]) as r)
+  (AllMime cs, IsSwaggerResponseList as, OpenApiMethod method)
+  => HasOpenApi (MultiVerb method (cs :: [Type]) as r)
   where
   toOpenApi _ =
     mempty

--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -42,10 +42,8 @@ import Servant.API.Modifiers (FoldRequired)
 import Prelude ()
 
 import Servant.OpenApi.Internal.TypeLevel.API
-#if MIN_VERSION_servant(0,20,3)
 import qualified Servant.Server.Internal.ResponseRender as Server
 import           Servant.API.MultiVerb
-#endif
 import qualified Data.Maybe as List
 
 -- | Generate a OpenApi specification for a servant API.
@@ -221,7 +219,6 @@ instance OpenApiMethod 'OPTIONS where openApiMethod _ = options
 instance OpenApiMethod 'HEAD where openApiMethod _ = head_
 instance OpenApiMethod 'PATCH where openApiMethod _ = patch
 
-#if MIN_VERSION_servant(0,18,1)
 instance HasOpenApi (UVerb method cs '[]) where
   toOpenApi _ = mempty
 
@@ -271,7 +268,6 @@ instance
 
 instance (Typeable (WithStatus s a), ToSchema a) => ToSchema (WithStatus s a) where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
-#endif
 
 instance {-# OVERLAPPABLE #-} (AllAccept cs, KnownNat status, OpenApiMethod method, ToSchema a) => HasOpenApi (Verb method status cs a) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy (Verb method status cs (Headers '[] a)))
@@ -322,11 +318,9 @@ instance HasOpenApi sub => HasOpenApi (RemoteHost :> sub) where
 instance HasOpenApi sub => HasOpenApi (HttpVersion :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
 
-#if MIN_VERSION_servant(0,20,0)
 -- | @'WithResource'@ combinator does not change our specification at all.
 instance (HasOpenApi sub) => HasOpenApi (WithResource res :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
-#endif
 
 -- | @'WithNamedContext'@ combinator does not change our specification at all.
 instance HasOpenApi sub => HasOpenApi (WithNamedContext x c sub) where
@@ -371,10 +365,12 @@ instance (HasOpenApi api, KnownSymbol desc) => HasOpenApi (Summary desc :> api) 
     toOpenApi (Proxy :: Proxy api)
       & allOperations . summary %~ (Just (Text.pack (symbolVal (Proxy :: Proxy desc))) <>)
 
+#if MIN_VERSION_servant(0,20,4)
 instance (HasOpenApi api, KnownSymbol operationId) => HasOpenApi (OperationId operationId :> api) where
   toOpenApi _ =
     toOpenApi (Proxy :: Proxy api)
       & allOperations . operationId %~ (Just (Text.pack (symbolVal (Proxy :: Proxy operationId))) <>)
+#endif
 
 instance (HasOpenApi sub, KnownSymbol (FoldDescription mods), KnownSymbol sym, SBoolI (FoldRequired mods), ToParamSchema a) => HasOpenApi (QueryParam' mods sym a :> sub) where
   toOpenApi _ =
@@ -481,15 +477,11 @@ instance (Accept ct, HasOpenApi sub, KnownSymbol (FoldDescription mods), ToSchem
           & description .~ transDesc (reflectDescription (Proxy :: Proxy mods))
           & content .~ InsOrdHashMap.fromList [(t, mempty & schema ?~ ref) | t <- toList $ contentTypes (Proxy :: Proxy ct)]
 
-#if MIN_VERSION_servant(0,18,2)
 instance (HasOpenApi sub) => HasOpenApi (Fragment a :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
-#endif
 
-#if MIN_VERSION_servant(0,19,0)
 instance (HasOpenApi (ToServantApi sub)) => HasOpenApi (NamedRoutes sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy (ToServantApi sub))
-#endif
 
 -- =======================================================================
 -- Below are the definitions that should be in Servant.API.ContentTypes
@@ -528,7 +520,6 @@ instance (AllToResponseHeader hs, ToResponseHeader h) => AllToResponseHeader (h 
 instance AllToResponseHeader hs => AllToResponseHeader (HList hs) where
   toAllResponseHeaders _ = toAllResponseHeaders (Proxy :: Proxy hs)
 
-#if MIN_VERSION_servant(0,20,3)
 type DeclareDefinition = Declare (Definitions Schema)
 
 class IsSwaggerResponse a where
@@ -680,4 +671,3 @@ instance
               . List.listToMaybe
               . toList
       refResps = Inline . addMime <$> resps
-#endif

--- a/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -14,20 +14,13 @@ module Servant.OpenApi.Internal.TypeLevel.API where
 
 import           GHC.Exts            (Constraint)
 import           Servant.API
-#if MIN_VERSION_servant(0,19,0)
 import           Servant.API.Generic (ToServantApi)
-#endif
-#if MIN_VERSION_servant(0,20,3)
-import Servant.API.MultiVerb (MultiVerb, Respond, RespondAs, RespondStreaming, WithHeaders, GenericAsConstructor)
 import Data.ByteString (ByteString)
-#endif
 -- | Build a list of endpoints from an API.
 type family EndpointsList api where
   EndpointsList (a :<|> b) = AppendList (EndpointsList a) (EndpointsList b)
   EndpointsList (e :> a)   = MapSub e (EndpointsList a)
-#if MIN_VERSION_servant(0,19,0)
   EndpointsList (NamedRoutes api) = EndpointsList (ToServantApi api)
-#endif
   EndpointsList a = '[a]
 
 -- | Check whether @sub@ is a sub API of @api@.
@@ -56,9 +49,7 @@ type family Or (a :: Constraint) (b :: Constraint) :: Constraint where
 type family IsIn sub api :: Constraint where
   IsIn e (a :<|> b) = Or (IsIn e a) (IsIn e b)
   IsIn (e :> a) (e :> b) = IsIn a b
-#if MIN_VERSION_servant(0,19,0)
   IsIn e (NamedRoutes api) = IsIn e (ToServantApi api)
-#endif
   IsIn e e = ()
 
 -- | Check whether a type is a member of a list of types.
@@ -96,19 +87,17 @@ type family BodyTypes' c api :: [*] where
   BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
   BodyTypes' c (Verb verb b cs NoContent) = '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]
-#if MIN_VERSION_servant(0,20,3)
+#if MIN_VERSION_servant(0,20,4)
   BodyTypes' c (MultiVerb verb cs as _) = AddBodyType c cs () (MultiVerbResponseBodies as)
 #endif
   BodyTypes' c (ReqBody' mods cs a :> api) = AddBodyType c cs a (BodyTypes' c api)
   BodyTypes' c (e :> api) = BodyTypes' c api
   BodyTypes' c (a :<|> b) = AppendList (BodyTypes' c a) (BodyTypes' c b)
-#if MIN_VERSION_servant(0,19,0)
   BodyTypes' c (NamedRoutes api) = BodyTypes' c (ToServantApi api)
-#endif
   BodyTypes' c api = '[]
 
 
-#if MIN_VERSION_servant(0,20,3)
+#if MIN_VERSION_servant(0,20,4)
 -- | The 'ResponseTypes' class allows to extract all types
 -- involved in a response, whether or not this type is
 -- in the body of the response, or, for example, in a header.

--- a/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
@@ -6,20 +5,18 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- The type families below use CPP inside their equation lists, which fourmolu
--- cannot parse.
-{- FOURMOLU_DISABLE -}
-
 module Servant.OpenApi.Internal.TypeLevel.API where
 
-import           GHC.Exts            (Constraint)
-import           Servant.API
-import           Servant.API.Generic (ToServantApi)
 import Data.ByteString (ByteString)
+import GHC.Exts (Constraint)
+import Servant.API
+import Servant.API.Generic (ToServantApi)
+import Servant.API.MultiVerb (GenericAsConstructor, MultiVerb, Respond, RespondAs, RespondStreaming, WithHeaders)
+
 -- | Build a list of endpoints from an API.
 type family EndpointsList api where
   EndpointsList (a :<|> b) = AppendList (EndpointsList a) (EndpointsList b)
-  EndpointsList (e :> a)   = MapSub e (EndpointsList a)
+  EndpointsList (e :> a) = MapSub e (EndpointsList a)
   EndpointsList (NamedRoutes api) = EndpointsList (ToServantApi api)
   EndpointsList a = '[a]
 
@@ -39,7 +36,7 @@ type family MapSub e xs where
 
 -- | Append two type-level lists.
 type family AppendList xs ys where
-  AppendList '[]       ys = ys
+  AppendList '[] ys = ys
   AppendList (x ': xs) ys = x ': AppendList xs ys
 
 type family Or (a :: Constraint) (b :: Constraint) :: Constraint where
@@ -66,8 +63,8 @@ type family Nub xs where
 
 -- | Remove element from a type-level list.
 type family Remove x xs where
-  Remove x '[]       = '[]
-  Remove x (x ': ys) =      Remove x ys
+  Remove x '[] = '[]
+  Remove x (x ': ys) = Remove x ys
   Remove x (y ': ys) = y ': Remove x ys
 
 -- | Extract a list of unique "body" types for a specific content-type from a servant API.
@@ -87,17 +84,13 @@ type family BodyTypes' c api :: [*] where
   BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
   BodyTypes' c (Verb verb b cs NoContent) = '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]
-#if MIN_VERSION_servant(0,20,4)
   BodyTypes' c (MultiVerb verb cs as _) = AddBodyType c cs () (MultiVerbResponseBodies as)
-#endif
   BodyTypes' c (ReqBody' mods cs a :> api) = AddBodyType c cs a (BodyTypes' c api)
   BodyTypes' c (e :> api) = BodyTypes' c api
   BodyTypes' c (a :<|> b) = AppendList (BodyTypes' c a) (BodyTypes' c b)
   BodyTypes' c (NamedRoutes api) = BodyTypes' c (ToServantApi api)
   BodyTypes' c api = '[]
 
-
-#if MIN_VERSION_servant(0,20,4)
 -- | The 'ResponseTypes' class allows to extract all types
 -- involved in a response, whether or not this type is
 -- in the body of the response, or, for example, in a header.
@@ -116,6 +109,7 @@ type family MultiVerbResponseBody a
 type instance MultiVerbResponseBody (Respond s description a) = a
 type instance MultiVerbResponseBody (RespondAs contentType s description a) = a
 type instance MultiVerbResponseBody (RespondStreaming s description framing contentType) = SourceIO ByteString
+
 -- The following instance is the main difference between 'MultiVerbResponseBody' and 'ResponseType'
 type instance MultiVerbResponseBody (WithHeaders headers returnType response) = MultiVerbResponseBody response
 type instance MultiVerbResponseBody (GenericAsConstructor r) = MultiVerbResponseBody r
@@ -123,4 +117,3 @@ type instance MultiVerbResponseBody (GenericAsConstructor r) = MultiVerbResponse
 type family MultiVerbResponseBodies (as :: [*]) where
   MultiVerbResponseBodies '[] = '[]
   MultiVerbResponseBodies (a ': as) = MultiVerbResponseBody a ': MultiVerbResponseBodies as
-#endif

--- a/servant-openapi3/test/Servant/OpenApiSpec.hs
+++ b/servant-openapi3/test/Servant/OpenApiSpec.hs
@@ -6,9 +6,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeOperators #-}
-#if MIN_VERSION_servant(0,18,1)
 {-# LANGUAGE TypeFamilies       #-}
-#endif
 module Servant.OpenApiSpec where
 
 import Control.Lens
@@ -40,11 +38,11 @@ spec = describe "HasOpenApi" $ do
   it "Hackage API (with tags)" $ checkOpenApi hackageOpenApiWithTags hackageAPI
   it "GetPost API (test subOperations)" $ checkOpenApi getPostOpenApi getPostAPI
   it "Comprehensive API" $ do
+#if MIN_VERSION_servant(0,20,4)
     let _x = toOpenApi comprehensiveAPI
-    True `shouldBe` True -- type-level test
-#if MIN_VERSION_servant(0,18,1)
-  it "UVerb API" $ checkOpenApi uverbOpenApi uverbAPI
 #endif
+    True `shouldBe` True -- type-level test
+  it "UVerb API" $ checkOpenApi uverbOpenApi uverbAPI
 
 main :: IO ()
 main = hspec spec
@@ -441,8 +439,6 @@ getPostAPI =
 -- UVerb API
 -- =======================================================================
 
-#if MIN_VERSION_servant(0,18,1)
-
 data FisxUser = FisxUser {name :: String}
   deriving (Eq, Show, Generic)
 
@@ -537,5 +533,3 @@ uverbAPI = [aesonQQ|
   }
 }
 |]
-
-#endif

--- a/servant-openapi3/test/Servant/OpenApiSpec.hs
+++ b/servant-openapi3/test/Servant/OpenApiSpec.hs
@@ -10,7 +10,10 @@
 module Servant.OpenApiSpec where
 
 import Control.Lens
-import Data.Aeson (ToJSON (toJSON), Value, encode, genericToJSON)
+import Data.Aeson (ToJSON (toJSON), Value (Array, Object), encode, genericToJSON)
+import Data.Aeson.Key (Key)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.QQ.Simple
 import qualified Data.Aeson.Types as JSON
 import Data.Char (toLower)
@@ -26,11 +29,30 @@ import Test.Hspec hiding (example)
 
 import Servant.OpenApi
 
+-- | The key the generated content maps use for @JSON@. Taken from servant
+-- rather than hardcoded, because servant-0.20.4 dropped the @charset@ parameter
+-- from its @Accept JSON@ instance and older versions still carry it.
+-- <https://github.com/haskell-servant/servant/pull/1881>
+jsonMediaType :: Key
+jsonMediaType = Key.fromString (show (Servant.API.contentType (Proxy :: Proxy JSON)))
+
+-- | Restate a golden document in terms of 'jsonMediaType'. The goldens below are
+-- written as @application/json@, so this is a no-op unless the servant we are
+-- built against spells the media type differently.
+withJsonMediaType :: Value -> Value
+withJsonMediaType (Object o) = Object (KeyMap.mapKeyVal rename withJsonMediaType o)
+  where
+    rename k
+      | k == "application/json" = jsonMediaType
+      | otherwise = k
+withJsonMediaType (Array a) = Array (withJsonMediaType <$> a)
+withJsonMediaType v = v
+
 checkAPI :: HasCallStack => HasOpenApi api => Proxy api -> Value -> IO ()
 checkAPI proxy = checkOpenApi (toOpenApi proxy)
 
 checkOpenApi :: HasCallStack => OpenApi -> Value -> IO ()
-checkOpenApi swag js = encode (toJSON swag) `shouldBe` encode js
+checkOpenApi swag js = encode (toJSON swag) `shouldBe` encode (withJsonMediaType js)
 
 spec :: Spec
 spec = describe "HasOpenApi" $ do

--- a/servant-openapi3/test/Servant/OpenApiSpec.hs
+++ b/servant-openapi3/test/Servant/OpenApiSpec.hs
@@ -5,8 +5,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies       #-}
+
 module Servant.OpenApiSpec where
 
 import Control.Lens
@@ -37,15 +38,20 @@ spec = describe "HasOpenApi" $ do
   it "Todo API" $ checkAPI (Proxy :: Proxy TodoAPI) todoAPI
   it "Hackage API (with tags)" $ checkOpenApi hackageOpenApiWithTags hackageAPI
   it "GetPost API (test subOperations)" $ checkOpenApi getPostOpenApi getPostAPI
-  it "Comprehensive API" $ do
-#if MIN_VERSION_servant(0,20,4)
-    let _x = toOpenApi comprehensiveAPI
-#endif
-    True `shouldBe` True -- type-level test
+  it "Comprehensive API" comprehensiveAPISpec
   it "UVerb API" $ checkOpenApi uverbOpenApi uverbAPI
 
 main :: IO ()
 main = hspec spec
+
+comprehensiveAPISpec :: Expectation
+#if MIN_VERSION_servant(0,20,4)
+comprehensiveAPISpec = do
+  let _x = toOpenApi comprehensiveAPI
+  True `shouldBe` True -- type-level test
+#else
+comprehensiveAPISpec = True `shouldBe` True -- type-level test
+#endif
 
 -- =======================================================================
 -- Todo API
@@ -439,8 +445,8 @@ getPostAPI =
 -- UVerb API
 -- =======================================================================
 
-data FisxUser = FisxUser {name :: String}
-  deriving (Eq, Show, Generic)
+newtype FisxUser = FisxUser {name :: String}
+  deriving (Eq, Generic, Show)
 
 instance ToSchema FisxUser
 
@@ -448,18 +454,20 @@ instance HasStatus FisxUser where
   type StatusOf FisxUser = 203
 
 data ArianUser = ArianUser
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Generic, Show)
 
 instance ToSchema ArianUser
 
-type UVerbAPI = "fisx" :> UVerb 'GET '[JSON] '[FisxUser, WithStatus 303 String]
-           :<|> "arian" :> UVerb 'POST '[JSON] '[WithStatus 201 ArianUser]
+type UVerbAPI =
+  "fisx" :> UVerb 'GET '[JSON] '[FisxUser, WithStatus 303 String]
+    :<|> "arian" :> UVerb 'POST '[JSON] '[WithStatus 201 ArianUser]
 
 uverbOpenApi :: OpenApi
 uverbOpenApi = toOpenApi (Proxy :: Proxy UVerbAPI)
 
 uverbAPI :: Value
-uverbAPI = [aesonQQ|
+uverbAPI =
+  [aesonQQ|
 {
   "openapi": "3.0.0",
   "info": {

--- a/servant-openapi3/test/Servant/OpenApiSpec.hs
+++ b/servant-openapi3/test/Servant/OpenApiSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -38,20 +37,13 @@ spec = describe "HasOpenApi" $ do
   it "Todo API" $ checkAPI (Proxy :: Proxy TodoAPI) todoAPI
   it "Hackage API (with tags)" $ checkOpenApi hackageOpenApiWithTags hackageAPI
   it "GetPost API (test subOperations)" $ checkOpenApi getPostOpenApi getPostAPI
-  it "Comprehensive API" comprehensiveAPISpec
+  it "Comprehensive API" $ do
+    let _x = toOpenApi comprehensiveAPI
+    True `shouldBe` True -- type-level test
   it "UVerb API" $ checkOpenApi uverbOpenApi uverbAPI
 
 main :: IO ()
 main = hspec spec
-
-comprehensiveAPISpec :: Expectation
-#if MIN_VERSION_servant(0,20,4)
-comprehensiveAPISpec = do
-  let _x = toOpenApi comprehensiveAPI
-  True `shouldBe` True -- type-level test
-#else
-comprehensiveAPISpec = True `shouldBe` True -- type-level test
-#endif
 
 -- =======================================================================
 -- Todo API

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               servant-server
-version:            0.20.3.0
+version:            0.20.4.0
 synopsis:
   A family of combinators for defining webservices APIs and serving them
 

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               servant
-version:            0.20.3.0
+version:            0.20.4.0
 synopsis:           A family of combinators for defining webservices APIs
 category:           Servant, Web
 description:


### PR DESCRIPTION
Because servant-openapi3 needed changes to be compatible with GHC 9.14, but
other servant packages did not, let us adjust the CPP in openapi3 such that it
becomes compilable with the latest released versions on Hackage.

That way, only servant-openapi3 needs a new upload, and other servant packages
can just get new revisions.
