### PR TITLE
Eliminate `servant-openapi3` dependency on `servant-server`

### DIFF
--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -74,7 +74,6 @@ library
                      , http-media                >=0.7.1.3  && <0.9
                      , lens                      >=5.3.6    && <5.4
                      , servant                   >=0.20.3   && <0.21
-                     , servant-server            >=0.20.3   && <0.21
                      , singleton-bool            >=0.1.6    && <0.2
                      , openapi3                  >=3.2.5    && <3.3
                      , text                      >=1.2.5.0  && <3

--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -41,7 +41,6 @@ import Servant.API.ContentTypes (AllMime, allMime)
 import Servant.API.Description (FoldDescription, reflectDescription)
 import Servant.API.Modifiers (FoldRequired)
 import Servant.API.MultiVerb
-import qualified Servant.Server.Internal.ResponseRender as Server
 import Prelude ()
 
 import Servant.OpenApi.Internal.TypeLevel.API
@@ -580,14 +579,14 @@ instance IsSwaggerResponseList '[] where
 instance
   ( IsSwaggerResponse a
   , IsSwaggerResponseList as
-  , KnownNat (Server.ResponseStatus a)
+  , KnownNat (MultiVerbResponseStatus a)
   )
   => IsSwaggerResponseList (a ': as)
   where
   responseListSwagger =
     InsOrdHashMap.insertWith
       combineResponseSwagger
-      (fromIntegral (natVal (Proxy @(Server.ResponseStatus a))))
+      (fromIntegral (natVal (Proxy @(MultiVerbResponseStatus a))))
       <$> responseSwagger @a
       <*> responseListSwagger @as
 

--- a/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -9,6 +9,7 @@ module Servant.OpenApi.Internal.TypeLevel.API where
 
 import Data.ByteString (ByteString)
 import GHC.Exts (Constraint)
+import GHC.TypeLits (Nat)
 import Servant.API
 import Servant.API.Generic (ToServantApi)
 import Servant.API.MultiVerb (GenericAsConstructor, MultiVerb, Respond, RespondAs, RespondStreaming, WithHeaders)
@@ -113,6 +114,13 @@ type instance MultiVerbResponseBody (RespondStreaming s description framing cont
 -- The following instance is the main difference between 'MultiVerbResponseBody' and 'ResponseType'
 type instance MultiVerbResponseBody (WithHeaders headers returnType response) = MultiVerbResponseBody response
 type instance MultiVerbResponseBody (GenericAsConstructor r) = MultiVerbResponseBody r
+
+type family MultiVerbResponseStatus a :: Nat
+
+type instance MultiVerbResponseStatus (Respond s description a) = s
+type instance MultiVerbResponseStatus (RespondAs contentType s description a) = s
+type instance MultiVerbResponseStatus (RespondStreaming s description framing contentType) = s
+type instance MultiVerbResponseStatus (WithHeaders headers returnType response) = MultiVerbResponseStatus response
 
 type family MultiVerbResponseBodies (as :: [*]) where
   MultiVerbResponseBodies '[] = '[]


### PR DESCRIPTION
This is done by duplicating the type family `ResponseStatus` inside `servant-openapi3` directly.

This is a simpler approach than [the PR I've opened to move ResponseStatus to `servant` proper](https://github.com/haskell-servant/servant/pull/1911), but I think that PR it better because unlike this PR it reduces the net amount of code.

But either being merged will fix my issue, namely removing the dependence of `servant-openapi3` on `servant-server`, a dependence which was only added last release and I don't think is required, and makes it harder to compile `servant-openapi3` to WASM.