### PR TITLE
No headers bodytype

### DIFF
--- a/servant-openapi3/CHANGELOG.md
+++ b/servant-openapi3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* The `HasOpenApi` instance that recurses through `UVerb` responses no
+  longer demands `ToSchema NoContent`.
 * Do not count `NoContent` as a body type if it appears in `Headers
   hdrs NoContent`.
 

--- a/servant-openapi3/CHANGELOG.md
+++ b/servant-openapi3/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 
 * The `HasOpenApi` instance that recurses through `UVerb` responses no
   longer demands `ToSchema NoContent`.
+  - `instance ToSchema (WithStatus s a)` has been removed, as the
+    `WithStatus` is now unwrapped when recursing into a `Verb`.
 * Do not count `NoContent` as a body type if it appears in `Headers
   hdrs NoContent`.
 

--- a/servant-openapi3/CHANGELOG.md
+++ b/servant-openapi3/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+* Do not count `NoContent` as a body type if it appears in `Headers
+  hdrs NoContent`.
+
 2.1.0.0
 -------
 

--- a/servant-openapi3/servant-openapi3.cabal
+++ b/servant-openapi3/servant-openapi3.cabal
@@ -74,7 +74,6 @@ library
                      , http-media                >=0.7.1.3  && <0.9
                      , lens                      >=5.3.6    && <5.4
                      , servant                   >=0.20.4   && <0.21
-                     , servant-server            >=0.20.3   && <0.22
                      , singleton-bool            >=0.1.6    && <0.2
                      , openapi3                  >=3.2.5    && <3.3
                      , text                      >=1.2.5.0  && <3

