### PR TITLE
Deduplicate `ResponseStatus` and `ResponseBody` type families by moving them to `servant`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -72,6 +72,16 @@ package *
 package HsOpenSSL
   ghc-options: -optc=-Wno-discarded-qualifiers -optc=-Wno-deprecated-declarations -optc=-Wno-incompatible-pointer-types
 
+-- Various examples depend on external packages that are not in the `servant` repository.
+-- At the time of writing, these external packages have upper bounds on `servant-server` 
+-- that are below the version of `servant-server` in this repository.
+-- As a result, without setting `allow-newer` for these packages, `cabal build all` 
+-- will fail, as some examples will fail to build.
+allow-newer: servant-multipart:servant-server
+allow-newer: servant-swagger-ui:servant-server
+allow-newer: servant-swagger-ui-core:servant-server
+allow-newer: servant-pagination:servant-server
+
 -- Print ticks so that doctest type querying is consistent across GHC versions.
 -- This block can be removed when we drop support for GHC 9.4 and below.
 if(impl(ghc >= 9.6.1))

--- a/changelog.d/pr-1911
+++ b/changelog.d/pr-1911
@@ -1,0 +1,14 @@
+synopsis: Deduplicate `ResponseStatus` and `ResponseBody` type families by moving them to `servant`
+packages: servant, servant-server, servant-client-core, servant-openapi3
+prs: #1911
+description: {
+  Previously `ResponseStatus` and `ResponseBody` where defined twice in different modules 
+  with the same name and almost duplicate definitions. Namely associated types of both classes 
+  `ResponseRender` in `servant-server` and `ResponseUnrender` in `servant-client-core`.
+
+  These associated type families have been removed from `servant-server` and 
+  `servant-client-core`, and instead there is now just now a standalone 
+  type family definition of each of these type families in `servant`.
+
+  For completeness, a `ResponseDescription` type family to has been added to `servant` also.
+}

--- a/doc/cookbook/managed-resource/managed-resource.cabal
+++ b/doc/cookbook/managed-resource/managed-resource.cabal
@@ -16,7 +16,7 @@ executable cookbook-managed-resource
                      , aeson >= 2.2
                      , servant >= 0.20 && <0.21
                      , servant-client >= 0.20 && <0.21
-                     , servant-server >= 0.20 && <0.21
+                     , servant-server >= 0.20 && <0.22
                      , warp >= 3.4.9
                      , wai >= 3.2
                      , http-types >= 0.12

--- a/doc/cookbook/using-free-client/using-free-client.cabal
+++ b/doc/cookbook/using-free-client/using-free-client.cabal
@@ -16,9 +16,9 @@ executable cookbook-using-free-client
                      , servant >= 0.20 && <0.21
                      , servant-client >= 0.20 && <0.21
                      , http-client
-                     , servant-client-core >= 0.20 && <0.21
+                     , servant-client-core >= 0.20 && <0.22
                      , base-compat
-                     , servant-server >= 0.20 && <0.21
+                     , servant-server >= 0.20 && <0.22
                      , warp >= 3.4.9
   default-language:    Haskell2010
   ghc-options:         -Wall -pgmL markdown-unlit

--- a/servant-auth/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth/servant-auth-client/servant-auth-client.cabal
@@ -36,7 +36,7 @@ library
     , containers          >=0.6.5.1  && < 0.9
     , servant-auth        == 0.4.10.0
     , servant             >= 0.20.3   && < 0.21
-    , servant-client-core >= 0.20.3   && < 0.21
+    , servant-client-core >= 0.20.3   && < 0.22
 
   exposed-modules:
       Servant.Auth.Client
@@ -69,7 +69,7 @@ test-suite spec
     , http-client          >= 0.7.19   && < 0.8
     , http-types           >= 0.12.4   && < 0.13
     , servant-auth-server  >= 0.4.2.0  && < 0.5
-    , servant-server       >= 0.20.2   && < 0.21
+    , servant-server       >= 0.20.2   && < 0.22
     , time                 >= 1.11     && < 1.16
     , transformers         >= 0.5.6.2  && < 0.7
     , wai                  >= 3.2.1.2  && < 3.3

--- a/servant-auth/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth/servant-auth-server/servant-auth-server.cabal
@@ -47,7 +47,7 @@ library
     , mtl                     ^>= 2.2.2   || ^>= 2.3.1
     , servant                 >= 0.20.3   && < 0.21
     , servant-auth            == 0.4.10.0
