### PR TITLE
Allow base-compat-0.15

### DIFF
--- a/servant-client-core/servant-client-core.cabal
+++ b/servant-client-core/servant-client-core.cabal
@@ -119,7 +119,7 @@ library
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
     , aeson              >=2.2     && <3
-    , base-compat        >=0.12    && <0.15
+    , base-compat        >=0.12    && <0.16
     , base64-bytestring  >=1.2     && <1.3
     , exceptions         >=0.10.4  && <0.11
     , free               >=5.2     && <5.3

--- a/servant-client/servant-client.cabal
+++ b/servant-client/servant-client.cabal
@@ -111,7 +111,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-    , base-compat          >=0.12     && <0.15
+    , base-compat          >=0.12     && <0.16
     , exceptions           >=0.10.4   && <0.11
     , http-client          >=0.7.19   && <0.8
     , http-media           >=0.8      && <0.9

--- a/servant-docs/servant-docs.cabal
+++ b/servant-docs/servant-docs.cabal
@@ -54,7 +54,7 @@ library
   build-depends:
       aeson                >= 2.2      && < 3
     , aeson-pretty         >= 0.8.5    && < 0.9
-    , base-compat          >= 0.12     && < 0.15
+    , base-compat          >= 0.12     && < 0.16
     , case-insensitive     >= 1.2.0.11 && < 1.3
     , hashable             >= 1.4.7.0  && < 1.6
     , http-media           >= 0.8      && < 0.9

--- a/servant-foreign/servant-foreign.cabal
+++ b/servant-foreign/servant-foreign.cabal
@@ -51,7 +51,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat >= 0.12    && < 0.15
+      base-compat >= 0.12    && < 0.16
     , lens        >= 5.3     && < 5.4
     , http-types  >= 0.12.4  && < 0.13
 

--- a/servant-http-streams/servant-http-streams.cabal
+++ b/servant-http-streams/servant-http-streams.cabal
@@ -58,7 +58,7 @@ library
   -- Other dependencies: Lower bound around what is in the latest Stackage LTS.
   -- Here can be exceptions if we really need features from the newer versions.
   build-depends:
-      base-compat           >= 0.12     && < 0.15
+      base-compat           >= 0.12     && < 0.16
     , case-insensitive
     , http-streams          >= 0.8.9.9  && < 0.9
     , http-media            >= 0.8      && < 0.9

--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -69,7 +69,7 @@ library
   build-depends:       aeson                     >=2.2      && <2.4
                      , aeson-pretty              >=0.8.9    && <0.9
                      , base                      >=4.16.4   && <4.23
-                     , base-compat               >=0.12     && <0.15
+                     , base-compat               >=0.12     && <0.16
                      , bytestring                >=0.11     && <0.13
                      , http-media                >=0.7.1.3  && <0.9
                      , lens                      >=5.3.6    && <5.4

--- a/servant-quickcheck/servant-quickcheck.cabal
+++ b/servant-quickcheck/servant-quickcheck.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       aeson                  >=2.2    && <2.4
     , base                   >= 4.16.4.0 && < 4.23
-    , base-compat-batteries  >=0.12   && <0.15
+    , base-compat-batteries  >=0.12   && <0.16
     , bytestring             >=0.11   && <0.13
     , case-insensitive       >=1.2    && <1.3
     , clock                  >=0.7    && <0.9

--- a/servant-swagger/servant-swagger.cabal
+++ b/servant-swagger/servant-swagger.cabal
@@ -72,7 +72,7 @@ library
   build-depends:       aeson                     >=2.2     && <3
                      , aeson-pretty              >=0.8.7    && <0.9
                      , base                      >= 4.16.4.0 && < 4.23
-                     , base-compat               >=0.12     && <0.15
+                     , base-compat               >=0.12     && <0.16
                      , bytestring                >=0.11 && <0.13
                      , http-media                >=0.8      && <0.9
                      , lens                      >=5.3      && <6


### PR DESCRIPTION
Tested locally. `servant-js` needs the bump too, but it is not in this repo. If the tests pass, I will merge and make revisions.
