### PR TITLE
Remove unused dependency of 'servant-openapi3' on 'servant-server'

### DIFF
--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -74,7 +74,6 @@ library
                      , http-media                >=0.7.1.3  && <0.9
                      , lens                      >=5.3.6    && <5.4
                      , servant                   >=0.20.4   && <0.21
-                     , servant-server            >=0.20.3   && <0.22
                      , singleton-bool            >=0.1.6    && <0.2
                      , openapi3                  >=3.2.5    && <3.3
                      , text                      >=1.2.5.0  && <3


### PR DESCRIPTION
Sorry for bugging you all again. I've clearly experienced an `Id-10-T` malfunction with my previous [PR](https://github.com/haskell-servant/servant/pull/1911)

Much of the point of `e23a6b469a03ea96334b7fca4265230b9f4a2204` was to remove the dependency of  `servant-openapi3` on `servant-server`, but somehow that slipped through the cracks.

This one line change removes the unused dependency. 

No need for changelog entries because the changelog entry from the previous PR says this is already done!

My apologies again. 

I would however suggest that one adds `-Werror` to the `servant*` packages if possible. Whilst having a brain would have prevented this issue there is quite of lot of noise now in the `cabal build all` output and I clearly didn't notice the new warning. If you'd like me to work on that open an issue and assign it to me. It will involve cleaning up a few warnings, but I don't think it's a huge endeavor.