-    , servant-server          >= 0.20.3   && < 0.21
+    , servant-server          >= 0.20.3   && < 0.22
     , tagged                  >= 0.8.4    && < 0.9
     , text                    >= 1.2.3.0  && < 2.2
     , time                    >= 1.11     && < 1.16

--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               servant-client-core
-version:            0.20.3.0
+version:            0.21.0.0
 synopsis:
   Core functionality and class for client function generation for servant APIs
 
@@ -113,7 +113,7 @@ library
     , text              >=1.2.3.0  && <2.2
 
   -- Servant dependencies
-  build-depends:   servant >=0.20.3
+  build-depends:   servant >=0.20.4
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant-client-core/src/Servant/Client/Core/MultiVerb/ResponseUnrender.hs
+++ b/servant-client-core/src/Servant/Client/Core/MultiVerb/ResponseUnrender.hs
@@ -9,7 +9,6 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Kind (Type)
 import Data.SOP
 import Data.Typeable
-import GHC.TypeLits
 import qualified Network.HTTP.Media as M
 import Network.HTTP.Types.Status (Status)
 import Servant.API.ContentTypes
@@ -38,7 +37,6 @@ fromSomeClientResponse (SomeClientResponse Response{..}) = do
 
 class ResponseUnrender cs a where
   type ResponseBody a :: Type
-  type ResponseStatus a :: Nat
   responseUnrender
     :: M.MediaType
     -> ResponseF (ResponseBody a)
@@ -77,7 +75,6 @@ instance
   )
   => ResponseUnrender cs (RespondAs (ct :: Type) s desc a)
   where
-  type ResponseStatus (RespondAs ct s desc a) = s
   type ResponseBody (RespondAs ct s desc a) = BSL.ByteString
 
   responseUnrender _ output = do
@@ -86,7 +83,6 @@ instance
       mimeUnrender (Proxy @ct) (Response.responseBody output)
 
 instance KnownStatus s => ResponseUnrender cs (RespondAs '() s desc ()) where
-  type ResponseStatus (RespondAs '() s desc ()) = s
   type ResponseBody (RespondAs '() s desc ()) = ()
 
   responseUnrender _ output =
@@ -96,7 +92,6 @@ instance
   KnownStatus s
   => ResponseUnrender cs (RespondStreaming s desc framing ct)
   where
-  type ResponseStatus (RespondStreaming s desc framing ct) = s
   type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
 
   responseUnrender _ resp = do
@@ -107,7 +102,6 @@ instance
   (AllMimeUnrender cs a, KnownStatus s)
   => ResponseUnrender cs (Respond s desc a)
   where
-  type ResponseStatus (Respond s desc a) = s
   type ResponseBody (Respond s desc a) = BSL.ByteString
 
   responseUnrender c output = do
@@ -124,7 +118,6 @@ instance
   )
   => ResponseUnrender cs (WithHeaders hs a r)
   where
-  type ResponseStatus (WithHeaders hs a r) = ResponseStatus r
   type ResponseBody (WithHeaders hs a r) = ResponseBody r
 
   responseUnrender c output = do

--- a/servant-client-core/src/Servant/Client/Core/MultiVerb/ResponseUnrender.hs
+++ b/servant-client-core/src/Servant/Client/Core/MultiVerb/ResponseUnrender.hs
@@ -4,8 +4,6 @@ module Servant.Client.Core.MultiVerb.ResponseUnrender where
 
 import Control.Applicative
 import Control.Monad
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as BSL
 import Data.Kind (Type)
 import Data.SOP
 import Data.Typeable
@@ -14,7 +12,6 @@ import Network.HTTP.Types.Status (Status)
 import Servant.API.ContentTypes
 import Servant.API.MultiVerb
 import Servant.API.Status
-import Servant.API.Stream (SourceIO)
 import Servant.API.UVerb.Union (Union)
 
 import Servant.Client.Core.Response (ResponseF (..))
@@ -36,7 +33,6 @@ fromSomeClientResponse (SomeClientResponse Response{..}) = do
       }
 
 class ResponseUnrender cs a where
-  type ResponseBody a :: Type
   responseUnrender
     :: M.MediaType
     -> ResponseF (ResponseBody a)
@@ -75,16 +71,12 @@ instance
   )
   => ResponseUnrender cs (RespondAs (ct :: Type) s desc a)
   where