--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -224,12 +224,7 @@ instance HasOpenApi (UVerb method cs '[]) where
 -- | @since <2.0.1.0>
 instance
   {-# OVERLAPPABLE #-}
-  ( AllAccept cs
-  , HasOpenApi (UVerb method cs as)
-  , HasStatus a
-  , OpenApiMethod method
-  , ToSchema a
-  )
+  (HasOpenApi (UVerb method cs as), HasOpenApi (Verb method (StatusOf a) cs a))
   => HasOpenApi (UVerb method cs (a ': as))
   where
   toOpenApi _ =

--- a/servant-openapi3/src/Servant/OpenApi/Internal.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal.hs
@@ -230,40 +230,56 @@ instance
   toOpenApi _ =
     toOpenApi (Proxy :: Proxy (Verb method (StatusOf a) cs a))
       `combineSwagger` toOpenApi (Proxy :: Proxy (UVerb method cs as))
-    where
-      -- workaround for https://github.com/GetShopTV/swagger2/issues/218
-      combinePathItem :: PathItem -> PathItem -> PathItem
-      combinePathItem s t =
-        PathItem
-          { _pathItemGet = _pathItemGet s <> _pathItemGet t
-          , _pathItemPut = _pathItemPut s <> _pathItemPut t
-          , _pathItemPost = _pathItemPost s <> _pathItemPost t
-          , _pathItemDelete = _pathItemDelete s <> _pathItemDelete t
-          , _pathItemOptions = _pathItemOptions s <> _pathItemOptions t
-          , _pathItemHead = _pathItemHead s <> _pathItemHead t
-          , _pathItemPatch = _pathItemPatch s <> _pathItemPatch t
-          , _pathItemTrace = _pathItemTrace s <> _pathItemTrace t
-          , _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
-          , _pathItemSummary = _pathItemSummary s <|> _pathItemSummary t
-          , _pathItemDescription = _pathItemDescription s <|> _pathItemDescription t
-          , _pathItemServers = _pathItemServers s <> _pathItemServers t
-          }
 
-      combineSwagger :: OpenApi -> OpenApi -> OpenApi
-      combineSwagger s t =
-        OpenApi
-          { _openApiOpenapi = _openApiOpenapi s <> _openApiOpenapi t
-          , _openApiInfo = _openApiInfo s <> _openApiInfo t
-          , _openApiServers = _openApiServers s <> _openApiServers t
-          , _openApiPaths = InsOrdHashMap.unionWith combinePathItem (_openApiPaths s) (_openApiPaths t)
-          , _openApiComponents = _openApiComponents s <> _openApiComponents t
-          , _openApiSecurity = _openApiSecurity s <> _openApiSecurity t
-          , _openApiTags = _openApiTags s <> _openApiTags t
-          , _openApiExternalDocs = _openApiExternalDocs s <|> _openApiExternalDocs t
-          }
+-- | Although the instance this overlaps correctly sets the status code
+-- for a @WithStatus n a@ entry, it also cause GHC to try and solve
+-- @'HasOpenApi' (Verb method (StatusOf (WithStatus n a)) cs (WithStatus n a))@.
+-- In most cases, this works fine, but it breaks down if @a ~ NoContent@ by
+-- trying to satisfy @ToSchema NoContent@.
+--
+-- Because 'WithStatus' inside a 'Verb' is nonsensical, we handle it
+-- explicitly before recursing into the @HasOpenApi (Verb method n cs a)@
+-- instance.
+instance
+  ( HasOpenApi (UVerb method cs as)
+  , HasOpenApi (Verb method n cs a)
+  )
+  => HasOpenApi (UVerb method cs (WithStatus n a ': as))
+  where
+  toOpenApi _ =
+    toOpenApi (Proxy :: Proxy (Verb method n cs a))
+      `combineSwagger` toOpenApi (Proxy :: Proxy (UVerb method cs as))
 
-instance (ToSchema a, Typeable (WithStatus s a)) => ToSchema (WithStatus s a) where
-  declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
+-- Workaround for https://github.com/GetShopTV/swagger2/issues/218
+combineSwagger :: OpenApi -> OpenApi -> OpenApi
+combineSwagger s1 s2 =
+  OpenApi
+    { _openApiOpenapi = _openApiOpenapi s1 <> _openApiOpenapi s2
+    , _openApiInfo = _openApiInfo s1 <> _openApiInfo s2
+    , _openApiServers = _openApiServers s1 <> _openApiServers s2
+    , _openApiPaths = InsOrdHashMap.unionWith combinePathItem (_openApiPaths s1) (_openApiPaths s2)
+    , _openApiComponents = _openApiComponents s1 <> _openApiComponents s2
+    , _openApiSecurity = _openApiSecurity s1 <> _openApiSecurity s2
+    , _openApiTags = _openApiTags s1 <> _openApiTags s2
+    , _openApiExternalDocs = _openApiExternalDocs s1 <|> _openApiExternalDocs s2
+    }
+  where
+    combinePathItem :: PathItem -> PathItem -> PathItem
+    combinePathItem p1 p2 =
+      PathItem
+        { _pathItemGet = _pathItemGet p1 <> _pathItemGet p2
+        , _pathItemPut = _pathItemPut p1 <> _pathItemPut p2
+        , _pathItemPost = _pathItemPost p1 <> _pathItemPost p2
+        , _pathItemDelete = _pathItemDelete p1 <> _pathItemDelete p2
+        , _pathItemOptions = _pathItemOptions p1 <> _pathItemOptions p2
+        , _pathItemHead = _pathItemHead p1 <> _pathItemHead p2
+        , _pathItemPatch = _pathItemPatch p1 <> _pathItemPatch p2
+        , _pathItemTrace = _pathItemTrace p1 <> _pathItemTrace p2
+        , _pathItemParameters = _pathItemParameters p1 <> _pathItemParameters p2
+        , _pathItemSummary = _pathItemSummary p1 <|> _pathItemSummary p2
+        , _pathItemDescription = _pathItemDescription p1 <|> _pathItemDescription p2
+        , _pathItemServers = _pathItemServers p1 <> _pathItemServers p2
+        }
 
 instance {-# OVERLAPPABLE #-} (AllAccept cs, KnownNat status, OpenApiMethod method, ToSchema a) => HasOpenApi (Verb method status cs a) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy (Verb method status cs (Headers '[] a)))

--- a/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -81,7 +81,7 @@ type AddBodyType c cs a as = If (Elem c cs) (a ': as) as
 -- completely empty on responses to requests that only accept 'application/json', while
 -- setting the content-type in the response accordingly.)
 type family BodyTypes' c api :: [*] where
-  BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
+  BodyTypes' c (Verb verb b cs (Headers hdrs a)) = BodyTypes' c (Verb verb b cs a)
   BodyTypes' c (Verb verb b cs NoContent) = '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]
   BodyTypes' c (MultiVerb verb cs as _) = AddBodyType c cs () (MultiVerbResponseBodies as)

--- a/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/servant-openapi3/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -89,6 +89,18 @@ type family BodyTypes' c api :: [*] where
   BodyTypes' c (e :> api) = BodyTypes' c api
   BodyTypes' c (a :<|> b) = AppendList (BodyTypes' c a) (BodyTypes' c b)
   BodyTypes' c (NamedRoutes api) = BodyTypes' c (ToServantApi api)
+  -- Handle UVerb by recursively expanding it to BodyTypes' c (Verb ...)
+  -- Unwrap WithStatus explicitly to avoid trying to expand
+  -- `Verb .. (WithStatus n a)` later on.
+  BodyTypes' c (UVerb verb cs (WithStatus n a ': as)) =
+    AppendList (BodyTypes' c (Verb verb (StatusOf a) cs a)) (BodyTypes' c (UVerb verb cs as))
+  -- If we don't have a WithStatus wrapper, it might be 'NoContent' or
+  -- some other type with a `HasStatus` instance. The catch-all will
+  -- expand it to '[] if we can't extract a useful body type from it,
+  -- so that's fine.
+  BodyTypes' c (UVerb verb cs (a ': as)) =
+    AppendList (BodyTypes' c (Verb verb (StatusOf a) cs a)) (BodyTypes' c (UVerb verb cs as))
+  BodyTypes' c (UVerb verb cs '[]) = '[]
   BodyTypes' c api = '[]
 
 -- | The 'ResponseTypes' class allows to extract all types


### PR DESCRIPTION
This is a renewal of [this PR against biocad/servant-openapi3](https://github.com/biocad/servant-openapi3/pull/56).

Stop `BodyTypes` incorrectly adding `NoContent` to the list of body types if it appears within a `Headers` (on endpoints that set response headers but don't return a response body).