-  type ResponseBody (RespondAs ct s desc a) = BSL.ByteString
-
   responseUnrender _ output = do
     guard (responseStatusCode output == statusVal (Proxy @s))
     either UnrenderError UnrenderSuccess $
       mimeUnrender (Proxy @ct) (Response.responseBody output)
 
 instance KnownStatus s => ResponseUnrender cs (RespondAs '() s desc ()) where
-  type ResponseBody (RespondAs '() s desc ()) = ()
-
   responseUnrender _ output =
     guard (responseStatusCode output == statusVal (Proxy @s))
 
@@ -92,8 +84,6 @@ instance
   KnownStatus s
   => ResponseUnrender cs (RespondStreaming s desc framing ct)
   where
-  type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
-
   responseUnrender _ resp = do
     guard (Response.responseStatusCode resp == statusVal (Proxy @s))
     pure $ Response.responseBody resp
@@ -102,8 +92,6 @@ instance
   (AllMimeUnrender cs a, KnownStatus s)
   => ResponseUnrender cs (Respond s desc a)
   where
-  type ResponseBody (Respond s desc a) = BSL.ByteString
-
   responseUnrender c output = do
     guard (responseStatusCode output == statusVal (Proxy @s))
     let results = allMimeUnrender (Proxy @cs)
@@ -118,8 +106,6 @@ instance
   )
   => ResponseUnrender cs (WithHeaders hs a r)
   where
-  type ResponseBody (WithHeaders hs a r) = ResponseBody r
-
   responseUnrender c output = do
     x <- responseUnrender @cs @r c output
     case extractHeaders @hs (responseHeaders output) of

--- a/servant-client-ghcjs/servant-client-ghcjs.cabal
+++ b/servant-client-ghcjs/servant-client-ghcjs.cabal
@@ -55,7 +55,7 @@ library
   -- strict, as we re-export stuff
   build-depends:
       servant              >=0.20 && <0.21
-    , servant-client-core  >=0.20 && <0.21
+    , servant-client-core  >=0.20 && <0.22
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -106,7 +106,7 @@ library
   -- Strict dependency on `servant-client-core` as we re-export things.
   build-depends:
     , servant              >=0.20.3 && <0.21
-    , servant-client-core  >=0.20.3 && <0.21
+    , servant-client-core  >=0.20.3 && <0.22
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
@@ -176,7 +176,7 @@ test-suite spec
     , network         >=3.2      && <3.3
     , QuickCheck      >=2.18     && <2.19
     , servant         >=0.20.2   && <0.21
-    , servant-server  >=0.20.2   && <0.21
+    , servant-server  >=0.20.2   && <0.22
 
   build-tool-depends: hspec-discover:hspec-discover >=2.11  && <2.12
 

--- a/servant-conduit/servant-conduit.cabal
+++ b/servant-conduit/servant-conduit.cabal
@@ -52,7 +52,7 @@ test-suite example
     , resourcet
     , servant        >=0.20     && <0.21
     , servant-conduit
-    , servant-server >=0.20.2   && <0.21
+    , servant-server >=0.20.2   && <0.22
     , servant-client >=0.20.2   && <0.21
     , wai            >=3.2.1.2  && <3.3
     , warp           >=3.4.9    && <3.5

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -53,7 +53,7 @@ library
   -- Strict dependency on `servant-client-core` as we re-export things.
   build-depends:
       servant               >= 0.20.2 && < 0.21
-    , servant-client-core   >= 0.20.2 && <0.21
+    , servant-client-core   >= 0.20.2 && <0.22
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
@@ -111,7 +111,7 @@ test-suite spec
     , HUnit             >= 1.6.0.0  && < 1.7
     , network           >= 3.2      && < 3.3
     , QuickCheck        >= 2.18     && < 2.19
-    , servant-server    >= 0.20.2 && < 0.21
+    , servant-server    >= 0.20.2 && < 0.22
     , servant           >= 0.20.2 && < 0.21
 
   build-tool-depends:

--- a/servant-machines/servant-machines.cabal
+++ b/servant-machines/servant-machines.cabal
@@ -49,7 +49,7 @@ test-suite example
     , servant        >=0.20.2   && <0.21
     , machines
     , servant-machines
-    , servant-server >=0.20.2   && <0.21
+    , servant-server >=0.20.2   && <0.22
     , servant-client >=0.20.2   && <0.21
     , wai            >=3.2.1.2  && <3.3
     , warp           >=3.4.9    && <3.5

--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                servant-openapi3
-version:             2.1.0.0
+version:             2.2.0.0
 synopsis:            Generate a Swagger/OpenAPI/OAS 3.0 specification for your servant API.
 description:
   Swagger is a project used to describe and document RESTful APIs. The core of the 
@@ -73,8 +73,8 @@ library
                      , bytestring                >=0.11     && <0.13
                      , http-media                >=0.7.1.3  && <0.9
                      , lens                      >=5.3.6    && <5.4
-                     , servant                   >=0.20.3   && <0.21
-                     , servant-server            >=0.20.3   && <0.21
+                     , servant                   >=0.20.4   && <0.21
+                     , servant-server            >=0.20.3   && <0.22
                      , singleton-bool            >=0.1.6    && <0.2
                      , openapi3                  >=3.2.5    && <3.3
                      , text                      >=1.2.5.0  && <3

--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -41,7 +41,6 @@ import Servant.API.ContentTypes (AllMime, allMime)
 import Servant.API.Description (FoldDescription, reflectDescription)
 import Servant.API.Modifiers (FoldRequired)
 import Servant.API.MultiVerb
-import qualified Servant.Server.Internal.ResponseRender as Server
 import Prelude ()
 
 import Servant.OpenApi.Internal.TypeLevel.API
@@ -580,14 +579,14 @@ instance IsSwaggerResponseList '[] where
 instance
   ( IsSwaggerResponse a
   , IsSwaggerResponseList as
-  , KnownNat (Server.ResponseStatus a)
+  , KnownNat (ResponseStatus a)
   )
   => IsSwaggerResponseList (a ': as)
   where
   responseListSwagger =
     InsOrdHashMap.insertWith
       combineResponseSwagger
-      (fromIntegral (natVal (Proxy @(Server.ResponseStatus a))))
+      (fromIntegral (natVal (Proxy @(ResponseStatus a))))
       <$> responseSwagger @a
       <*> responseListSwagger @as
 

--- a/servant-pipes/servant-pipes.cabal
+++ b/servant-pipes/servant-pipes.cabal
@@ -53,7 +53,7 @@ test-suite example
     , pipes-safe
     , servant-pipes
     , pipes-bytestring  >=2.1.6    && <2.2
-    , servant-server    >=0.20.2   && <0.21
+    , servant-server    >=0.20.2   && <0.22
     , servant-client    >=0.20.2   && <0.21
     , wai               >=3.2.1.2  && <3.3
     , warp              >=3.4.9    && <3.5

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -49,7 +49,7 @@ library
     , QuickCheck             >=2.18   && <2.19
     , servant                >=0.20.2 && <0.21
     , servant-client         >=0.20.2 && <0.21
-    , servant-server         >=0.20.2 && <0.21
+    , servant-server         >=0.20.2 && <0.22
     , split                  >=0.2    && <0.3
     , text                   >=1.2    && <2.2
     , time                   >=1.11   && <1.16

--- a/servant-server/servant-server.cabal
+++ b/servant-server/servant-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               servant-server
-version:            0.20.4.0
+version:            0.21.0.0
 synopsis:
   A family of combinators for defining webservices APIs and serving them
 
@@ -128,7 +128,7 @@ library
   -- strict dependency as we re-export 'servant' things.
   build-depends:
     , http-api-data  >=0.6.3 && <0.8
-    , servant        >=0.20.3 && <0.21
+    , servant        >=0.20.4 && <0.21
 
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.

--- a/servant-server/src/Servant/Server/Internal/ResponseRender.hs
+++ b/servant-server/src/Servant/Server/Internal/ResponseRender.hs
@@ -11,7 +11,6 @@ import Data.SOP
 import Data.Sequence ((<|))
 import qualified Data.Sequence as Seq
 import Data.Typeable
-import GHC.TypeLits
 import qualified Network.HTTP.Media as M
 import Network.HTTP.Types (Status, hContentType)
 import qualified Network.Wai as Wai
@@ -73,7 +72,6 @@ instance ResponseListRender cs '[] where
   responseListStatuses = []
 
 class IsWaiBody (ResponseBody a) => ResponseRender cs a where
-  type ResponseStatus a :: Nat
   type ResponseBody a :: Type
   responseRender
     :: AcceptHeader
@@ -99,7 +97,6 @@ instance
   )
   => ResponseRender cs (WithHeaders hs a r)
   where
-  type ResponseStatus (WithHeaders hs a r) = ResponseStatus r
   type ResponseBody (WithHeaders hs a r) = ResponseBody r
 
   responseRender acc x = addHeaders <$> responseRender @cs @r acc y
@@ -116,7 +113,6 @@ instance
   )
   => ResponseRender cs (RespondAs (ct :: Type) s desc a)
   where
-  type ResponseStatus (RespondAs ct s desc a) = s
   type ResponseBody (RespondAs ct s desc a) = BSL.ByteString
 
   responseRender _ x =
@@ -128,7 +124,6 @@ instance
         }
 
 instance KnownStatus s => ResponseRender cs (RespondAs '() s desc ()) where
-  type ResponseStatus (RespondAs '() s desc ()) = s
   type ResponseBody (RespondAs '() s desc ()) = ()
 
   responseRender _ _ =
@@ -143,7 +138,6 @@ instance
   (Accept ct, KnownStatus s)
   => ResponseRender cs (RespondStreaming s desc framing ct)
   where
-  type ResponseStatus (RespondStreaming s desc framing ct) = s
   type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
   responseRender _ x =
     pure . addContentType @ct $
@@ -157,7 +151,6 @@ instance
   (AllMimeRender cs a, KnownStatus s)
   => ResponseRender cs (Respond s desc a)
   where
-  type ResponseStatus (Respond s desc a) = s
   type ResponseBody (Respond s desc a) = BSL.ByteString
 
   -- Note: here it seems like we are rendering for all possible content types,

--- a/servant-server/src/Servant/Server/Internal/ResponseRender.hs
+++ b/servant-server/src/Servant/Server/Internal/ResponseRender.hs
@@ -72,7 +72,6 @@ instance ResponseListRender cs '[] where
   responseListStatuses = []
 
 class IsWaiBody (ResponseBody a) => ResponseRender cs a where
-  type ResponseBody a :: Type
   responseRender
     :: AcceptHeader
     -> ResponseType a
@@ -97,8 +96,6 @@ instance
   )
   => ResponseRender cs (WithHeaders hs a r)
   where
-  type ResponseBody (WithHeaders hs a r) = ResponseBody r
-
   responseRender acc x = addHeaders <$> responseRender @cs @r acc y
     where
       (hs, y) = toHeaders @xs x
@@ -113,8 +110,6 @@ instance
   )
   => ResponseRender cs (RespondAs (ct :: Type) s desc a)
   where
-  type ResponseBody (RespondAs ct s desc a) = BSL.ByteString
-
   responseRender _ x =
     pure . addContentType @ct $
       InternalResponse
@@ -124,8 +119,6 @@ instance
         }
 
 instance KnownStatus s => ResponseRender cs (RespondAs '() s desc ()) where
-  type ResponseBody (RespondAs '() s desc ()) = ()
-
   responseRender _ _ =
     pure $
       InternalResponse
@@ -138,7 +131,6 @@ instance
   (Accept ct, KnownStatus s)
   => ResponseRender cs (RespondStreaming s desc framing ct)
   where
-  type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
   responseRender _ x =
     pure . addContentType @ct $
       InternalResponse
@@ -151,8 +143,6 @@ instance
   (AllMimeRender cs a, KnownStatus s)
   => ResponseRender cs (Respond s desc a)
   where
-  type ResponseBody (Respond s desc a) = BSL.ByteString
-
   -- Note: here it seems like we are rendering for all possible content types,
   -- only to choose the correct one afterwards. However, render results besides the
   -- one picked by 'M.mapAcceptMedia' are not evaluated, and therefore nor are the

--- a/servant/src/Servant/API/MultiVerb.hs
+++ b/servant/src/Servant/API/MultiVerb.hs
@@ -37,6 +37,7 @@ module Servant.API.MultiVerb
   , ResponseTypes
   , ResponseStatus
   , ResponseDescription
+  , ResponseBody
   , UnrenderResult (..)
   )
 where
@@ -44,6 +45,7 @@ where
 import Control.Applicative (Alternative (..), empty)
 import Control.Monad (MonadPlus (..), ap)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
 import Data.Kind
 import Data.Proxy
@@ -125,18 +127,23 @@ instance MonadPlus UnrenderResult where
 type family ResponseType a :: Type
 type family ResponseStatus a :: Nat
 type family ResponseDescription a :: Symbol
+type family ResponseBody a :: Type
 
 type instance ResponseType (Respond s description a) = a
 type instance ResponseStatus (Respond s description a) = s
 type instance ResponseDescription (Respond s description a) = description
+type instance ResponseBody (Respond s description a) = BSL.ByteString
 
 type instance ResponseType (RespondAs responseContentType s description a) = a
 type instance ResponseStatus (RespondAs responseContentType s description a) = s
 type instance ResponseDescription (RespondAs responseContentType s description a) = description
+type instance ResponseBody (RespondAs (responseContentType :: Type) s description a) = BSL.ByteString
+type instance ResponseBody (RespondAs '() s description ()) = ()
 
 type instance ResponseType (RespondStreaming s description framing ct) = SourceIO ByteString
 type instance ResponseStatus (RespondStreaming s description framing ct) = s
 type instance ResponseDescription (RespondStreaming s description framing ct) = description
+type instance ResponseBody (RespondStreaming s description framing ct) = SourceIO ByteString
 
 -- | This type adds response headers to a 'MultiVerb' response.
 data WithHeaders (headers :: [Type]) (returnType :: Type) (response :: Type)
@@ -228,6 +235,7 @@ instance ServantHeader h name x => ServantHeader (OptHeader h) name (Maybe x) wh
 type instance ResponseType (WithHeaders headers returnType response) = returnType
 type instance ResponseStatus (WithHeaders headers returnType response) = ResponseStatus response
 type instance ResponseDescription (WithHeaders headers returnType response) = ResponseDescription response
+type instance ResponseBody (WithHeaders headers returnType response) = ResponseBody response
 
 type family ResponseTypes (as :: [Type]) where
   ResponseTypes '[] = '[]

--- a/servant/src/Servant/API/MultiVerb.hs
+++ b/servant/src/Servant/API/MultiVerb.hs
@@ -35,6 +35,8 @@ module Servant.API.MultiVerb
   , GenericAsUnion (..)
   , ResponseType
   , ResponseTypes
+  , ResponseStatus
+  , ResponseDescription
   , UnrenderResult (..)
   )
 where
@@ -121,12 +123,20 @@ instance MonadPlus UnrenderResult where
   mplus m@(UnrenderSuccess _) _ = m
 
 type family ResponseType a :: Type
+type family ResponseStatus a :: Nat
+type family ResponseDescription a :: Symbol
 
 type instance ResponseType (Respond s description a) = a
+type instance ResponseStatus (Respond s description a) = s
+type instance ResponseDescription (Respond s description a) = description
 
 type instance ResponseType (RespondAs responseContentType s description a) = a
+type instance ResponseStatus (RespondAs responseContentType s description a) = s
+type instance ResponseDescription (RespondAs responseContentType s description a) = description
 
 type instance ResponseType (RespondStreaming s description framing ct) = SourceIO ByteString
+type instance ResponseStatus (RespondStreaming s description framing ct) = s
+type instance ResponseDescription (RespondStreaming s description framing ct) = description
 
 -- | This type adds response headers to a 'MultiVerb' response.
 data WithHeaders (headers :: [Type]) (returnType :: Type) (response :: Type)
@@ -216,6 +226,8 @@ instance ServantHeader h name x => ServantHeader (OptHeader h) name (Maybe x) wh
   constructHeader = foldMap (constructHeader @h)
 
 type instance ResponseType (WithHeaders headers returnType response) = returnType
+type instance ResponseStatus (WithHeaders headers returnType response) = ResponseStatus response
+type instance ResponseDescription (WithHeaders headers returnType response) = ResponseDescription response
 
 type family ResponseTypes (as :: [Type]) where
   ResponseTypes '[] = '[]


### PR DESCRIPTION
We add a `ResponseStatus` type family to `servant::Servant.API.MultiVerb` and as a result we can remove duplicate definitions in `servant-client` AND `servant-server`.

More importantly, now `servant-openapi3` no longer needs to depend on `servant-server`, reducing its dependency footprint and making it easier to compile to WebAssembly.

Also added a `ResponseDescription` type family, but this isn't used elsewhere, I've just included it for completeness.

The alternative is a [PR to just duplicate the `ResponseStatus` type family into `servant-openapi3`](https://github.com/haskell-servant/servant/pull/1912), but I think this is a better approach. But in the end either PR will achieve what I want which is removing the dependence of `servant-openapi3` on `servant-server`.
